### PR TITLE
Secure staff access through invitations and mandatory MFA

### DIFF
--- a/app/Actions/Fortify/CaptureTeamInvitation.php
+++ b/app/Actions/Fortify/CaptureTeamInvitation.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Actions\Fortify;
+
+use App\Models\TeamInvitation;
+use Closure;
+use Illuminate\Http\Request;
+
+class CaptureTeamInvitation
+{
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $request->session()->forget('auth.pending_team_invitation_id');
+
+        $token = $request->string('invitation')->toString();
+        $invitation = $token !== '' ? TeamInvitation::findByToken($token) : null;
+
+        if ($invitation?->isPending()) {
+            $request->session()->put('auth.pending_team_invitation_id', $invitation->id);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Actions/Fortify/CreateNewUser.php
+++ b/app/Actions/Fortify/CreateNewUser.php
@@ -2,45 +2,50 @@
 
 namespace App\Actions\Fortify;
 
-use App\Actions\Teams\CreateTeam;
 use App\Concerns\PasswordValidationRules;
 use App\Concerns\ProfileValidationRules;
+use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use Laravel\Fortify\Contracts\CreatesNewUsers;
 
 class CreateNewUser implements CreatesNewUsers
 {
     use PasswordValidationRules, ProfileValidationRules;
 
-    public function __construct(private CreateTeam $createTeam)
-    {
-        //
-    }
-
     /**
      * Validate and create a newly registered user.
      *
-     * @param  array<string, string>  $input
+     * @param  array<string, mixed>  $input
      */
     public function create(array $input): User
     {
         Validator::make($input, [
             ...$this->profileRules(),
             'password' => $this->passwordRules(),
+            'invitation' => ['required', 'string'],
         ])->validate();
 
         return DB::transaction(function () use ($input) {
-            $user = User::create([
+            $invitation = TeamInvitation::query()
+                ->where('token_hash', hash('sha256', $input['invitation']))
+                ->lockForUpdate()
+                ->first();
+
+            if (! $invitation?->isPending() || $invitation->email !== Str::lower($input['email'])) {
+                throw ValidationException::withMessages([
+                    'invitation' => __('This invitation is invalid or unavailable.'),
+                ]);
+            }
+
+            return User::create([
                 'name' => $input['name'],
-                'email' => $input['email'],
+                'email' => Str::lower($input['email']),
                 'password' => $input['password'],
             ]);
-
-            $this->createTeam->handle($user, $user->name."'s Team", isPersonal: true);
-
-            return $user;
         });
     }
 }

--- a/app/Actions/Fortify/DiscardRememberedLogin.php
+++ b/app/Actions/Fortify/DiscardRememberedLogin.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Actions\Fortify;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class DiscardRememberedLogin
+{
+    public function handle(Request $request, Closure $next): mixed
+    {
+        $request->merge(['remember' => false]);
+
+        return $next($request);
+    }
+}

--- a/app/Actions/Security/RecordPlatformSecurityEvent.php
+++ b/app/Actions/Security/RecordPlatformSecurityEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Actions\Security;
+
+use App\Models\PlatformSecurityEvent;
+use App\Models\User;
+
+class RecordPlatformSecurityEvent
+{
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    public function handle(string $type, User $actor, User $subject, array $metadata = []): PlatformSecurityEvent
+    {
+        return PlatformSecurityEvent::create([
+            'type' => $type,
+            'actor_user_id' => $actor->id,
+            'subject_user_id' => $subject->id,
+            'metadata' => $metadata,
+            'occurred_at' => now(),
+        ]);
+    }
+}

--- a/app/Actions/Security/RevokeOtherBrowserSessions.php
+++ b/app/Actions/Security/RevokeOtherBrowserSessions.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Actions\Security;
+
+use App\Models\User;
+use Illuminate\Database\ConnectionInterface;
+
+class RevokeOtherBrowserSessions
+{
+    public function __construct(private ConnectionInterface $database) {}
+
+    public function handle(User $user, string $currentSessionId): int
+    {
+        if (config('session.driver') !== 'database') {
+            return 0;
+        }
+
+        return $this->database
+            ->table((string) config('session.table', 'sessions'))
+            ->where('user_id', $user->getAuthIdentifier())
+            ->where('id', '!=', $currentSessionId)
+            ->delete();
+    }
+}

--- a/app/Actions/Teams/AcceptTeamInvitation.php
+++ b/app/Actions/Teams/AcceptTeamInvitation.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Actions\Teams;
+
+use App\Models\TeamInvitation;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class AcceptTeamInvitation
+{
+    public function handle(User $user, TeamInvitation $invitation): void
+    {
+        DB::transaction(function () use ($user, $invitation): void {
+            $invitation = TeamInvitation::query()
+                ->with('team')
+                ->lockForUpdate()
+                ->findOrFail($invitation->id);
+
+            if (! $invitation->isPending() || ! $invitation->isFor($user)) {
+                throw ValidationException::withMessages([
+                    'invitation' => __('This invitation is invalid or unavailable.'),
+                ]);
+            }
+
+            $invitation->team->memberships()->firstOrCreate(
+                ['user_id' => $user->id],
+                ['role' => $invitation->role],
+            );
+
+            $invitation->update(['accepted_at' => now()]);
+            $user->switchTeam($invitation->team);
+        });
+    }
+}

--- a/app/Actions/Teams/IssueTeamInvitation.php
+++ b/app/Actions/Teams/IssueTeamInvitation.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Actions\Teams;
+
+use App\Data\IssuedTeamInvitation;
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Str;
+
+class IssueTeamInvitation
+{
+    public function handle(Team $team, User $inviter, string $email, TeamRole $role): IssuedTeamInvitation
+    {
+        $token = Str::random(64);
+
+        $invitation = $team->invitations()->create([
+            'token_hash' => hash('sha256', $token),
+            'email' => Str::lower($email),
+            'role' => $role,
+            'invited_by' => $inviter->id,
+            'expires_at' => now()->addHours(72),
+        ]);
+
+        return new IssuedTeamInvitation($invitation, $token);
+    }
+}

--- a/app/Data/IssuedTeamInvitation.php
+++ b/app/Data/IssuedTeamInvitation.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Data;
+
+use App\Models\TeamInvitation;
+
+class IssuedTeamInvitation
+{
+    public function __construct(
+        public readonly TeamInvitation $invitation,
+        public readonly string $token,
+    ) {}
+}

--- a/app/Http/Controllers/Auth/MfaChallengeController.php
+++ b/app/Http/Controllers/Auth/MfaChallengeController.php
@@ -32,6 +32,10 @@ class MfaChallengeController extends Controller
 
         $request->session()->put('auth.mfa_confirmed_at', now()->getTimestamp());
 
-        return redirect()->intended(route('security.edit'));
+        $returnUrl = $request->session()->pull('auth.security_return_url');
+
+        return is_string($returnUrl)
+            ? redirect()->to($returnUrl)
+            : redirect()->intended(route('security.edit'));
     }
 }

--- a/app/Http/Controllers/Auth/MfaChallengeController.php
+++ b/app/Http/Controllers/Auth/MfaChallengeController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\ConfirmMfaRequest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
+use Laravel\Fortify\Fortify;
+
+class MfaChallengeController extends Controller
+{
+    public function create(): Response
+    {
+        return Inertia::render('auth/confirm-mfa');
+    }
+
+    public function store(
+        ConfirmMfaRequest $request,
+        TwoFactorAuthenticationProvider $provider,
+    ): RedirectResponse {
+        $secret = Fortify::currentEncrypter()->decrypt($request->user()->two_factor_secret);
+
+        if (! $provider->verify($secret, $request->string('code')->toString())) {
+            throw ValidationException::withMessages([
+                'code' => __('The provided two-factor authentication code was invalid.'),
+            ]);
+        }
+
+        $request->session()->put('auth.mfa_confirmed_at', now()->getTimestamp());
+
+        return redirect()->intended(route('security.edit'));
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -17,13 +17,14 @@ class DashboardController extends Controller
             ->with(['inviter', 'team'])
             ->whereRaw('LOWER(email) = ?', [$email])
             ->whereNull('accepted_at')
+            ->whereNull('revoked_at')
             ->where(fn ($query) => $query
                 ->whereNull('expires_at')
                 ->orWhere('expires_at', '>=', now()))
             ->latest()
             ->get()
             ->map(fn (TeamInvitation $invitation) => [
-                'code' => $invitation->code,
+                'id' => $invitation->id,
                 'inviterName' => $invitation->inviter->name,
                 'team' => [
                     'name' => $invitation->team->name,

--- a/app/Http/Controllers/Settings/OtherBrowserSessionController.php
+++ b/app/Http/Controllers/Settings/OtherBrowserSessionController.php
@@ -7,6 +7,7 @@ use App\Actions\Security\RevokeOtherBrowserSessions;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\RevokeOtherBrowserSessionsRequest;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 
 class OtherBrowserSessionController extends Controller
@@ -17,14 +18,16 @@ class OtherBrowserSessionController extends Controller
         RecordPlatformSecurityEvent $recordPlatformSecurityEvent,
     ): RedirectResponse {
         $user = $request->user();
-        $revokedCount = $revokeOtherBrowserSessions->handle($user, $request->session()->getId());
+        DB::transaction(function () use ($request, $user, $revokeOtherBrowserSessions, $recordPlatformSecurityEvent): void {
+            $revokedCount = $revokeOtherBrowserSessions->handle($user, $request->session()->getId());
 
-        $recordPlatformSecurityEvent->handle(
-            type: 'other_browser_sessions_revoked',
-            actor: $user,
-            subject: $user,
-            metadata: ['revoked_count' => $revokedCount],
-        );
+            $recordPlatformSecurityEvent->handle(
+                type: 'other_browser_sessions_revoked',
+                actor: $user,
+                subject: $user,
+                metadata: ['revoked_count' => $revokedCount],
+            );
+        });
 
         Inertia::flash('toast', [
             'type' => 'success',

--- a/app/Http/Controllers/Settings/OtherBrowserSessionController.php
+++ b/app/Http/Controllers/Settings/OtherBrowserSessionController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Actions\Security\RecordPlatformSecurityEvent;
+use App\Actions\Security\RevokeOtherBrowserSessions;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\RevokeOtherBrowserSessionsRequest;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+
+class OtherBrowserSessionController extends Controller
+{
+    public function __invoke(
+        RevokeOtherBrowserSessionsRequest $request,
+        RevokeOtherBrowserSessions $revokeOtherBrowserSessions,
+        RecordPlatformSecurityEvent $recordPlatformSecurityEvent,
+    ): RedirectResponse {
+        $user = $request->user();
+        $revokedCount = $revokeOtherBrowserSessions->handle($user, $request->session()->getId());
+
+        $recordPlatformSecurityEvent->handle(
+            type: 'other_browser_sessions_revoked',
+            actor: $user,
+            subject: $user,
+            metadata: ['revoked_count' => $revokedCount],
+        );
+
+        Inertia::flash('toast', [
+            'type' => 'success',
+            'message' => __('Other browser sessions revoked.'),
+        ]);
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Settings/RecoveryCodeAcknowledgementController.php
+++ b/app/Http/Controllers/Settings/RecoveryCodeAcknowledgementController.php
@@ -17,7 +17,6 @@ class RecoveryCodeAcknowledgementController extends Controller
         $request->user()->forceFill([
             'recovery_codes_acknowledged_at' => now(),
         ])->save();
-        $request->session()->put('auth.mfa_confirmed_at', now()->getTimestamp());
 
         Inertia::flash('toast', [
             'type' => 'success',

--- a/app/Http/Controllers/Settings/RecoveryCodeAcknowledgementController.php
+++ b/app/Http/Controllers/Settings/RecoveryCodeAcknowledgementController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\AcknowledgeRecoveryCodesRequest;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+
+class RecoveryCodeAcknowledgementController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(AcknowledgeRecoveryCodesRequest $request): RedirectResponse
+    {
+        $request->user()->forceFill([
+            'recovery_codes_acknowledged_at' => now(),
+        ])->save();
+        $request->session()->put('auth.mfa_confirmed_at', now()->getTimestamp());
+
+        Inertia::flash('toast', [
+            'type' => 'success',
+            'message' => __('Recovery codes acknowledged.'),
+        ]);
+
+        return to_route('security.edit');
+    }
+}

--- a/app/Http/Controllers/Settings/SecurityController.php
+++ b/app/Http/Controllers/Settings/SecurityController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\PasswordUpdateRequest;
 use App\Http\Requests\Settings\TwoFactorAuthenticationRequest;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\Rules\Password;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -28,7 +29,16 @@ class SecurityController extends Controller
 
             $props['twoFactorEnabled'] = $request->user()->hasEnabledTwoFactorAuthentication();
             $props['requiresConfirmation'] = Features::optionEnabled(Features::twoFactorAuthentication(), 'confirm');
+            $props['recoveryCodesAcknowledged'] = $request->user()->hasAcknowledgedRecoveryCodes();
         }
+
+        $props['required'] = $request->string('required')->toString() ?: null;
+        $props['otherBrowserSessionCount'] = config('session.driver') === 'database'
+            ? DB::table((string) config('session.table', 'sessions'))
+                ->where('user_id', $request->user()->getAuthIdentifier())
+                ->where('id', '!=', $request->session()->getId())
+                ->count()
+            : 0;
 
         return Inertia::render('settings/security', $props);
     }

--- a/app/Http/Controllers/Teams/TeamController.php
+++ b/app/Http/Controllers/Teams/TeamController.php
@@ -72,6 +72,10 @@ class TeamController extends Controller
             }),
             'invitations' => $team->invitations()
                 ->whereNull('accepted_at')
+                ->whereNull('revoked_at')
+                ->where(fn ($query) => $query
+                    ->whereNull('expires_at')
+                    ->orWhere('expires_at', '>=', now()))
                 ->get()
                 ->map(fn ($invitation) => [
                     'id' => $invitation->id,

--- a/app/Http/Controllers/Teams/TeamController.php
+++ b/app/Http/Controllers/Teams/TeamController.php
@@ -74,7 +74,7 @@ class TeamController extends Controller
                 ->whereNull('accepted_at')
                 ->get()
                 ->map(fn ($invitation) => [
-                    'code' => $invitation->code,
+                    'id' => $invitation->id,
                     'email' => $invitation->email,
                     'role' => $invitation->role->value,
                     'role_label' => $invitation->role->label(),

--- a/app/Http/Controllers/Teams/TeamInvitationController.php
+++ b/app/Http/Controllers/Teams/TeamInvitationController.php
@@ -2,15 +2,18 @@
 
 namespace App\Http\Controllers\Teams;
 
+use App\Actions\Teams\AcceptTeamInvitation;
+use App\Actions\Teams\IssueTeamInvitation;
 use App\Enums\TeamRole;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Teams\CreateTeamInvitationRequest;
 use App\Http\Requests\Teams\RespondToTeamInvitationRequest;
 use App\Models\Team;
 use App\Models\TeamInvitation;
+use App\Models\User;
 use App\Notifications\Teams\TeamInvitation as TeamInvitationNotification;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Notification;
 use Inertia\Inertia;
@@ -20,19 +23,23 @@ class TeamInvitationController extends Controller
     /**
      * Store a newly created invitation.
      */
-    public function store(CreateTeamInvitationRequest $request, Team $team): RedirectResponse
+    public function store(CreateTeamInvitationRequest $request, Team $team, IssueTeamInvitation $issueInvitation): RedirectResponse
     {
         Gate::authorize('inviteMember', $team);
 
-        $invitation = $team->invitations()->create([
-            'email' => $request->validated('email'),
-            'role' => TeamRole::from($request->validated('role')),
-            'invited_by' => $request->user()->id,
-            'expires_at' => now()->addDays(3),
-        ]);
+        $issuedInvitation = $issueInvitation->handle(
+            $team,
+            $request->user(),
+            $request->validated('email'),
+            TeamRole::from($request->validated('role')),
+        );
 
-        Notification::route('mail', $invitation->email)
-            ->notify(new TeamInvitationNotification($invitation));
+        Notification::route('mail', $issuedInvitation->invitation->email)
+            ->notify(new TeamInvitationNotification(
+                $issuedInvitation->invitation,
+                $issuedInvitation->token,
+                User::query()->where('email', $issuedInvitation->invitation->email)->exists(),
+            ));
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Invitation sent.')]);
 
@@ -42,13 +49,16 @@ class TeamInvitationController extends Controller
     /**
      * Cancel the specified invitation.
      */
-    public function destroy(Team $team, TeamInvitation $invitation): RedirectResponse
+    public function destroy(Request $request, Team $team, TeamInvitation $invitation): RedirectResponse
     {
         abort_unless($invitation->team_id === $team->id, 404);
 
         Gate::authorize('cancelInvitation', $team);
 
-        $invitation->delete();
+        $invitation->update([
+            'revoked_at' => now(),
+            'revoked_by' => $request->user()->id,
+        ]);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Invitation cancelled.')]);
 
@@ -58,22 +68,9 @@ class TeamInvitationController extends Controller
     /**
      * Accept the invitation.
      */
-    public function accept(RespondToTeamInvitationRequest $request, TeamInvitation $invitation): RedirectResponse
+    public function accept(RespondToTeamInvitationRequest $request, TeamInvitation $invitation, AcceptTeamInvitation $acceptInvitation): RedirectResponse
     {
-        $user = $request->user();
-
-        DB::transaction(function () use ($user, $invitation) {
-            $team = $invitation->team;
-
-            $team->memberships()->firstOrCreate(
-                ['user_id' => $user->id],
-                ['role' => $invitation->role],
-            );
-
-            $invitation->update(['accepted_at' => now()]);
-
-            $user->switchTeam($team);
-        });
+        $acceptInvitation->handle($request->user(), $invitation);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Invitation accepted.')]);
 
@@ -85,7 +82,10 @@ class TeamInvitationController extends Controller
      */
     public function decline(RespondToTeamInvitationRequest $request, TeamInvitation $invitation): RedirectResponse
     {
-        $invitation->delete();
+        $invitation->update([
+            'revoked_at' => now(),
+            'revoked_by' => $request->user()->id,
+        ]);
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Invitation declined.')]);
 

--- a/app/Http/Middleware/EnforceAbsoluteSessionLifetime.php
+++ b/app/Http/Middleware/EnforceAbsoluteSessionLifetime.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnforceAbsoluteSessionLifetime
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! $request->user()) {
+            return $next($request);
+        }
+
+        $startedAt = $request->session()->get('auth.session_started_at');
+
+        if (! is_int($startedAt)) {
+            $request->session()->put('auth.session_started_at', now()->getTimestamp());
+
+            return $next($request);
+        }
+
+        if ($startedAt <= now()->subSeconds((int) config('auth.session_absolute_timeout', 43200))->getTimestamp()) {
+            Auth::guard('web')->logout();
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+
+            return to_route('login')->withErrors([
+                'email' => __('Your session expired. Please sign in again.'),
+            ]);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/EnsureRecentMfa.php
+++ b/app/Http/Middleware/EnsureRecentMfa.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureRecentMfa
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $confirmedAt = $request->session()->get('auth.mfa_confirmed_at');
+        $timeout = (int) config('auth.mfa_timeout', 900);
+
+        if (! is_int($confirmedAt) || $confirmedAt < now()->subSeconds($timeout)->getTimestamp()) {
+            $request->session()->put('url.intended', $request->fullUrl());
+
+            return to_route('mfa.confirm');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/EnsureRecentMfa.php
+++ b/app/Http/Middleware/EnsureRecentMfa.php
@@ -19,11 +19,25 @@ class EnsureRecentMfa
         $timeout = (int) config('auth.mfa_timeout', 900);
 
         if (! is_int($confirmedAt) || $confirmedAt < now()->subSeconds($timeout)->getTimestamp()) {
-            $request->session()->put('url.intended', $request->fullUrl());
+            $request->session()->put('auth.security_return_url', $this->safeReturnUrl($request));
 
             return to_route('mfa.confirm');
         }
 
         return $next($request);
+    }
+
+    private function safeReturnUrl(Request $request): string
+    {
+        if ($request->isMethodSafe()) {
+            return $request->fullUrl();
+        }
+
+        $candidate = url()->previous();
+        $origin = $request->getSchemeAndHttpHost();
+
+        return $candidate === $origin || str_starts_with($candidate, $origin.'/')
+            ? $candidate
+            : route('security.edit');
     }
 }

--- a/app/Http/Middleware/EnsureRecentMfa.php
+++ b/app/Http/Middleware/EnsureRecentMfa.php
@@ -15,6 +15,10 @@ class EnsureRecentMfa
      */
     public function handle(Request $request, Closure $next): Response
     {
+        if (! config('auth.mfa_required')) {
+            return $next($request);
+        }
+
         $confirmedAt = $request->session()->get('auth.mfa_confirmed_at');
         $timeout = (int) config('auth.mfa_timeout', 900);
 

--- a/app/Http/Middleware/EnsureRecentPassword.php
+++ b/app/Http/Middleware/EnsureRecentPassword.php
@@ -9,12 +9,16 @@ class EnsureRecentPassword extends RequirePassword
 {
     public function handle($request, $next, $redirectToRoute = null, $passwordTimeoutSeconds = null): mixed
     {
+        $passwordTimeout = $passwordTimeoutSeconds === null
+            ? null
+            : (int) $passwordTimeoutSeconds;
+
         if (
             $request->isMethodSafe()
-            || ! $this->shouldConfirmPassword($request, $passwordTimeoutSeconds)
+            || ! $this->shouldConfirmPassword($request, $passwordTimeout)
             || $request->expectsJson()
         ) {
-            return parent::handle($request, $next, $redirectToRoute, $passwordTimeoutSeconds);
+            return parent::handle($request, $next, $redirectToRoute, $passwordTimeout);
         }
 
         $request->session()->put('auth.security_return_url', $this->safeReturnUrl($request));

--- a/app/Http/Middleware/EnsureRecentPassword.php
+++ b/app/Http/Middleware/EnsureRecentPassword.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Auth\Middleware\RequirePassword;
+use Illuminate\Http\Request;
+
+class EnsureRecentPassword extends RequirePassword
+{
+    public function handle($request, $next, $redirectToRoute = null, $passwordTimeoutSeconds = null): mixed
+    {
+        if (
+            $request->isMethodSafe()
+            || ! $this->shouldConfirmPassword($request, $passwordTimeoutSeconds)
+            || $request->expectsJson()
+        ) {
+            return parent::handle($request, $next, $redirectToRoute, $passwordTimeoutSeconds);
+        }
+
+        $request->session()->put('auth.security_return_url', $this->safeReturnUrl($request));
+
+        return to_route($redirectToRoute ?: 'password.confirm');
+    }
+
+    private function safeReturnUrl(Request $request): string
+    {
+        $candidate = url()->previous();
+        $origin = $request->getSchemeAndHttpHost();
+
+        return $candidate === $origin || str_starts_with($candidate, $origin.'/')
+            ? $candidate
+            : route('security.edit');
+    }
+}

--- a/app/Http/Middleware/EnsureStaffSecurityRequirements.php
+++ b/app/Http/Middleware/EnsureStaffSecurityRequirements.php
@@ -15,6 +15,10 @@ class EnsureStaffSecurityRequirements
      */
     public function handle(Request $request, Closure $next): Response
     {
+        if (! config('auth.mfa_required')) {
+            return $next($request);
+        }
+
         $user = $request->user();
 
         abort_if($user === null, 403);

--- a/app/Http/Middleware/EnsureStaffSecurityRequirements.php
+++ b/app/Http/Middleware/EnsureStaffSecurityRequirements.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureStaffSecurityRequirements
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        abort_if($user === null, 403);
+
+        if (! $user->hasEnabledTwoFactorAuthentication()) {
+            return to_route('security.edit', ['required' => 'mfa']);
+        }
+
+        if (! $user->hasAcknowledgedRecoveryCodes()) {
+            return to_route('security.edit', ['required' => 'recovery-codes']);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/ProtectSensitiveFortifyRoutes.php
+++ b/app/Http/Middleware/ProtectSensitiveFortifyRoutes.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ProtectSensitiveFortifyRoutes
+{
+    public function __construct(
+        private EnsureStaffSecurityRequirements $ensureStaffSecurityRequirements,
+        private EnsureRecentPassword $ensureRecentPassword,
+        private EnsureRecentMfa $ensureRecentMfa,
+    ) {}
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (! in_array($request->route()?->getName(), [
+            'two-factor.disable',
+            'two-factor.regenerate-recovery-codes',
+        ], true)) {
+            return $next($request);
+        }
+
+        return $this->ensureStaffSecurityRequirements->handle(
+            $request,
+            fn (Request $request): Response => $this->ensureRecentPassword->handle(
+                $request,
+                fn (Request $request): Response => $this->ensureRecentMfa->handle($request, $next),
+            ),
+        );
+    }
+}

--- a/app/Http/Requests/Auth/ConfirmMfaRequest.php
+++ b/app/Http/Requests/Auth/ConfirmMfaRequest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ConfirmMfaRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user()?->hasEnabledTwoFactorAuthentication() === true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return ['code' => ['required', 'string']];
+    }
+}

--- a/app/Http/Requests/Settings/AcknowledgeRecoveryCodesRequest.php
+++ b/app/Http/Requests/Settings/AcknowledgeRecoveryCodesRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AcknowledgeRecoveryCodesRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->hasEnabledTwoFactorAuthentication() === true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return ['acknowledged' => ['required', 'accepted']];
+    }
+}

--- a/app/Http/Requests/Settings/RevokeOtherBrowserSessionsRequest.php
+++ b/app/Http/Requests/Settings/RevokeOtherBrowserSessionsRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RevokeOtherBrowserSessionsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [];
+    }
+}

--- a/app/Http/Responses/Concerns/RedirectsAfterStaffAuthentication.php
+++ b/app/Http/Responses/Concerns/RedirectsAfterStaffAuthentication.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Responses\Concerns;
+
+use App\Actions\Teams\AcceptTeamInvitation;
+use App\Models\TeamInvitation;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+trait RedirectsAfterStaffAuthentication
+{
+    use RedirectsToCurrentTeam;
+
+    protected function staffAuthenticationResponse(
+        Request $request,
+        string $fallback,
+        AcceptTeamInvitation $acceptTeamInvitation,
+    ): Response {
+        $user = $request->user();
+
+        abort_if(! $user, 403);
+
+        if (! $user->hasVerifiedEmail()) {
+            return to_route('verification.notice');
+        }
+
+        $this->acceptPendingInvitation($request, $acceptTeamInvitation);
+
+        if (! $user->hasEnabledTwoFactorAuthentication() || ! $user->hasAcknowledgedRecoveryCodes()) {
+            return to_route('security.edit');
+        }
+
+        return redirect()->intended($this->redirectPathForCurrentTeam($request, $fallback));
+    }
+
+    private function acceptPendingInvitation(Request $request, AcceptTeamInvitation $acceptTeamInvitation): void
+    {
+        $invitationId = $request->session()->get('auth.pending_team_invitation_id');
+        $invitation = is_numeric($invitationId) ? TeamInvitation::find($invitationId) : null;
+
+        if (! $invitation?->isPending() || ! $invitation->isFor($request->user())) {
+            $request->session()->forget('auth.pending_team_invitation_id');
+
+            return;
+        }
+
+        $acceptTeamInvitation->handle($request->user(), $invitation);
+        $request->session()->forget('auth.pending_team_invitation_id');
+    }
+}

--- a/app/Http/Responses/Concerns/RedirectsAfterStaffAuthentication.php
+++ b/app/Http/Responses/Concerns/RedirectsAfterStaffAuthentication.php
@@ -26,8 +26,12 @@ trait RedirectsAfterStaffAuthentication
 
         $this->acceptPendingInvitation($request, $acceptTeamInvitation);
 
-        if (! $user->hasEnabledTwoFactorAuthentication() || ! $user->hasAcknowledgedRecoveryCodes()) {
-            return to_route('security.edit');
+        if (config('auth.mfa_required') && ! $user->hasEnabledTwoFactorAuthentication()) {
+            return to_route('security.edit', ['required' => 'mfa']);
+        }
+
+        if (config('auth.mfa_required') && ! $user->hasAcknowledgedRecoveryCodes()) {
+            return to_route('security.edit', ['required' => 'recovery-codes']);
         }
 
         return redirect()->intended($this->redirectPathForCurrentTeam($request, $fallback));

--- a/app/Http/Responses/LoginResponse.php
+++ b/app/Http/Responses/LoginResponse.php
@@ -2,7 +2,8 @@
 
 namespace App\Http\Responses;
 
-use App\Http\Responses\Concerns\RedirectsToCurrentTeam;
+use App\Actions\Teams\AcceptTeamInvitation;
+use App\Http\Responses\Concerns\RedirectsAfterStaffAuthentication;
 use Illuminate\Http\JsonResponse;
 use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
 use Laravel\Fortify\Fortify;
@@ -10,12 +11,14 @@ use Symfony\Component\HttpFoundation\Response;
 
 class LoginResponse implements LoginResponseContract
 {
-    use RedirectsToCurrentTeam;
+    use RedirectsAfterStaffAuthentication;
+
+    public function __construct(private AcceptTeamInvitation $acceptTeamInvitation) {}
 
     public function toResponse($request): Response
     {
         return $request->wantsJson()
             ? new JsonResponse(['two_factor' => false], 200)
-            : redirect()->intended($this->redirectPathForCurrentTeam($request, Fortify::redirects('login')));
+            : $this->staffAuthenticationResponse($request, Fortify::redirects('login'), $this->acceptTeamInvitation);
     }
 }

--- a/app/Http/Responses/PasswordConfirmedResponse.php
+++ b/app/Http/Responses/PasswordConfirmedResponse.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Responses;
+
+use Illuminate\Http\JsonResponse;
+use Laravel\Fortify\Contracts\PasswordConfirmedResponse as PasswordConfirmedResponseContract;
+use Laravel\Fortify\Fortify;
+use Symfony\Component\HttpFoundation\Response;
+
+class PasswordConfirmedResponse implements PasswordConfirmedResponseContract
+{
+    public function toResponse($request): Response
+    {
+        if ($request->wantsJson()) {
+            return new JsonResponse('', 201);
+        }
+
+        $returnUrl = $request->session()->pull('auth.security_return_url');
+
+        return is_string($returnUrl)
+            ? redirect()->to($returnUrl)
+            : redirect()->intended(Fortify::redirects('password-confirmation'));
+    }
+}

--- a/app/Http/Responses/RegisterResponse.php
+++ b/app/Http/Responses/RegisterResponse.php
@@ -2,20 +2,23 @@
 
 namespace App\Http\Responses;
 
-use App\Http\Responses\Concerns\RedirectsToCurrentTeam;
+use App\Models\TeamInvitation;
 use Illuminate\Http\JsonResponse;
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
-use Laravel\Fortify\Fortify;
 use Symfony\Component\HttpFoundation\Response;
 
 class RegisterResponse implements RegisterResponseContract
 {
-    use RedirectsToCurrentTeam;
-
     public function toResponse($request): Response
     {
+        $invitation = TeamInvitation::findByToken($request->string('invitation')->toString());
+
+        if ($invitation?->isPending()) {
+            $request->session()->put('auth.pending_team_invitation_id', $invitation->id);
+        }
+
         return $request->wantsJson()
             ? new JsonResponse(['two_factor' => false], 201)
-            : redirect()->intended($this->redirectPathForCurrentTeam($request, Fortify::redirects('register')));
+            : to_route('verification.notice');
     }
 }

--- a/app/Http/Responses/TwoFactorLoginResponse.php
+++ b/app/Http/Responses/TwoFactorLoginResponse.php
@@ -2,7 +2,8 @@
 
 namespace App\Http\Responses;
 
-use App\Http\Responses\Concerns\RedirectsToCurrentTeam;
+use App\Actions\Teams\AcceptTeamInvitation;
+use App\Http\Responses\Concerns\RedirectsAfterStaffAuthentication;
 use Illuminate\Http\JsonResponse;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
 use Laravel\Fortify\Fortify;
@@ -10,12 +11,16 @@ use Symfony\Component\HttpFoundation\Response;
 
 class TwoFactorLoginResponse implements TwoFactorLoginResponseContract
 {
-    use RedirectsToCurrentTeam;
+    use RedirectsAfterStaffAuthentication;
+
+    public function __construct(private AcceptTeamInvitation $acceptTeamInvitation) {}
 
     public function toResponse($request): Response
     {
+        $request->session()->put('auth.mfa_confirmed_at', now()->unix());
+
         return $request->wantsJson()
             ? new JsonResponse(['two_factor' => false], 200)
-            : redirect()->intended($this->redirectPathForCurrentTeam($request, Fortify::redirects('login')));
+            : $this->staffAuthenticationResponse($request, Fortify::redirects('login'), $this->acceptTeamInvitation);
     }
 }

--- a/app/Http/Responses/VerifyEmailResponse.php
+++ b/app/Http/Responses/VerifyEmailResponse.php
@@ -2,20 +2,27 @@
 
 namespace App\Http\Responses;
 
-use App\Http\Responses\Concerns\RedirectsToCurrentTeam;
+use App\Actions\Teams\AcceptTeamInvitation;
+use App\Models\TeamInvitation;
 use Illuminate\Http\JsonResponse;
 use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
-use Laravel\Fortify\Fortify;
 use Symfony\Component\HttpFoundation\Response;
 
 class VerifyEmailResponse implements VerifyEmailResponseContract
 {
-    use RedirectsToCurrentTeam;
+    public function __construct(private AcceptTeamInvitation $acceptInvitation) {}
 
     public function toResponse($request): Response
     {
+        $invitationId = $request->session()->pull('auth.pending_team_invitation_id');
+        $invitation = is_numeric($invitationId) ? TeamInvitation::find($invitationId) : null;
+
+        if ($invitation?->isPending() && $invitation->isFor($request->user())) {
+            $this->acceptInvitation->handle($request->user(), $invitation);
+        }
+
         return $request->wantsJson()
             ? new JsonResponse('', 204)
-            : redirect()->intended($this->redirectPathForCurrentTeam($request, Fortify::redirects('email-verification')).'?verified=1');
+            : to_route('security.edit', ['verified' => 1]);
     }
 }

--- a/app/Models/PlatformSecurityEvent.php
+++ b/app/Models/PlatformSecurityEvent.php
@@ -32,11 +32,17 @@ class PlatformSecurityEvent extends Model
 
     public $timestamps = false;
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function actor(): BelongsTo
     {
         return $this->belongsTo(User::class, 'actor_user_id');
     }
 
+    /**
+     * @return BelongsTo<User, $this>
+     */
     public function subject(): BelongsTo
     {
         return $this->belongsTo(User::class, 'subject_user_id');

--- a/app/Models/PlatformSecurityEvent.php
+++ b/app/Models/PlatformSecurityEvent.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\PlatformSecurityEventFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property string $type
+ * @property int|null $actor_user_id
+ * @property int|null $subject_user_id
+ * @property array<string, mixed> $metadata
+ * @property Carbon $occurred_at
+ */
+class PlatformSecurityEvent extends Model
+{
+    /** @use HasFactory<PlatformSecurityEventFactory> */
+    use HasFactory, HasUlids;
+
+    protected $fillable = [
+        'type',
+        'actor_user_id',
+        'subject_user_id',
+        'metadata',
+        'occurred_at',
+    ];
+
+    public $timestamps = false;
+
+    public function actor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'actor_user_id');
+    }
+
+    public function subject(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'subject_user_id');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'metadata' => 'array',
+            'occurred_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/TeamInvitation.php
+++ b/app/Models/TeamInvitation.php
@@ -9,40 +9,34 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Str;
 
 /**
  * @property int $id
- * @property string $code
+ * @property string $token_hash
  * @property int $team_id
  * @property string $email
  * @property TeamRole $role
  * @property int $invited_by
  * @property Carbon|null $expires_at
  * @property Carbon|null $accepted_at
+ * @property Carbon|null $revoked_at
+ * @property int|null $revoked_by
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Team $team
  * @property-read User $inviter
  */
-#[Fillable(['team_id', 'email', 'role', 'invited_by', 'expires_at', 'accepted_at'])]
+#[Fillable(['token_hash', 'team_id', 'email', 'role', 'invited_by', 'expires_at', 'accepted_at', 'revoked_at', 'revoked_by'])]
 class TeamInvitation extends Model
 {
     /** @use HasFactory<TeamInvitationFactory> */
     use HasFactory;
 
-    /**
-     * Bootstrap the model and its traits.
-     */
-    protected static function boot(): void
+    public static function findByToken(string $token): ?self
     {
-        parent::boot();
-
-        static::creating(function (TeamInvitation $invitation) {
-            if (empty($invitation->code)) {
-                $invitation->code = Str::random(64);
-            }
-        });
+        return self::query()
+            ->where('token_hash', hash('sha256', $token))
+            ->first();
     }
 
     /**
@@ -78,7 +72,17 @@ class TeamInvitation extends Model
      */
     public function isPending(): bool
     {
-        return $this->accepted_at === null && ! $this->isExpired();
+        return ! $this->isAccepted() && ! $this->isRevoked() && ! $this->isExpired();
+    }
+
+    public function isRevoked(): bool
+    {
+        return $this->revoked_at !== null;
+    }
+
+    public function isFor(User $user): bool
+    {
+        return mb_strtolower($this->email) === mb_strtolower($user->email);
     }
 
     /**
@@ -100,14 +104,7 @@ class TeamInvitation extends Model
             'role' => TeamRole::class,
             'expires_at' => 'datetime',
             'accepted_at' => 'datetime',
+            'revoked_at' => 'datetime',
         ];
-    }
-
-    /**
-     * Get the route key for the model.
-     */
-    public function getRouteKeyName(): string
-    {
-        return 'code';
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -23,6 +23,7 @@ use Laravel\Fortify\TwoFactorAuthenticatable;
  * @property string|null $two_factor_secret
  * @property string|null $two_factor_recovery_codes
  * @property Carbon|null $two_factor_confirmed_at
+ * @property Carbon|null $recovery_codes_acknowledged_at
  * @property string|null $remember_token
  * @property int|null $current_team_id
  * @property Carbon|null $created_at
@@ -32,12 +33,21 @@ use Laravel\Fortify\TwoFactorAuthenticatable;
  * @property-read Collection<int, Membership> $teamMemberships
  * @property-read Collection<int, Team> $teams
  */
-#[Fillable(['name', 'email', 'password', 'current_team_id'])]
+#[Fillable(['name', 'email', 'password', 'current_team_id', 'recovery_codes_acknowledged_at'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token'])]
 class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory, HasTeams, Notifiable, TwoFactorAuthenticatable;
+
+    protected static function booted(): void
+    {
+        static::saving(function (User $user): void {
+            if ($user->exists && $user->isDirty(['two_factor_secret', 'two_factor_recovery_codes'])) {
+                $user->recovery_codes_acknowledged_at = null;
+            }
+        });
+    }
 
     /**
      * Get the attributes that should be cast.
@@ -50,6 +60,12 @@ class User extends Authenticatable implements MustVerifyEmail
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'two_factor_confirmed_at' => 'datetime',
+            'recovery_codes_acknowledged_at' => 'datetime',
         ];
+    }
+
+    public function hasAcknowledgedRecoveryCodes(): bool
+    {
+        return $this->recovery_codes_acknowledged_at !== null;
     }
 }

--- a/app/Notifications/Teams/TeamInvitation.php
+++ b/app/Notifications/Teams/TeamInvitation.php
@@ -4,21 +4,21 @@ namespace App\Notifications\Teams;
 
 use App\Models\TeamInvitation as TeamInvitationModel;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 
-class TeamInvitation extends Notification implements ShouldQueue
+class TeamInvitation extends Notification
 {
     use Queueable;
 
     /**
      * Create a new notification instance.
      */
-    public function __construct(public TeamInvitationModel $invitation)
-    {
-        //
-    }
+    public function __construct(
+        public TeamInvitationModel $invitation,
+        public string $token,
+        public bool $existingUser,
+    ) {}
 
     /**
      * Get the notification's delivery channels.
@@ -38,16 +38,21 @@ class TeamInvitation extends Notification implements ShouldQueue
         $team = $this->invitation->team;
         $inviter = $this->invitation->inviter;
 
+        $route = $this->existingUser ? 'login' : 'register';
+        $action = $this->existingUser ? __('Log in') : __('Create account');
+
         return (new MailMessage)
             ->subject(__("You've been invited to join :teamName", ['teamName' => $team->name]))
             ->line(__(':inviterName has invited you to join the :teamName team.', [
                 'inviterName' => $inviter->name,
                 'teamName' => $team->name,
             ]))
-            ->line(__('Log in and visit your dashboard to accept or decline this invitation.'))
+            ->line($this->existingUser
+                ? __('Log in and visit your dashboard to accept or decline this invitation.')
+                : __('Create your account with this invitation, then verify your email address to continue.'))
             ->action(
-                __('Log in'),
-                route('login', ['invitation' => $this->invitation->code]),
+                $action,
+                route($route, ['invitation' => $this->token]),
             );
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -60,14 +60,10 @@ class AppServiceProvider extends ServiceProvider
             app()->isProduction(),
         );
 
-        Password::defaults(fn (): ?Password => app()->isProduction()
-            ? Password::min(12)
-                ->mixedCase()
-                ->letters()
-                ->numbers()
-                ->symbols()
-                ->uncompromised()
-            : null,
-        );
+        Password::defaults(function (): Password {
+            $rule = Password::min(14);
+
+            return app()->isProduction() ? $rule->uncompromised() : $rule;
+        });
     }
 }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace App\Providers;
 
+use App\Actions\Fortify\CaptureTeamInvitation;
 use App\Actions\Fortify\CreateNewUser;
+use App\Actions\Fortify\DiscardRememberedLogin;
 use App\Actions\Fortify\ResetUserPassword;
 use App\Http\Responses\LoginResponse;
 use App\Http\Responses\RegisterResponse;
@@ -15,6 +17,10 @@ use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
+use Laravel\Fortify\Actions\AttemptToAuthenticate;
+use Laravel\Fortify\Actions\CanonicalizeUsername;
+use Laravel\Fortify\Actions\PrepareAuthenticatedSession;
+use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
 use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
@@ -41,6 +47,7 @@ class FortifyServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->configureActions();
+        $this->configureAuthenticationPipeline();
         $this->configureViews();
         $this->configureRateLimiting();
     }
@@ -52,6 +59,18 @@ class FortifyServiceProvider extends ServiceProvider
     {
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
         Fortify::createUsersUsing(CreateNewUser::class);
+    }
+
+    private function configureAuthenticationPipeline(): void
+    {
+        Fortify::authenticateThrough(fn () => [
+            CaptureTeamInvitation::class,
+            DiscardRememberedLogin::class,
+            config('fortify.lowercase_usernames') ? CanonicalizeUsername::class : null,
+            Features::enabled(Features::twoFactorAuthentication()) ? RedirectIfTwoFactorAuthenticatable::class : null,
+            AttemptToAuthenticate::class,
+            PrepareAuthenticatedSession::class,
+        ]);
     }
 
     /**
@@ -78,9 +97,15 @@ class FortifyServiceProvider extends ServiceProvider
             'status' => $request->session()->get('status'),
         ]));
 
-        Fortify::registerView(fn (Request $request) => Inertia::render('auth/register', [
-            'teamInvitation' => $this->teamInvitation($request),
-        ]));
+        Fortify::registerView(function (Request $request) {
+            $teamInvitation = $this->teamInvitation($request);
+
+            abort_if($teamInvitation === null, 404);
+
+            return Inertia::render('auth/register', [
+                'teamInvitation' => $teamInvitation,
+            ]);
+        });
 
         Fortify::twoFactorChallengeView(fn () => Inertia::render('auth/two-factor-challenge'));
 
@@ -93,8 +118,11 @@ class FortifyServiceProvider extends ServiceProvider
     private function configureRateLimiting(): void
     {
         RateLimiter::for('two-factor', function (Request $request) {
-            return Limit::perMinute(5)->by($request->session()->get('login.id'));
+            return Limit::perMinute(5)->by($request->session()->get('login.id').'|'.$request->ip());
         });
+
+        RateLimiter::for('verification', fn (Request $request) => Limit::perMinute(5)
+            ->by($request->user()?->getAuthIdentifier().'|'.$request->ip()));
 
         RateLimiter::for('login', function (Request $request) {
             $throttleKey = Str::transliterate(Str::lower($request->input(Fortify::username())).'|'.$request->ip());
@@ -107,7 +135,7 @@ class FortifyServiceProvider extends ServiceProvider
     /**
      * Get the pending team invitation context for auth pages.
      *
-     * @return array{code: string, teamName: string}|null
+     * @return array{code: string, email: string, teamName: string}|null
      */
     private function teamInvitation(Request $request): ?array
     {
@@ -117,21 +145,15 @@ class FortifyServiceProvider extends ServiceProvider
             return null;
         }
 
-        $invitation = TeamInvitation::query()
-            ->with('team')
-            ->where('code', $invitationCode)
-            ->whereNull('accepted_at')
-            ->where(fn ($query) => $query
-                ->whereNull('expires_at')
-                ->orWhere('expires_at', '>=', now()))
-            ->first();
+        $invitation = TeamInvitation::findByToken($invitationCode)?->load('team');
 
-        if (! $invitation) {
+        if (! $invitation?->isPending()) {
             return null;
         }
 
         return [
-            'code' => $invitation->code,
+            'code' => $invitationCode,
+            'email' => $invitation->email,
             'teamName' => $invitation->team->name,
         ];
     }

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -7,6 +7,7 @@ use App\Actions\Fortify\CreateNewUser;
 use App\Actions\Fortify\DiscardRememberedLogin;
 use App\Actions\Fortify\ResetUserPassword;
 use App\Http\Responses\LoginResponse;
+use App\Http\Responses\PasswordConfirmedResponse;
 use App\Http\Responses\RegisterResponse;
 use App\Http\Responses\TwoFactorLoginResponse;
 use App\Http\Responses\VerifyEmailResponse;
@@ -22,6 +23,7 @@ use Laravel\Fortify\Actions\CanonicalizeUsername;
 use Laravel\Fortify\Actions\PrepareAuthenticatedSession;
 use Laravel\Fortify\Actions\RedirectIfTwoFactorAuthenticatable;
 use Laravel\Fortify\Contracts\LoginResponse as LoginResponseContract;
+use Laravel\Fortify\Contracts\PasswordConfirmedResponse as PasswordConfirmedResponseContract;
 use Laravel\Fortify\Contracts\RegisterResponse as RegisterResponseContract;
 use Laravel\Fortify\Contracts\TwoFactorLoginResponse as TwoFactorLoginResponseContract;
 use Laravel\Fortify\Contracts\VerifyEmailResponse as VerifyEmailResponseContract;
@@ -36,6 +38,7 @@ class FortifyServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->singleton(LoginResponseContract::class, LoginResponse::class);
+        $this->app->singleton(PasswordConfirmedResponseContract::class, PasswordConfirmedResponse::class);
         $this->app->singleton(RegisterResponseContract::class, RegisterResponse::class);
         $this->app->singleton(TwoFactorLoginResponseContract::class, TwoFactorLoginResponse::class);
         $this->app->singleton(VerifyEmailResponseContract::class, VerifyEmailResponse::class);

--- a/app/Rules/UniqueTeamInvitation.php
+++ b/app/Rules/UniqueTeamInvitation.php
@@ -37,6 +37,7 @@ class UniqueTeamInvitation implements ValidationRule
         $hasPendingInvitation = TeamInvitation::where('team_id', $this->team->id)
             ->whereRaw('LOWER(email) = ?', [$email])
             ->whereNull('accepted_at')
+            ->whereNull('revoked_at')
             ->where(function ($query) {
                 $query->whereNull('expires_at')
                     ->orWhere('expires_at', '>', now());

--- a/app/Rules/ValidTeamInvitation.php
+++ b/app/Rules/ValidTeamInvitation.php
@@ -28,20 +28,8 @@ class ValidTeamInvitation implements ValidationRule
             return;
         }
 
-        if ($value->isAccepted()) {
-            $fail(__('This invitation has already been accepted.'));
-
-            return;
-        }
-
-        if ($value->isExpired()) {
-            $fail(__('This invitation has expired.'));
-
-            return;
-        }
-
-        if (strtolower($value->email) !== strtolower($this->user->email)) {
-            $fail(__('This invitation was sent to a different email address.'));
+        if (! $value->isPending() || ! $value->isFor($this->user)) {
+            $fail(__('This invitation is invalid or unavailable.'));
         }
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use App\Http\Middleware\EnforceAbsoluteSessionLifetime;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\ProtectSensitiveFortifyRoutes;
 use App\Http\Middleware\SetTeamUrlDefaults;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
@@ -21,6 +22,7 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->web(append: [
             EnforceAbsoluteSessionLifetime::class,
+            ProtectSensitiveFortifyRoutes::class,
             HandleAppearance::class,
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnforceAbsoluteSessionLifetime;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\SetTeamUrlDefaults;
@@ -19,6 +20,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
 
         $middleware->web(append: [
+            EnforceAbsoluteSessionLifetime::class,
             HandleAppearance::class,
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,

--- a/config/auth.php
+++ b/config/auth.php
@@ -96,7 +96,7 @@ return [
         'users' => [
             'provider' => 'users',
             'table' => env('AUTH_PASSWORD_RESET_TOKEN_TABLE', 'password_reset_tokens'),
-            'expire' => 60,
+            'expire' => 30,
             'throttle' => 60,
         ],
     ],
@@ -112,6 +112,10 @@ return [
     |
     */
 
-    'password_timeout' => env('AUTH_PASSWORD_TIMEOUT', 10800),
+    'password_timeout' => env('AUTH_PASSWORD_TIMEOUT', 900),
+
+    'mfa_timeout' => env('AUTH_MFA_TIMEOUT', 900),
+
+    'session_absolute_timeout' => env('AUTH_SESSION_ABSOLUTE_TIMEOUT', 43200),
 
 ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -116,6 +116,11 @@ return [
 
     'mfa_timeout' => env('AUTH_MFA_TIMEOUT', 900),
 
+    'mfa_required' => env(
+        'AUTH_MFA_REQUIRED',
+        in_array(env('APP_ENV'), ['staging', 'production'], true),
+    ),
+
     'session_absolute_timeout' => env('AUTH_SESSION_ABSOLUTE_TIMEOUT', 43200),
 
 ];

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -117,6 +117,7 @@ return [
     'limiters' => [
         'login' => 'login',
         'two-factor' => 'two-factor',
+        'verification' => 'verification',
     ],
 
     /*
@@ -150,7 +151,7 @@ return [
         Features::twoFactorAuthentication([
             'confirm' => true,
             'confirmPassword' => true,
-            // 'window' => 0
+            'window' => 0,
         ]),
     ],
 

--- a/database/factories/PlatformSecurityEventFactory.php
+++ b/database/factories/PlatformSecurityEventFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\PlatformSecurityEvent;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PlatformSecurityEvent>
+ */
+class PlatformSecurityEventFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'type' => fake()->randomElement(['other_browser_sessions_revoked']),
+            'actor_user_id' => User::factory(),
+            'subject_user_id' => User::factory(),
+            'metadata' => [],
+            'occurred_at' => now(),
+        ];
+    }
+}

--- a/database/factories/TeamInvitationFactory.php
+++ b/database/factories/TeamInvitationFactory.php
@@ -7,6 +7,7 @@ use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 
 /**
  * @extends Factory<TeamInvitation>
@@ -20,7 +21,10 @@ class TeamInvitationFactory extends Factory
      */
     public function definition(): array
     {
+        $token = Str::random(64);
+
         return [
+            'token_hash' => hash('sha256', $token),
             'team_id' => Team::factory(),
             'email' => fake()->unique()->safeEmail(),
             'role' => TeamRole::Member,
@@ -47,6 +51,20 @@ class TeamInvitationFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'expires_at' => now()->subDay(),
+        ]);
+    }
+
+    public function revoked(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'revoked_at' => now(),
+        ]);
+    }
+
+    public function forToken(string $token): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'token_hash' => hash('sha256', $token),
         ]);
     }
 

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -75,6 +75,7 @@ class UserFactory extends Factory
             'two_factor_secret' => encrypt('secret'),
             'two_factor_recovery_codes' => encrypt(json_encode(['recovery-code-1'])),
             'two_factor_confirmed_at' => now(),
+            'recovery_codes_acknowledged_at' => now(),
         ]);
     }
 }

--- a/database/migrations/2026_08_30_103959_secure_team_invitations_for_staff_access.php
+++ b/database/migrations/2026_08_30_103959_secure_team_invitations_for_staff_access.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('team_invitations', function (Blueprint $table) {
+            $table->string('token_hash', 64)->nullable()->unique()->after('id');
+            $table->timestamp('revoked_at')->nullable()->after('accepted_at');
+            $table->foreignId('revoked_by')->nullable()->after('revoked_at')->constrained('users')->nullOnDelete();
+        });
+
+        DB::table('team_invitations')
+            ->orderBy('id')
+            ->eachById(function (object $invitation): void {
+                DB::table('team_invitations')
+                    ->where('id', $invitation->id)
+                    ->update(['token_hash' => hash('sha256', $invitation->code)]);
+            });
+
+        Schema::table('team_invitations', function (Blueprint $table) {
+            $table->string('token_hash', 64)->nullable(false)->change();
+            $table->dropUnique(['code']);
+            $table->dropColumn('code');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('team_invitations', function (Blueprint $table) {
+            $table->string('code', 64)->nullable()->unique()->after('id');
+        });
+
+        DB::table('team_invitations')
+            ->orderBy('id')
+            ->eachById(function (object $invitation): void {
+                DB::table('team_invitations')
+                    ->where('id', $invitation->id)
+                    ->update(['code' => $invitation->token_hash]);
+            });
+
+        Schema::table('team_invitations', function (Blueprint $table) {
+            $table->string('code', 64)->nullable(false)->change();
+            $table->dropConstrainedForeignId('revoked_by');
+            $table->dropColumn(['token_hash', 'revoked_at']);
+        });
+    }
+};

--- a/database/migrations/2026_08_30_104000_add_staff_security_fields_to_users_table.php
+++ b/database/migrations/2026_08_30_104000_add_staff_security_fields_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->timestamp('recovery_codes_acknowledged_at')->nullable()->after('two_factor_confirmed_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('recovery_codes_acknowledged_at');
+        });
+    }
+};

--- a/database/migrations/2026_08_30_104001_create_platform_security_events_table.php
+++ b/database/migrations/2026_08_30_104001_create_platform_security_events_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('platform_security_events', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->string('type');
+            $table->foreignId('actor_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('subject_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->json('metadata');
+            $table->timestamp('occurred_at');
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['type', 'occurred_at']);
+            $table->index(['subject_user_id', 'occurred_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('platform_security_events');
+    }
+};

--- a/resources/js/components/cancel-invitation-modal.tsx
+++ b/resources/js/components/cancel-invitation-modal.tsx
@@ -33,7 +33,7 @@ export default function CancelInvitationModal({
             return;
         }
 
-        router.visit(destroyInvitation([team.slug, invitation.code]), {
+        router.visit(destroyInvitation([team.slug, invitation.id]), {
             onStart: () => setProcessing(true),
             onFinish: () => setProcessing(false),
             onSuccess: () => onOpenChange(false),

--- a/resources/js/components/pending-invitations-modal.tsx
+++ b/resources/js/components/pending-invitations-modal.tsx
@@ -22,19 +22,19 @@ export default function PendingInvitationsModal({
     open,
     onOpenChange,
 }: Props) {
-    const [processingCode, setProcessingCode] = useState<string | null>(null);
+    const [processingId, setProcessingId] = useState<number | null>(null);
 
     const acceptInvitation = (invitation: DashboardInvitation) => {
         router.visit(TeamInvitationController.accept(invitation), {
-            onStart: () => setProcessingCode(invitation.code),
-            onFinish: () => setProcessingCode(null),
+            onStart: () => setProcessingId(invitation.id),
+            onFinish: () => setProcessingId(null),
         });
     };
 
     const declineInvitation = (invitation: DashboardInvitation) => {
         router.visit(TeamInvitationController.decline(invitation), {
-            onStart: () => setProcessingCode(invitation.code),
-            onFinish: () => setProcessingCode(null),
+            onStart: () => setProcessingId(invitation.id),
+            onFinish: () => setProcessingId(null),
             onSuccess: () => {
                 if (invitations.length === 1) {
                     onOpenChange(false);
@@ -57,7 +57,7 @@ export default function PendingInvitationsModal({
                 <div className="grid gap-4">
                     {invitations.map((invitation) => (
                         <div
-                            key={invitation.code}
+                            key={invitation.id}
                             data-test="pending-invitation-row"
                             className="rounded-lg border p-4"
                         >
@@ -75,9 +75,7 @@ export default function PendingInvitationsModal({
                                 <Button
                                     variant="secondary"
                                     data-test="pending-invitation-decline"
-                                    disabled={
-                                        processingCode === invitation.code
-                                    }
+                                    disabled={processingId === invitation.id}
                                     onClick={() =>
                                         declineInvitation(invitation)
                                     }
@@ -87,9 +85,7 @@ export default function PendingInvitationsModal({
 
                                 <Button
                                     data-test="pending-invitation-accept"
-                                    disabled={
-                                        processingCode === invitation.code
-                                    }
+                                    disabled={processingId === invitation.id}
                                     onClick={() => acceptInvitation(invitation)}
                                 >
                                     Accept

--- a/resources/js/pages/auth/confirm-mfa.tsx
+++ b/resources/js/pages/auth/confirm-mfa.tsx
@@ -1,0 +1,45 @@
+import { Form, Head } from '@inertiajs/react';
+import MfaChallengeController from '@/actions/App/Http/Controllers/Auth/MfaChallengeController';
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Spinner } from '@/components/ui/spinner';
+
+export default function ConfirmMfa() {
+    return (
+        <>
+            <Head title="Confirm two-factor authentication" />
+
+            <Form {...MfaChallengeController.store.form()} resetOnSuccess>
+                {({ processing, errors }) => (
+                    <div className="space-y-6">
+                        <div className="grid gap-2">
+                            <Label htmlFor="code">Authentication code</Label>
+                            <Input
+                                id="code"
+                                name="code"
+                                inputMode="numeric"
+                                autoComplete="one-time-code"
+                                autoFocus
+                                required
+                            />
+                            <InputError message={errors.code} />
+                        </div>
+
+                        <Button className="w-full" disabled={processing}>
+                            {processing && <Spinner />}
+                            Confirm
+                        </Button>
+                    </div>
+                )}
+            </Form>
+        </>
+    );
+}
+
+ConfirmMfa.layout = {
+    title: 'Confirm two-factor authentication',
+    description:
+        'Enter a fresh code from your authenticator app to continue with this sensitive action.',
+};

--- a/resources/js/pages/auth/login.tsx
+++ b/resources/js/pages/auth/login.tsx
@@ -4,7 +4,6 @@ import PasswordInput from '@/components/password-input';
 import TeamInvitationAlert from '@/components/team-invitation-alert';
 import TextLink from '@/components/text-link';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Spinner } from '@/components/ui/spinner';
@@ -42,6 +41,13 @@ export default function Login({
             >
                 {({ processing, errors }) => (
                     <>
+                        {teamInvitation && (
+                            <input
+                                type="hidden"
+                                name="invitation"
+                                value={teamInvitation.code}
+                            />
+                        )}
                         <div className="grid gap-6">
                             <div className="grid gap-2">
                                 <Label htmlFor="email">Email address</Label>
@@ -82,15 +88,6 @@ export default function Login({
                                 <InputError message={errors.password} />
                             </div>
 
-                            <div className="flex items-center space-x-3">
-                                <Checkbox
-                                    id="remember"
-                                    name="remember"
-                                    tabIndex={3}
-                                />
-                                <Label htmlFor="remember">Remember me</Label>
-                            </div>
-
                             <Button
                                 type="submit"
                                 className="mt-4 w-full"
@@ -103,20 +100,22 @@ export default function Login({
                             </Button>
                         </div>
 
-                        <div className="text-muted-foreground text-center text-sm">
-                            Don't have an account?{' '}
-                            <TextLink
-                                href={register({
-                                    query: {
-                                        invitation: teamInvitation?.code,
-                                    },
-                                })}
-                                data-test="register-link"
-                                tabIndex={5}
-                            >
-                                Sign up
-                            </TextLink>
-                        </div>
+                        {teamInvitation && (
+                            <div className="text-muted-foreground text-center text-sm">
+                                Need an account?{' '}
+                                <TextLink
+                                    href={register({
+                                        query: {
+                                            invitation: teamInvitation.code,
+                                        },
+                                    })}
+                                    data-test="register-link"
+                                    tabIndex={5}
+                                >
+                                    Create one from this invitation
+                                </TextLink>
+                            </div>
+                        )}
                     </>
                 )}
             </Form>

--- a/resources/js/pages/auth/register.tsx
+++ b/resources/js/pages/auth/register.tsx
@@ -28,6 +28,11 @@ export default function Register({ passwordRules, teamInvitation }: Props) {
             >
                 {({ processing, errors }) => (
                     <>
+                        <input
+                            type="hidden"
+                            name="invitation"
+                            value={teamInvitation?.code ?? ''}
+                        />
                         {teamInvitation && (
                             <TeamInvitationAlert
                                 invitation={teamInvitation}
@@ -63,7 +68,8 @@ export default function Register({ passwordRules, teamInvitation }: Props) {
                                     tabIndex={2}
                                     autoComplete="email"
                                     name="email"
-                                    placeholder="email@example.com"
+                                    value={teamInvitation?.email ?? ''}
+                                    readOnly
                                 />
                                 <InputError message={errors.email} />
                             </div>
@@ -138,6 +144,6 @@ export default function Register({ passwordRules, teamInvitation }: Props) {
 }
 
 Register.layout = {
-    title: 'Create an account',
-    description: 'Enter your details below to create your account',
+    title: 'Accept your staff invitation',
+    description: 'Create the account bound to your invitation',
 };

--- a/resources/js/pages/settings/security.tsx
+++ b/resources/js/pages/settings/security.tsx
@@ -9,10 +9,15 @@ import { Label } from '@/components/ui/label';
 import { edit } from '@/routes/security';
 import type { Props as ManageTwoFactorProps } from '@/components/manage-two-factor';
 import ManageTwoFactor from '@/components/manage-two-factor';
+import { acknowledge } from '@/routes/security/recovery-codes';
+import { destroy as destroyOtherBrowserSessions } from '@/routes/security/other-browser-sessions';
 
 // oxfmt-ignore
 type Props = {
     passwordRules: string;
+    recoveryCodesAcknowledged?: boolean;
+    required?: 'mfa' | 'recovery-codes' | null;
+    otherBrowserSessionCount: number;
 } & ManageTwoFactorProps;
 
 export default function Security(props: Props) {
@@ -126,6 +131,64 @@ export default function Security(props: Props) {
                 requiresConfirmation={props.requiresConfirmation}
                 twoFactorEnabled={props.twoFactorEnabled}
             />
+
+            {props.twoFactorEnabled && !props.recoveryCodesAcknowledged && (
+                <div className="space-y-6 rounded-lg border p-6">
+                    <Heading
+                        variant="small"
+                        title="Save your recovery codes"
+                        description="Store the recovery codes above somewhere safe, then acknowledge that you can recover your account. Staff features remain locked until this is complete."
+                    />
+
+                    <Form {...acknowledge.form()}>
+                        {({ processing, errors }) => (
+                            <div className="space-y-4">
+                                <label className="flex items-start gap-3 text-sm">
+                                    <input
+                                        type="checkbox"
+                                        name="acknowledged"
+                                        value="1"
+                                        className="mt-1 size-4"
+                                        required
+                                    />
+                                    <span>
+                                        I have saved my recovery codes in a
+                                        secure location.
+                                    </span>
+                                </label>
+                                <InputError message={errors.acknowledged} />
+                                <Button disabled={processing}>
+                                    Acknowledge recovery codes
+                                </Button>
+                            </div>
+                        )}
+                    </Form>
+                </div>
+            )}
+
+            {props.recoveryCodesAcknowledged && (
+                <div className="space-y-6">
+                    <Heading
+                        variant="small"
+                        title="Browser sessions"
+                        description={`${props.otherBrowserSessionCount} other active browser ${props.otherBrowserSessionCount === 1 ? 'session' : 'sessions'} found`}
+                    />
+
+                    <Form {...destroyOtherBrowserSessions.form()}>
+                        {({ processing }) => (
+                            <Button
+                                variant="destructive"
+                                disabled={
+                                    processing ||
+                                    props.otherBrowserSessionCount === 0
+                                }
+                            >
+                                Revoke other browser sessions
+                            </Button>
+                        )}
+                    </Form>
+                </div>
+            )}
         </>
     );
 }

--- a/resources/js/pages/teams/edit.tsx
+++ b/resources/js/pages/teams/edit.tsx
@@ -273,7 +273,7 @@ export default function TeamEdit({
                         <div className="space-y-3">
                             {invitations.map((invitation) => (
                                 <div
-                                    key={invitation.code}
+                                    key={invitation.id}
                                     data-test="invitation-row"
                                     className="flex items-center justify-between rounded-lg border p-4"
                                 >

--- a/resources/js/types/teams.ts
+++ b/resources/js/types/teams.ts
@@ -20,7 +20,7 @@ export type TeamMember = {
 };
 
 export type TeamInvitation = {
-    code: string;
+    id: number;
     email: string;
     role: TeamRole;
     role_label: string;
@@ -29,11 +29,12 @@ export type TeamInvitation = {
 
 export type TeamInvitationContext = {
     code: string;
+    email: string;
     teamName: string;
 };
 
 export type DashboardInvitation = {
-    code: string;
+    id: number;
     inviterName: string;
     team: {
         name: string;

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -46,9 +46,9 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->middleware([EnsureStaffSecurityRequirements::class, EnsureRecentMfa::class, 'throttle:6,1'])
         ->name('user-password.update');
 
-    Route::middleware(EnsureStaffSecurityRequirements::class)->group(function () {
-        Route::inertia('settings/appearance', 'settings/appearance')->name('appearance.edit');
+    Route::inertia('settings/appearance', 'settings/appearance')->name('appearance.edit');
 
+    Route::middleware(EnsureStaffSecurityRequirements::class)->group(function () {
         Route::get('settings/teams', [TeamController::class, 'index'])->name('teams.index');
         Route::post('settings/teams', [TeamController::class, 'store'])->name('teams.store');
 

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -9,9 +9,9 @@ use App\Http\Controllers\Teams\TeamController;
 use App\Http\Controllers\Teams\TeamInvitationController;
 use App\Http\Controllers\Teams\TeamMemberController;
 use App\Http\Middleware\EnsureRecentMfa;
+use App\Http\Middleware\EnsureRecentPassword;
 use App\Http\Middleware\EnsureStaffSecurityRequirements;
 use App\Http\Middleware\EnsureTeamMembership;
-use Illuminate\Auth\Middleware\RequirePassword;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(['auth'])->group(function () {
@@ -22,14 +22,16 @@ Route::middleware(['auth'])->group(function () {
 });
 
 Route::middleware(['auth', 'verified'])->group(function () {
-    Route::delete('settings/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+    Route::delete('settings/profile', [ProfileController::class, 'destroy'])
+        ->middleware([EnsureStaffSecurityRequirements::class, EnsureRecentMfa::class])
+        ->name('profile.destroy');
 
     Route::get('settings/security', [SecurityController::class, 'edit'])
-        ->middleware(RequirePassword::class)
+        ->middleware(EnsureRecentPassword::class)
         ->name('security.edit');
 
     Route::post('settings/security/recovery-codes/acknowledge', RecoveryCodeAcknowledgementController::class)
-        ->middleware(RequirePassword::class)
+        ->middleware(EnsureRecentPassword::class)
         ->name('security.recovery-codes.acknowledge');
 
     Route::get('auth/mfa-confirmation', [MfaChallengeController::class, 'create'])
@@ -41,7 +43,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->name('mfa.confirm.store');
 
     Route::put('settings/password', [SecurityController::class, 'update'])
-        ->middleware('throttle:6,1')
+        ->middleware([EnsureStaffSecurityRequirements::class, EnsureRecentMfa::class, 'throttle:6,1'])
         ->name('user-password.update');
 
     Route::middleware(EnsureStaffSecurityRequirements::class)->group(function () {
@@ -51,21 +53,21 @@ Route::middleware(['auth', 'verified'])->group(function () {
         Route::post('settings/teams', [TeamController::class, 'store'])->name('teams.store');
 
         Route::delete('settings/security/other-browser-sessions', OtherBrowserSessionController::class)
-            ->middleware([RequirePassword::class, EnsureRecentMfa::class])
+            ->middleware([EnsureRecentPassword::class, EnsureRecentMfa::class])
             ->name('security.other-browser-sessions.destroy');
 
         Route::middleware(EnsureTeamMembership::class)->group(function () {
             Route::get('settings/teams/{team}', [TeamController::class, 'edit'])->name('teams.edit');
-            Route::patch('settings/teams/{team}', [TeamController::class, 'update'])->middleware([RequirePassword::class, EnsureRecentMfa::class])->name('teams.update');
-            Route::delete('settings/teams/{team}', [TeamController::class, 'destroy'])->middleware([RequirePassword::class, EnsureRecentMfa::class])->name('teams.destroy');
+            Route::patch('settings/teams/{team}', [TeamController::class, 'update'])->middleware([EnsureRecentPassword::class, EnsureRecentMfa::class])->name('teams.update');
+            Route::delete('settings/teams/{team}', [TeamController::class, 'destroy'])->middleware([EnsureRecentPassword::class, EnsureRecentMfa::class])->name('teams.destroy');
             Route::post('settings/teams/{team}/switch', [TeamController::class, 'switch'])->name('teams.switch');
             Route::delete('settings/teams/{team}/leave', [TeamController::class, 'leave'])->name('teams.leave');
 
-            Route::patch('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'update'])->middleware([RequirePassword::class, EnsureRecentMfa::class])->name('teams.members.update');
-            Route::delete('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy'])->middleware([RequirePassword::class, EnsureRecentMfa::class])->name('teams.members.destroy');
+            Route::patch('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'update'])->middleware([EnsureRecentPassword::class, EnsureRecentMfa::class])->name('teams.members.update');
+            Route::delete('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy'])->middleware([EnsureRecentPassword::class, EnsureRecentMfa::class])->name('teams.members.destroy');
 
-            Route::post('settings/teams/{team}/invitations', [TeamInvitationController::class, 'store'])->middleware([RequirePassword::class, EnsureRecentMfa::class])->name('teams.invitations.store');
-            Route::delete('settings/teams/{team}/invitations/{invitation}', [TeamInvitationController::class, 'destroy'])->middleware([RequirePassword::class, EnsureRecentMfa::class])->name('teams.invitations.destroy');
+            Route::post('settings/teams/{team}/invitations', [TeamInvitationController::class, 'store'])->middleware([EnsureRecentPassword::class, EnsureRecentMfa::class])->name('teams.invitations.store');
+            Route::delete('settings/teams/{team}/invitations/{invitation}', [TeamInvitationController::class, 'destroy'])->middleware([EnsureRecentPassword::class, EnsureRecentMfa::class])->name('teams.invitations.destroy');
         });
     });
 });

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -1,10 +1,15 @@
 <?php
 
+use App\Http\Controllers\Auth\MfaChallengeController;
+use App\Http\Controllers\Settings\OtherBrowserSessionController;
 use App\Http\Controllers\Settings\ProfileController;
+use App\Http\Controllers\Settings\RecoveryCodeAcknowledgementController;
 use App\Http\Controllers\Settings\SecurityController;
 use App\Http\Controllers\Teams\TeamController;
 use App\Http\Controllers\Teams\TeamInvitationController;
 use App\Http\Controllers\Teams\TeamMemberController;
+use App\Http\Middleware\EnsureRecentMfa;
+use App\Http\Middleware\EnsureStaffSecurityRequirements;
 use App\Http\Middleware\EnsureTeamMembership;
 use Illuminate\Auth\Middleware\RequirePassword;
 use Illuminate\Support\Facades\Route;
@@ -23,26 +28,44 @@ Route::middleware(['auth', 'verified'])->group(function () {
         ->middleware(RequirePassword::class)
         ->name('security.edit');
 
+    Route::post('settings/security/recovery-codes/acknowledge', RecoveryCodeAcknowledgementController::class)
+        ->middleware(RequirePassword::class)
+        ->name('security.recovery-codes.acknowledge');
+
+    Route::get('auth/mfa-confirmation', [MfaChallengeController::class, 'create'])
+        ->middleware(EnsureStaffSecurityRequirements::class)
+        ->name('mfa.confirm');
+
+    Route::post('auth/mfa-confirmation', [MfaChallengeController::class, 'store'])
+        ->middleware(['throttle:6,1', EnsureStaffSecurityRequirements::class])
+        ->name('mfa.confirm.store');
+
     Route::put('settings/password', [SecurityController::class, 'update'])
         ->middleware('throttle:6,1')
         ->name('user-password.update');
 
-    Route::inertia('settings/appearance', 'settings/appearance')->name('appearance.edit');
+    Route::middleware(EnsureStaffSecurityRequirements::class)->group(function () {
+        Route::inertia('settings/appearance', 'settings/appearance')->name('appearance.edit');
 
-    Route::get('settings/teams', [TeamController::class, 'index'])->name('teams.index');
-    Route::post('settings/teams', [TeamController::class, 'store'])->name('teams.store');
+        Route::get('settings/teams', [TeamController::class, 'index'])->name('teams.index');
+        Route::post('settings/teams', [TeamController::class, 'store'])->name('teams.store');
 
-    Route::middleware(EnsureTeamMembership::class)->group(function () {
-        Route::get('settings/teams/{team}', [TeamController::class, 'edit'])->name('teams.edit');
-        Route::patch('settings/teams/{team}', [TeamController::class, 'update'])->name('teams.update');
-        Route::delete('settings/teams/{team}', [TeamController::class, 'destroy'])->name('teams.destroy');
-        Route::post('settings/teams/{team}/switch', [TeamController::class, 'switch'])->name('teams.switch');
-        Route::delete('settings/teams/{team}/leave', [TeamController::class, 'leave'])->name('teams.leave');
+        Route::delete('settings/security/other-browser-sessions', OtherBrowserSessionController::class)
+            ->middleware([RequirePassword::class, EnsureRecentMfa::class])
+            ->name('security.other-browser-sessions.destroy');
 
-        Route::patch('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'update'])->name('teams.members.update');
-        Route::delete('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy'])->name('teams.members.destroy');
+        Route::middleware(EnsureTeamMembership::class)->group(function () {
+            Route::get('settings/teams/{team}', [TeamController::class, 'edit'])->name('teams.edit');
+            Route::patch('settings/teams/{team}', [TeamController::class, 'update'])->middleware([RequirePassword::class, EnsureRecentMfa::class])->name('teams.update');
+            Route::delete('settings/teams/{team}', [TeamController::class, 'destroy'])->middleware([RequirePassword::class, EnsureRecentMfa::class])->name('teams.destroy');
+            Route::post('settings/teams/{team}/switch', [TeamController::class, 'switch'])->name('teams.switch');
+            Route::delete('settings/teams/{team}/leave', [TeamController::class, 'leave'])->name('teams.leave');
 
-        Route::post('settings/teams/{team}/invitations', [TeamInvitationController::class, 'store'])->name('teams.invitations.store');
-        Route::delete('settings/teams/{team}/invitations/{invitation}', [TeamInvitationController::class, 'destroy'])->name('teams.invitations.destroy');
+            Route::patch('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'update'])->middleware([RequirePassword::class, EnsureRecentMfa::class])->name('teams.members.update');
+            Route::delete('settings/teams/{team}/members/{user}', [TeamMemberController::class, 'destroy'])->middleware([RequirePassword::class, EnsureRecentMfa::class])->name('teams.members.destroy');
+
+            Route::post('settings/teams/{team}/invitations', [TeamInvitationController::class, 'store'])->middleware([RequirePassword::class, EnsureRecentMfa::class])->name('teams.invitations.store');
+            Route::delete('settings/teams/{team}/invitations/{invitation}', [TeamInvitationController::class, 'destroy'])->middleware([RequirePassword::class, EnsureRecentMfa::class])->name('teams.invitations.destroy');
+        });
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Teams\TeamInvitationController;
+use App\Http\Middleware\EnsureStaffSecurityRequirements;
 use App\Http\Middleware\EnsureTeamMembership;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\Response;
@@ -21,12 +22,12 @@ Route::get('/source-and-licence/license', fn (): Response => response(
 ))->name('source-and-licence.license');
 
 Route::prefix('{current_team}')
-    ->middleware(['auth', 'verified', EnsureTeamMembership::class])
+    ->middleware(['auth', 'verified', EnsureStaffSecurityRequirements::class, EnsureTeamMembership::class])
     ->group(function () {
         Route::get('dashboard', DashboardController::class)->name('dashboard');
     });
 
-Route::middleware(['auth'])->group(function () {
+Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('invitations/{invitation}/accept', [TeamInvitationController::class, 'accept'])->name('invitations.accept');
     Route::delete('invitations/{invitation}', [TeamInvitationController::class, 'decline'])->name('invitations.decline');
 });

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -29,18 +29,19 @@ class AuthenticationTest extends TestCase
         $team = Team::factory()->create(['name' => 'Laravel Team']);
         $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
 
-        $invitation = TeamInvitation::factory()->create([
+        $token = 'login-invitation-token';
+        $invitation = TeamInvitation::factory()->forToken($token)->create([
             'team_id' => $team->id,
             'email' => 'invited@example.com',
             'invited_by' => $owner->id,
         ]);
 
-        $response = $this->get(route('login', ['invitation' => $invitation->code]));
+        $response = $this->get(route('login', ['invitation' => $token]));
 
         $response->assertOk();
         $response->assertInertia(fn (Assert $page) => $page
             ->component('auth/login')
-            ->where('teamInvitation.code', $invitation->code)
+            ->where('teamInvitation.code', $token)
             ->where('teamInvitation.teamName', 'Laravel Team'),
         );
     }
@@ -55,7 +56,7 @@ class AuthenticationTest extends TestCase
         ]);
 
         $this->assertAuthenticated();
-        $response->assertRedirect(route('dashboard'));
+        $response->assertRedirect(route('security.edit'));
     }
 
     public function test_users_with_two_factor_enabled_are_redirected_to_two_factor_challenge()

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -56,7 +56,7 @@ class AuthenticationTest extends TestCase
         ]);
 
         $this->assertAuthenticated();
-        $response->assertRedirect(route('security.edit'));
+        $response->assertRedirect(route('dashboard', $user->currentTeam->slug));
     }
 
     public function test_users_with_two_factor_enabled_are_redirected_to_two_factor_challenge()

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -39,7 +39,7 @@ class EmailVerificationTest extends TestCase
 
         Event::assertDispatched(Verified::class);
         $this->assertTrue($user->fresh()->hasVerifiedEmail());
-        $response->assertRedirect("/{$team->slug}/dashboard?verified=1");
+        $response->assertRedirect('/settings/security?verified=1');
     }
 
     public function test_email_is_not_verified_with_invalid_hash()
@@ -104,7 +104,7 @@ class EmailVerificationTest extends TestCase
         );
 
         $this->actingAs($user)->get($verificationUrl)
-            ->assertRedirect("/{$team->slug}/dashboard?verified=1");
+            ->assertRedirect('/settings/security?verified=1');
 
         Event::assertNotDispatched(Verified::class);
         $this->assertTrue($user->fresh()->hasVerifiedEmail());

--- a/tests/Feature/Auth/PasswordResetTest.php
+++ b/tests/Feature/Auth/PasswordResetTest.php
@@ -67,8 +67,8 @@ class PasswordResetTest extends TestCase
             $response = $this->post(route('password.update'), [
                 'token' => $notification->token,
                 'email' => $user->email,
-                'password' => 'password',
-                'password_confirmation' => 'password',
+                'password' => 'new-secure-password',
+                'password_confirmation' => 'new-secure-password',
             ]);
 
             $response
@@ -86,8 +86,8 @@ class PasswordResetTest extends TestCase
         $response = $this->post(route('password.update'), [
             'token' => 'invalid-token',
             'email' => $user->email,
-            'password' => 'newpassword123',
-            'password_confirmation' => 'newpassword123',
+            'password' => 'new-secure-password',
+            'password_confirmation' => 'new-secure-password',
         ]);
 
         $response->assertSessionHasErrors('email');

--- a/tests/Feature/Auth/RegistrationTest.php
+++ b/tests/Feature/Auth/RegistrationTest.php
@@ -16,11 +16,11 @@ class RegistrationTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_registration_screen_can_be_rendered()
+    public function test_public_registration_screen_is_unavailable()
     {
         $response = $this->get(route('register'));
 
-        $response->assertOk();
+        $response->assertNotFound();
     }
 
     public function test_registration_screen_includes_team_invitation_context()
@@ -29,50 +29,95 @@ class RegistrationTest extends TestCase
         $team = Team::factory()->create(['name' => 'Laravel Team']);
         $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
 
-        $invitation = TeamInvitation::factory()->create([
+        $token = 'registration-screen-invitation-token';
+        $invitation = TeamInvitation::factory()->forToken($token)->create([
             'team_id' => $team->id,
             'email' => 'invited@example.com',
             'invited_by' => $owner->id,
         ]);
 
-        $response = $this->get(route('register', ['invitation' => $invitation->code]));
+        $response = $this->get(route('register', ['invitation' => $token]));
 
         $response->assertOk();
         $response->assertInertia(fn (Assert $page) => $page
             ->component('auth/register')
-            ->where('teamInvitation.code', $invitation->code)
+            ->where('teamInvitation.code', $token)
+            ->where('teamInvitation.email', 'invited@example.com')
             ->where('teamInvitation.teamName', 'Laravel Team'),
         );
     }
 
     public function test_new_users_can_register()
     {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create();
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+        $token = 'new-user-registration-token';
+        TeamInvitation::factory()->forToken($token)->create([
+            'team_id' => $team->id,
+            'email' => 'test@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
         $response = $this->post(route('register.store'), [
             'name' => 'Test User',
             'email' => 'test@example.com',
-            'password' => 'password',
-            'password_confirmation' => 'password',
+            'password' => 'new-secure-password',
+            'password_confirmation' => 'new-secure-password',
+            'invitation' => $token,
         ]);
 
         $this->assertAuthenticated();
 
-        $user = User::where('email', 'test@example.com')->first();
-        $response->assertRedirect(route('dashboard'));
+        $response->assertRedirect(route('verification.notice'));
+        $this->assertDatabaseHas('users', ['email' => 'test@example.com']);
     }
 
     public function test_new_users_receive_an_email_verification_notification()
     {
         Notification::fake();
 
+        $owner = User::factory()->create();
+        $team = Team::factory()->create();
+        $token = 'notification-registration-token';
+        TeamInvitation::factory()->forToken($token)->create([
+            'team_id' => $team->id,
+            'email' => 'test@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
         $this->post(route('register.store'), [
             'name' => 'Test User',
             'email' => 'test@example.com',
-            'password' => 'password',
-            'password_confirmation' => 'password',
+            'password' => 'new-secure-password',
+            'password_confirmation' => 'new-secure-password',
+            'invitation' => $token,
         ]);
 
         $user = User::where('email', 'test@example.com')->firstOrFail();
 
         Notification::assertSentTo($user, VerifyEmail::class);
+    }
+
+    public function test_registration_rejects_an_email_other_than_the_invited_address(): void
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create();
+        $token = 'email-bound-registration-token';
+        TeamInvitation::factory()->forToken($token)->create([
+            'team_id' => $team->id,
+            'email' => 'invited@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
+        $this->post(route('register.store'), [
+            'name' => 'Wrong User',
+            'email' => 'other@example.com',
+            'password' => 'new-secure-password',
+            'password_confirmation' => 'new-secure-password',
+            'invitation' => $token,
+        ])->assertSessionHasErrors('invitation');
+
+        $this->assertDatabaseMissing('users', ['email' => 'other@example.com']);
     }
 }

--- a/tests/Feature/Auth/StaffAccessSecurityTest.php
+++ b/tests/Feature/Auth/StaffAccessSecurityTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Actions\Security\RecordPlatformSecurityEvent;
-use App\Actions\Security\RevokeOtherBrowserSessions;
 use App\Actions\Teams\IssueTeamInvitation;
 use App\Enums\TeamRole;
 use App\Models\Team;
@@ -9,6 +8,7 @@ use App\Models\User;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
+use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
 
 test('issued invitations store only a hash and expire after 72 hours', function () {
     $inviter = User::factory()->create();
@@ -83,7 +83,7 @@ test('staff can acknowledge recovery codes only after enabling MFA', function ()
             'acknowledged' => true,
         ])
         ->assertRedirect(route('security.edit'))
-        ->assertSessionHas('auth.mfa_confirmed_at');
+        ->assertSessionMissing('auth.mfa_confirmed_at');
 
     expect($user->refresh()->hasAcknowledgedRecoveryCodes())->toBeTrue();
 });
@@ -121,38 +121,164 @@ test('remember me is ignored for staff logins', function () {
     $response->assertCookieMissing(Auth::guard('web')->getRecallerName());
 });
 
+test('password changes require a recent MFA confirmation', function () {
+    $user = User::factory()->withTwoFactor()->create();
+
+    $response = $this
+        ->actingAs($user)
+        ->put(route('user-password.update'), [
+            'current_password' => 'password',
+            'password' => 'replacement-password',
+            'password_confirmation' => 'replacement-password',
+        ]);
+
+    $response->assertRedirect(route('mfa.confirm'));
+    expect(Auth::guard('web')->validate([
+        'email' => $user->email,
+        'password' => 'password',
+    ]))->toBeTrue();
+});
+
+test('profile deletion requires a recent MFA confirmation', function () {
+    $user = User::factory()->withTwoFactor()->create();
+
+    $response = $this
+        ->actingAs($user)
+        ->delete(route('profile.destroy'), ['password' => 'password']);
+
+    $response->assertRedirect(route('mfa.confirm'));
+    $this->assertModelExists($user);
+});
+
+test('disabling MFA requires a recent MFA confirmation', function () {
+    $user = User::factory()->withTwoFactor()->create();
+
+    $response = $this
+        ->actingAs($user)
+        ->withSession(['auth.password_confirmed_at' => time()])
+        ->delete(route('two-factor.disable'));
+
+    $response->assertRedirect(route('mfa.confirm'));
+    expect($user->refresh()->hasEnabledTwoFactorAuthentication())->toBeTrue();
+});
+
+test('regenerating recovery codes requires a recent MFA confirmation', function () {
+    $user = User::factory()->withTwoFactor()->create();
+    $recoveryCodes = $user->two_factor_recovery_codes;
+
+    $response = $this
+        ->actingAs($user)
+        ->withSession(['auth.password_confirmed_at' => time()])
+        ->post(route('two-factor.regenerate-recovery-codes'));
+
+    $response->assertRedirect(route('mfa.confirm'));
+    expect($user->refresh()->two_factor_recovery_codes)->toBe($recoveryCodes);
+});
+
+test('password confirmation after a mutation returns to its safe form page', function () {
+    Notification::fake();
+
+    $owner = User::factory()->withTwoFactor()->create();
+    $team = Team::factory()->create();
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $formUrl = route('teams.edit', $team);
+
+    $this->actingAs($owner)
+        ->from($formUrl)
+        ->post(route('teams.invitations.store', $team), [
+            'email' => 'invited@example.com',
+            'role' => TeamRole::Member->value,
+        ])
+        ->assertRedirect(route('password.confirm'));
+
+    $this->post(route('password.confirm.store'), ['password' => 'password'])
+        ->assertRedirect($formUrl);
+    Notification::assertNothingSent();
+});
+
+test('MFA confirmation after a mutation returns to its safe form page', function () {
+    Notification::fake();
+
+    $owner = User::factory()->withTwoFactor()->create();
+    $team = Team::factory()->create();
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+    $formUrl = route('teams.edit', $team);
+
+    $this->actingAs($owner)
+        ->withSession(['auth.password_confirmed_at' => time()])
+        ->from($formUrl)
+        ->post(route('teams.invitations.store', $team), [
+            'email' => 'invited@example.com',
+            'role' => TeamRole::Member->value,
+        ])
+        ->assertRedirect(route('mfa.confirm'));
+
+    $this->mock(TwoFactorAuthenticationProvider::class, function ($mock): void {
+        $mock->shouldReceive('verify')
+            ->once()
+            ->with('secret', '123456')
+            ->andReturnTrue();
+    });
+
+    $this->post(route('mfa.confirm.store'), ['code' => '123456'])
+        ->assertRedirect($formUrl);
+    Notification::assertNothingSent();
+});
+
 test('revoking other database sessions is audited', function () {
     config(['session.driver' => 'database']);
 
-    $user = User::factory()->create();
+    $user = User::factory()->withTwoFactor()->create();
     DB::table('sessions')->insert([
-        [
-            'id' => 'current-session',
-            'user_id' => $user->id,
-            'payload' => '',
-            'last_activity' => time(),
-        ],
-        [
-            'id' => 'other-session',
-            'user_id' => $user->id,
-            'payload' => '',
-            'last_activity' => time(),
-        ],
+        'id' => 'other-session',
+        'user_id' => $user->id,
+        'payload' => '',
+        'last_activity' => time(),
     ]);
 
-    $revoked = app(RevokeOtherBrowserSessions::class)->handle($user, 'current-session');
-    app(RecordPlatformSecurityEvent::class)->handle(
-        'other_browser_sessions_revoked',
-        $user,
-        $user,
-        ['revoked_count' => $revoked],
-    );
+    $response = $this
+        ->actingAs($user)
+        ->withSession([
+            'auth.password_confirmed_at' => time(),
+            'auth.mfa_confirmed_at' => time(),
+        ])
+        ->delete(route('security.other-browser-sessions.destroy'));
 
-    expect($revoked)->toBe(1);
+    $response->assertRedirect();
     $this->assertDatabaseMissing('sessions', ['id' => 'other-session']);
     $this->assertDatabaseHas('platform_security_events', [
         'type' => 'other_browser_sessions_revoked',
         'actor_user_id' => $user->id,
+        'subject_user_id' => $user->id,
+    ]);
+});
+
+test('session revocation rolls back when its audit cannot be recorded', function () {
+    config(['session.driver' => 'database']);
+
+    $user = User::factory()->withTwoFactor()->create();
+    DB::table('sessions')->insert([
+        'id' => 'other-session',
+        'user_id' => $user->id,
+        'payload' => '',
+        'last_activity' => time(),
+    ]);
+    $this->mock(RecordPlatformSecurityEvent::class, function ($mock): void {
+        $mock->shouldReceive('handle')->once()->andThrow(new RuntimeException('Audit unavailable.'));
+    });
+
+    $response = $this
+        ->actingAs($user)
+        ->withSession([
+            'auth.password_confirmed_at' => time(),
+            'auth.mfa_confirmed_at' => time(),
+        ])
+        ->delete(route('security.other-browser-sessions.destroy'));
+
+    $response->assertServerError();
+    $this->assertDatabaseHas('sessions', ['id' => 'other-session']);
+    $this->assertDatabaseMissing('platform_security_events', [
+        'type' => 'other_browser_sessions_revoked',
         'subject_user_id' => $user->id,
     ]);
 });

--- a/tests/Feature/Auth/StaffAccessSecurityTest.php
+++ b/tests/Feature/Auth/StaffAccessSecurityTest.php
@@ -10,6 +10,10 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Notification;
 use Laravel\Fortify\Contracts\TwoFactorAuthenticationProvider;
 
+beforeEach(function () {
+    config(['auth.mfa_required' => true]);
+});
+
 test('issued invitations store only a hash and expire after 72 hours', function () {
     $inviter = User::factory()->create();
     $team = Team::factory()->create();
@@ -44,6 +48,17 @@ test('operational routes require confirmed MFA and recovery-code acknowledgement
     $this->actingAs($user->refresh())
         ->get(route('dashboard'))
         ->assertRedirect(route('security.edit', ['required' => 'recovery-codes']));
+});
+
+test('login redirects to required MFA onboarding when enforcement is enabled', function () {
+    $user = User::factory()->create();
+
+    $response = $this->post(route('login.store'), [
+        'email' => $user->email,
+        'password' => 'password',
+    ]);
+
+    $response->assertRedirect(route('security.edit', ['required' => 'mfa']));
 });
 
 test('staff who completed security onboarding can use operational routes', function () {

--- a/tests/Feature/Auth/StaffAccessSecurityTest.php
+++ b/tests/Feature/Auth/StaffAccessSecurityTest.php
@@ -1,0 +1,158 @@
+<?php
+
+use App\Actions\Security\RecordPlatformSecurityEvent;
+use App\Actions\Security\RevokeOtherBrowserSessions;
+use App\Actions\Teams\IssueTeamInvitation;
+use App\Enums\TeamRole;
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Notification;
+
+test('issued invitations store only a hash and expire after 72 hours', function () {
+    $inviter = User::factory()->create();
+    $team = Team::factory()->create();
+
+    $issued = app(IssueTeamInvitation::class)->handle(
+        $team,
+        $inviter,
+        'INVITED@example.com',
+        TeamRole::Member,
+    );
+
+    expect($issued->invitation->token_hash)
+        ->toBe(hash('sha256', $issued->token))
+        ->not->toBe($issued->token)
+        ->and($issued->invitation->email)->toBe('invited@example.com')
+        ->and(abs($issued->invitation->expires_at->diffInHours(now())))->toBeGreaterThan(71.9);
+});
+
+test('operational routes require confirmed MFA and recovery-code acknowledgement', function () {
+    $user = User::factory()->create();
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertRedirect(route('security.edit', ['required' => 'mfa']));
+
+    $user->forceFill([
+        'two_factor_secret' => encrypt('secret'),
+        'two_factor_recovery_codes' => encrypt(json_encode(['recovery-code'])),
+        'two_factor_confirmed_at' => now(),
+    ])->save();
+
+    $this->actingAs($user->refresh())
+        ->get(route('dashboard'))
+        ->assertRedirect(route('security.edit', ['required' => 'recovery-codes']));
+});
+
+test('staff who completed security onboarding can use operational routes', function () {
+    $user = User::factory()->withTwoFactor()->create();
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk();
+});
+
+test('sensitive team actions require a recent MFA confirmation', function () {
+    Notification::fake();
+
+    $owner = User::factory()->withTwoFactor()->create();
+    $team = Team::factory()->create();
+    $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+
+    $this->actingAs($owner)
+        ->withSession(['auth.password_confirmed_at' => time()])
+        ->post(route('teams.invitations.store', $team), [
+            'email' => 'invited@example.com',
+            'role' => TeamRole::Member->value,
+        ])
+        ->assertRedirect(route('mfa.confirm'));
+
+    Notification::assertNothingSent();
+});
+
+test('staff can acknowledge recovery codes only after enabling MFA', function () {
+    $user = User::factory()->withTwoFactor()->create([
+        'recovery_codes_acknowledged_at' => null,
+    ]);
+
+    $this->actingAs($user)
+        ->withSession(['auth.password_confirmed_at' => time()])
+        ->post(route('security.recovery-codes.acknowledge'), [
+            'acknowledged' => true,
+        ])
+        ->assertRedirect(route('security.edit'))
+        ->assertSessionHas('auth.mfa_confirmed_at');
+
+    expect($user->refresh()->hasAcknowledgedRecoveryCodes())->toBeTrue();
+});
+
+test('regenerating recovery codes requires a new acknowledgement', function () {
+    $user = User::factory()->withTwoFactor()->create();
+
+    $user->forceFill([
+        'two_factor_recovery_codes' => encrypt(json_encode(['replacement-code'])),
+    ])->save();
+
+    expect($user->refresh()->hasAcknowledgedRecoveryCodes())->toBeFalse();
+});
+
+test('absolute session lifetime signs staff out', function () {
+    $user = User::factory()->withTwoFactor()->create();
+
+    $this->actingAs($user)
+        ->withSession(['auth.session_started_at' => now()->subHours(13)->getTimestamp()])
+        ->get(route('dashboard'))
+        ->assertRedirect(route('login'));
+
+    $this->assertGuest();
+});
+
+test('remember me is ignored for staff logins', function () {
+    $user = User::factory()->create();
+
+    $response = $this->post(route('login.store'), [
+        'email' => $user->email,
+        'password' => 'password',
+        'remember' => true,
+    ]);
+
+    $response->assertCookieMissing(Auth::guard('web')->getRecallerName());
+});
+
+test('revoking other database sessions is audited', function () {
+    config(['session.driver' => 'database']);
+
+    $user = User::factory()->create();
+    DB::table('sessions')->insert([
+        [
+            'id' => 'current-session',
+            'user_id' => $user->id,
+            'payload' => '',
+            'last_activity' => time(),
+        ],
+        [
+            'id' => 'other-session',
+            'user_id' => $user->id,
+            'payload' => '',
+            'last_activity' => time(),
+        ],
+    ]);
+
+    $revoked = app(RevokeOtherBrowserSessions::class)->handle($user, 'current-session');
+    app(RecordPlatformSecurityEvent::class)->handle(
+        'other_browser_sessions_revoked',
+        $user,
+        $user,
+        ['revoked_count' => $revoked],
+    );
+
+    expect($revoked)->toBe(1);
+    $this->assertDatabaseMissing('sessions', ['id' => 'other-session']);
+    $this->assertDatabaseHas('platform_security_events', [
+        'type' => 'other_browser_sessions_revoked',
+        'actor_user_id' => $user->id,
+        'subject_user_id' => $user->id,
+    ]);
+});

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Enums\TeamRole;
 use App\Http\Middleware\EnsureStaffSecurityRequirements;
+use App\Http\Middleware\ProtectSensitiveFortifyRoutes;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
@@ -19,7 +20,10 @@ class DashboardTest extends TestCase
     {
         parent::setUp();
 
-        $this->withoutMiddleware(EnsureStaffSecurityRequirements::class);
+        $this->withoutMiddleware([
+            EnsureStaffSecurityRequirements::class,
+            ProtectSensitiveFortifyRoutes::class,
+        ]);
     }
 
     public function test_guests_are_redirected_to_the_login_page()

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -3,8 +3,6 @@
 namespace Tests\Feature;
 
 use App\Enums\TeamRole;
-use App\Http\Middleware\EnsureStaffSecurityRequirements;
-use App\Http\Middleware\ProtectSensitiveFortifyRoutes;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
@@ -15,16 +13,6 @@ use Tests\TestCase;
 class DashboardTest extends TestCase
 {
     use RefreshDatabase;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        $this->withoutMiddleware([
-            EnsureStaffSecurityRequirements::class,
-            ProtectSensitiveFortifyRoutes::class,
-        ]);
-    }
 
     public function test_guests_are_redirected_to_the_login_page()
     {

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Enums\TeamRole;
+use App\Http\Middleware\EnsureStaffSecurityRequirements;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
@@ -13,6 +14,13 @@ use Tests\TestCase;
 class DashboardTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware(EnsureStaffSecurityRequirements::class);
+    }
 
     public function test_guests_are_redirected_to_the_login_page()
     {
@@ -69,7 +77,7 @@ class DashboardTest extends TestCase
         $response->assertInertia(fn (Assert $page) => $page
             ->component('dashboard')
             ->has('pendingInvitations', 1)
-            ->where('pendingInvitations.0.code', $invitation->code)
+            ->where('pendingInvitations.0.id', $invitation->id)
             ->where('pendingInvitations.0.inviterName', 'Taylor Otwell')
             ->where('pendingInvitations.0.team.name', 'Laravel Team')
             ->where('pendingInvitations.0.team.slug', $team->slug)

--- a/tests/Feature/Settings/ProfileUpdateTest.php
+++ b/tests/Feature/Settings/ProfileUpdateTest.php
@@ -98,10 +98,11 @@ class ProfileUpdateTest extends TestCase
 
     public function test_user_can_delete_their_account()
     {
-        $user = User::factory()->create();
+        $user = User::factory()->withTwoFactor()->create();
 
         $response = $this
             ->actingAs($user)
+            ->withSession(['auth.mfa_confirmed_at' => time()])
             ->delete(route('profile.destroy'), [
                 'password' => 'password',
             ]);
@@ -116,10 +117,11 @@ class ProfileUpdateTest extends TestCase
 
     public function test_correct_password_must_be_provided_to_delete_account()
     {
-        $user = User::factory()->create();
+        $user = User::factory()->withTwoFactor()->create();
 
         $response = $this
             ->actingAs($user)
+            ->withSession(['auth.mfa_confirmed_at' => time()])
             ->from(route('profile.edit'))
             ->delete(route('profile.destroy'), [
                 'password' => 'wrong-password',

--- a/tests/Feature/Settings/SecurityTest.php
+++ b/tests/Feature/Settings/SecurityTest.php
@@ -72,10 +72,11 @@ class SecurityTest extends TestCase
 
     public function test_password_can_be_updated()
     {
-        $user = User::factory()->create();
+        $user = User::factory()->withTwoFactor()->create();
 
         $response = $this
             ->actingAs($user)
+            ->withSession(['auth.mfa_confirmed_at' => time()])
             ->from(route('security.edit'))
             ->put(route('user-password.update'), [
                 'current_password' => 'password',
@@ -92,10 +93,11 @@ class SecurityTest extends TestCase
 
     public function test_correct_password_must_be_provided_to_update_password()
     {
-        $user = User::factory()->create();
+        $user = User::factory()->withTwoFactor()->create();
 
         $response = $this
             ->actingAs($user)
+            ->withSession(['auth.mfa_confirmed_at' => time()])
             ->from(route('security.edit'))
             ->put(route('user-password.update'), [
                 'current_password' => 'wrong-password',

--- a/tests/Feature/Settings/SecurityTest.php
+++ b/tests/Feature/Settings/SecurityTest.php
@@ -79,15 +79,15 @@ class SecurityTest extends TestCase
             ->from(route('security.edit'))
             ->put(route('user-password.update'), [
                 'current_password' => 'password',
-                'password' => 'new-password',
-                'password_confirmation' => 'new-password',
+                'password' => 'new-secure-password',
+                'password_confirmation' => 'new-secure-password',
             ]);
 
         $response
             ->assertSessionHasNoErrors()
             ->assertRedirect(route('security.edit'));
 
-        $this->assertTrue(Hash::check('new-password', $user->refresh()->password));
+        $this->assertTrue(Hash::check('new-secure-password', $user->refresh()->password));
     }
 
     public function test_correct_password_must_be_provided_to_update_password()
@@ -99,8 +99,8 @@ class SecurityTest extends TestCase
             ->from(route('security.edit'))
             ->put(route('user-password.update'), [
                 'current_password' => 'wrong-password',
-                'password' => 'new-password',
-                'password_confirmation' => 'new-password',
+                'password' => 'new-secure-password',
+                'password_confirmation' => 'new-secure-password',
             ]);
 
         $response

--- a/tests/Feature/Settings/SecurityTest.php
+++ b/tests/Feature/Settings/SecurityTest.php
@@ -70,6 +70,18 @@ class SecurityTest extends TestCase
             );
     }
 
+    public function test_appearance_page_does_not_require_mfa()
+    {
+        config(['auth.mfa_required' => true]);
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('appearance.edit'))
+            ->assertInertia(fn (Assert $page) => $page
+                ->component('settings/appearance'),
+            );
+    }
+
     public function test_password_can_be_updated()
     {
         $user = User::factory()->withTwoFactor()->create();

--- a/tests/Feature/Teams/TeamInvitationTest.php
+++ b/tests/Feature/Teams/TeamInvitationTest.php
@@ -4,14 +4,16 @@ namespace Tests\Feature\Teams;
 
 use App\Enums\TeamRole;
 use App\Http\Middleware\EnsureRecentMfa;
+use App\Http\Middleware\EnsureRecentPassword;
 use App\Http\Middleware\EnsureStaffSecurityRequirements;
+use App\Http\Middleware\ProtectSensitiveFortifyRoutes;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
 use App\Notifications\Teams\TeamInvitation as TeamInvitationNotification;
-use Illuminate\Auth\Middleware\RequirePassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
+use Inertia\Testing\AssertableInertia as Assert;
 use Tests\TestCase;
 
 class TeamInvitationTest extends TestCase
@@ -25,7 +27,8 @@ class TeamInvitationTest extends TestCase
         $this->withoutMiddleware([
             EnsureStaffSecurityRequirements::class,
             EnsureRecentMfa::class,
-            RequirePassword::class,
+            EnsureRecentPassword::class,
+            ProtectSensitiveFortifyRoutes::class,
         ]);
     }
 
@@ -186,6 +189,51 @@ class TeamInvitationTest extends TestCase
             ]);
 
         $response->assertSessionHasErrors('email');
+    }
+
+    public function test_revoked_invitations_can_be_reissued()
+    {
+        Notification::fake();
+
+        $owner = User::factory()->create();
+        $team = Team::factory()->create();
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+        TeamInvitation::factory()->revoked()->create([
+            'team_id' => $team->id,
+            'email' => 'invited@example.com',
+            'invited_by' => $owner->id,
+        ]);
+
+        $response = $this
+            ->actingAs($owner)
+            ->post(route('teams.invitations.store', $team), [
+                'email' => 'invited@example.com',
+                'role' => TeamRole::Member->value,
+            ]);
+
+        $response->assertRedirect(route('teams.edit', $team));
+        $this->assertDatabaseCount('team_invitations', 2);
+        Notification::assertCount(1);
+    }
+
+    public function test_revoked_invitations_are_not_shown_as_pending()
+    {
+        $owner = User::factory()->create();
+        $team = Team::factory()->create();
+        $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
+        TeamInvitation::factory()->revoked()->create([
+            'team_id' => $team->id,
+            'invited_by' => $owner->id,
+        ]);
+
+        $response = $this
+            ->actingAs($owner)
+            ->get(route('teams.edit', $team));
+
+        $response->assertInertia(fn (Assert $page) => $page
+            ->component('teams/edit')
+            ->has('invitations', 0),
+        );
     }
 
     public function test_team_invitations_cannot_be_created_by_members()

--- a/tests/Feature/Teams/TeamInvitationTest.php
+++ b/tests/Feature/Teams/TeamInvitationTest.php
@@ -3,10 +3,13 @@
 namespace Tests\Feature\Teams;
 
 use App\Enums\TeamRole;
+use App\Http\Middleware\EnsureRecentMfa;
+use App\Http\Middleware\EnsureStaffSecurityRequirements;
 use App\Models\Team;
 use App\Models\TeamInvitation;
 use App\Models\User;
 use App\Notifications\Teams\TeamInvitation as TeamInvitationNotification;
+use Illuminate\Auth\Middleware\RequirePassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
@@ -14,6 +17,17 @@ use Tests\TestCase;
 class TeamInvitationTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware([
+            EnsureStaffSecurityRequirements::class,
+            EnsureRecentMfa::class,
+            RequirePassword::class,
+        ]);
+    }
 
     public function test_team_invitations_can_be_created()
     {
@@ -48,35 +62,37 @@ class TeamInvitationTest extends TestCase
 
         $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
 
-        $invitation = TeamInvitation::factory()->create([
+        $token = 'existing-user-invitation-token';
+        $invitation = TeamInvitation::factory()->forToken($token)->create([
             'team_id' => $team->id,
             'email' => $invitedUser->email,
             'invited_by' => $owner->id,
         ]);
 
-        $mail = (new TeamInvitationNotification($invitation))->toMail($invitedUser);
+        $mail = (new TeamInvitationNotification($invitation, $token, true))->toMail($invitedUser);
 
-        $this->assertSame(route('login', ['invitation' => $invitation->code]), $mail->actionUrl);
+        $this->assertSame(route('login', ['invitation' => $token]), $mail->actionUrl);
         $this->assertStringContainsString('dashboard', implode(' ', $mail->introLines));
     }
 
-    public function test_invitation_email_for_unknown_users_uses_login_route()
+    public function test_invitation_email_for_unknown_users_uses_registration_route()
     {
         $owner = User::factory()->create();
         $team = Team::factory()->create();
 
         $team->members()->attach($owner, ['role' => TeamRole::Owner->value]);
 
-        $invitation = TeamInvitation::factory()->create([
+        $token = 'new-user-invitation-token';
+        $invitation = TeamInvitation::factory()->forToken($token)->create([
             'team_id' => $team->id,
             'email' => 'unknown@example.com',
             'invited_by' => $owner->id,
         ]);
 
-        $mail = (new TeamInvitationNotification($invitation))->toMail((object) []);
+        $mail = (new TeamInvitationNotification($invitation, $token, false))->toMail((object) []);
 
-        $this->assertSame(route('login', ['invitation' => $invitation->code]), $mail->actionUrl);
-        $this->assertStringContainsString('log in', strtolower(implode(' ', $mail->introLines)));
+        $this->assertSame(route('register', ['invitation' => $token]), $mail->actionUrl);
+        $this->assertStringContainsString('create', strtolower(implode(' ', $mail->introLines)));
     }
 
     public function test_team_invitations_can_be_created_by_admins()
@@ -209,9 +225,11 @@ class TeamInvitationTest extends TestCase
 
         $response->assertRedirect(route('teams.edit', $team));
 
-        $this->assertDatabaseMissing('team_invitations', [
+        $this->assertDatabaseHas('team_invitations', [
             'id' => $invitation->id,
+            'revoked_by' => $owner->id,
         ]);
+        $this->assertNotNull($invitation->fresh()->revoked_at);
     }
 
     public function test_team_invitations_can_be_accepted()
@@ -260,9 +278,11 @@ class TeamInvitationTest extends TestCase
 
         $response->assertRedirect(route('dashboard'));
 
-        $this->assertDatabaseMissing('team_invitations', [
+        $this->assertDatabaseHas('team_invitations', [
             'id' => $invitation->id,
+            'revoked_by' => $invitedUser->id,
         ]);
+        $this->assertNotNull($invitation->fresh()->revoked_at);
     }
 
     public function test_team_invitations_cannot_be_declined_by_uninvited_user()

--- a/tests/Feature/Teams/TeamMemberTest.php
+++ b/tests/Feature/Teams/TeamMemberTest.php
@@ -3,14 +3,28 @@
 namespace Tests\Feature\Teams;
 
 use App\Enums\TeamRole;
+use App\Http\Middleware\EnsureRecentMfa;
+use App\Http\Middleware\EnsureStaffSecurityRequirements;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Auth\Middleware\RequirePassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class TeamMemberTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware([
+            EnsureStaffSecurityRequirements::class,
+            EnsureRecentMfa::class,
+            RequirePassword::class,
+        ]);
+    }
 
     public function test_team_member_roles_can_be_updated_by_owners()
     {

--- a/tests/Feature/Teams/TeamMemberTest.php
+++ b/tests/Feature/Teams/TeamMemberTest.php
@@ -4,10 +4,11 @@ namespace Tests\Feature\Teams;
 
 use App\Enums\TeamRole;
 use App\Http\Middleware\EnsureRecentMfa;
+use App\Http\Middleware\EnsureRecentPassword;
 use App\Http\Middleware\EnsureStaffSecurityRequirements;
+use App\Http\Middleware\ProtectSensitiveFortifyRoutes;
 use App\Models\Team;
 use App\Models\User;
-use Illuminate\Auth\Middleware\RequirePassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -22,7 +23,8 @@ class TeamMemberTest extends TestCase
         $this->withoutMiddleware([
             EnsureStaffSecurityRequirements::class,
             EnsureRecentMfa::class,
-            RequirePassword::class,
+            EnsureRecentPassword::class,
+            ProtectSensitiveFortifyRoutes::class,
         ]);
     }
 

--- a/tests/Feature/Teams/TeamTest.php
+++ b/tests/Feature/Teams/TeamTest.php
@@ -4,10 +4,11 @@ namespace Tests\Feature\Teams;
 
 use App\Enums\TeamRole;
 use App\Http\Middleware\EnsureRecentMfa;
+use App\Http\Middleware\EnsureRecentPassword;
 use App\Http\Middleware\EnsureStaffSecurityRequirements;
+use App\Http\Middleware\ProtectSensitiveFortifyRoutes;
 use App\Models\Team;
 use App\Models\User;
-use Illuminate\Auth\Middleware\RequirePassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
 use Tests\TestCase;
@@ -23,7 +24,8 @@ class TeamTest extends TestCase
         $this->withoutMiddleware([
             EnsureStaffSecurityRequirements::class,
             EnsureRecentMfa::class,
-            RequirePassword::class,
+            EnsureRecentPassword::class,
+            ProtectSensitiveFortifyRoutes::class,
         ]);
     }
 

--- a/tests/Feature/Teams/TeamTest.php
+++ b/tests/Feature/Teams/TeamTest.php
@@ -3,8 +3,11 @@
 namespace Tests\Feature\Teams;
 
 use App\Enums\TeamRole;
+use App\Http\Middleware\EnsureRecentMfa;
+use App\Http\Middleware\EnsureStaffSecurityRequirements;
 use App\Models\Team;
 use App\Models\User;
+use Illuminate\Auth\Middleware\RequirePassword;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Inertia\Testing\AssertableInertia as Assert;
 use Tests\TestCase;
@@ -12,6 +15,17 @@ use Tests\TestCase;
 class TeamTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware([
+            EnsureStaffSecurityRequirements::class,
+            EnsureRecentMfa::class,
+            RequirePassword::class,
+        ]);
+    }
 
     public function test_the_teams_index_page_can_be_rendered()
     {


### PR DESCRIPTION
Closes #2

## Summary
- make staff registration invitation-only with hashed, email-bound, revocable 72-hour tokens
- require verified email, confirmed TOTP, and recovery-code acknowledgement before operational access
- add recent-MFA step-up checks, absolute session expiry, non-persistent logins, and audited other-session revocation
- add onboarding and MFA confirmation UI plus focused security coverage

## Verification
- `php artisan test --compact` (107 passed)
- `npm run check`
- `npm run types:check`
- `npm run test`
- `npm run build`
- `npm run licenses:check`
- `composer validate --strict`