### PR TITLE
Enforce Organisation lifecycle, ownership, and Access Holds

### DIFF
--- a/app/Actions/Organisations/AcceptOrganisationOwnershipTransfer.php
+++ b/app/Actions/Organisations/AcceptOrganisationOwnershipTransfer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Actions\Organisations;
+
+use App\Enums\OrganisationLifecycleEventType;
+use App\Enums\OrganisationOwnershipTransferStatus;
+use App\Models\Membership;
+use App\Models\Organisation;
+use App\Models\OrganisationOwnershipTransfer;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class AcceptOrganisationOwnershipTransfer
+{
+    public function __construct(
+        private InvalidateOrganisationAccess $invalidateOrganisationAccess,
+        private RecordOrganisationLifecycleEvent $recordOrganisationLifecycleEvent,
+    ) {}
+
+    public function handle(OrganisationOwnershipTransfer $transfer, User $nominee): OrganisationOwnershipTransfer
+    {
+        return DB::transaction(function () use ($transfer, $nominee): OrganisationOwnershipTransfer {
+            $organisation = Organisation::lockForUpdate()->findOrFail($transfer->organisation_id);
+            $transfer = $organisation->ownershipTransfers()->lockForUpdate()->findOrFail($transfer->id);
+
+            if ($transfer->nominee_user_id !== $nominee->id || ! $transfer->isPending()) {
+                throw ValidationException::withMessages(['transfer' => __('This ownership transfer is invalid or unavailable.')]);
+            }
+
+            $nominatorMembership = Membership::where('organisation_id', $organisation->id)
+                ->where('user_id', $transfer->nominated_by_user_id)
+                ->lockForUpdate()
+                ->first();
+            $nomineeMembership = Membership::where('organisation_id', $organisation->id)
+                ->where('user_id', $nominee->id)
+                ->lockForUpdate()
+                ->first();
+
+            if (! $nominatorMembership?->is_owner || $nomineeMembership === null) {
+                throw ValidationException::withMessages(['transfer' => __('This ownership transfer is no longer valid.')]);
+            }
+
+            $nomineeMembership->update(['is_owner' => true]);
+            $nominatorMembership->update(['is_owner' => false]);
+            $transfer->update([
+                'status' => OrganisationOwnershipTransferStatus::Accepted,
+                'accepted_at' => now(),
+            ]);
+
+            $this->invalidateOrganisationAccess->handle($organisation);
+            $this->recordOrganisationLifecycleEvent->handle(
+                $organisation,
+                OrganisationLifecycleEventType::OwnershipTransferAccepted,
+                $nominee,
+                metadata: [
+                    'transfer_id' => $transfer->id,
+                    'previous_owner_user_id' => $transfer->nominated_by_user_id,
+                    'new_owner_user_id' => $nominee->id,
+                ],
+            );
+
+            return $transfer;
+        });
+    }
+}

--- a/app/Actions/Organisations/ChangeOrganisationSlug.php
+++ b/app/Actions/Organisations/ChangeOrganisationSlug.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Actions\Organisations;
+
+use App\Enums\OrganisationLifecycleEventType;
+use App\Models\Organisation;
+use App\Models\OrganisationSlug;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class ChangeOrganisationSlug
+{
+    public function __construct(
+        private InvalidateOrganisationAccess $invalidateOrganisationAccess,
+        private RecordOrganisationLifecycleEvent $recordOrganisationLifecycleEvent,
+    ) {}
+
+    public function handle(Organisation $organisation, string $slug, User $actor): Organisation
+    {
+        $slug = Str::slug($slug);
+
+        if ($slug === '') {
+            throw ValidationException::withMessages(['slug' => __('The slug must contain at least one letter or number.')]);
+        }
+
+        return Cache::lock("organisation-slug:{$slug}", 10)->block(5, function () use ($organisation, $slug, $actor): Organisation {
+            return DB::transaction(function () use ($organisation, $slug, $actor): Organisation {
+                $organisation = Organisation::lockForUpdate()->findOrFail($organisation->id);
+
+                if ($organisation->slug === $slug) {
+                    return $organisation;
+                }
+
+                if (Organisation::where('slug', $slug)->whereKeyNot($organisation->id)->exists()) {
+                    throw ValidationException::withMessages(['slug' => __('This organisation slug is unavailable.')]);
+                }
+
+                $previousUse = OrganisationSlug::where('slug', $slug)->lockForUpdate()->first();
+
+                if ($previousUse?->quarantined_until?->isFuture()) {
+                    throw ValidationException::withMessages(['slug' => __('This organisation slug is quarantined.')]);
+                }
+
+                $previousUse?->delete();
+                $oldSlug = $organisation->slug;
+                $redirectUntil = now()->addDays((int) config('organisation_lifecycle.slug_redirect_days'));
+
+                $organisation->previousSlugs()->create([
+                    'slug' => $oldSlug,
+                    'redirect_until' => $redirectUntil,
+                    'quarantined_until' => $redirectUntil->copy()->addDays((int) config('organisation_lifecycle.slug_quarantine_days')),
+                ]);
+                $organisation->update(['slug' => $slug]);
+
+                $this->invalidateOrganisationAccess->handle($organisation);
+                $this->recordOrganisationLifecycleEvent->handle(
+                    $organisation,
+                    OrganisationLifecycleEventType::SlugChanged,
+                    $actor,
+                    metadata: ['from' => $oldSlug, 'to' => $slug, 'redirect_until' => $redirectUntil->toISOString()],
+                );
+
+                return $organisation;
+            });
+        });
+    }
+}

--- a/app/Actions/Organisations/InvalidateOrganisationAccess.php
+++ b/app/Actions/Organisations/InvalidateOrganisationAccess.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Actions\Organisations;
+
+use App\Models\Organisation;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+
+class InvalidateOrganisationAccess
+{
+    public function handle(Organisation $organisation): void
+    {
+        Organisation::whereKey($organisation->id)->update([
+            'access_version' => DB::raw('access_version + 1'),
+            'signed_links_invalidated_at' => now(),
+        ]);
+        $organisation->refresh();
+
+        Cache::forget("organisation:{$organisation->id}:access");
+    }
+}

--- a/app/Actions/Organisations/NominateOrganisationOwnershipTransfer.php
+++ b/app/Actions/Organisations/NominateOrganisationOwnershipTransfer.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Actions\Organisations;
+
+use App\Enums\OrganisationLifecycleEventType;
+use App\Enums\OrganisationOwnershipTransferStatus;
+use App\Models\Organisation;
+use App\Models\OrganisationOwnershipTransfer;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class NominateOrganisationOwnershipTransfer
+{
+    public function __construct(private RecordOrganisationLifecycleEvent $recordOrganisationLifecycleEvent) {}
+
+    public function handle(Organisation $organisation, User $owner, User $nominee): OrganisationOwnershipTransfer
+    {
+        return DB::transaction(function () use ($organisation, $owner, $nominee): OrganisationOwnershipTransfer {
+            $organisation = Organisation::lockForUpdate()->findOrFail($organisation->id);
+
+            if (! $owner->ownsOrganisation($organisation) || ! $nominee->belongsToOrganisation($organisation) || $nominee->ownsOrganisation($organisation)) {
+                throw ValidationException::withMessages([
+                    'nominee_user_id' => __('Ownership can only be transferred by an Owner to a non-owner member.'),
+                ]);
+            }
+
+            $organisation->ownershipTransfers()
+                ->where('status', OrganisationOwnershipTransferStatus::Pending)
+                ->where('expires_at', '<=', now())
+                ->update(['status' => OrganisationOwnershipTransferStatus::Expired]);
+
+            if ($organisation->ownershipTransfers()->where('status', OrganisationOwnershipTransferStatus::Pending)->exists()) {
+                throw ValidationException::withMessages([
+                    'nominee_user_id' => __('This organisation already has a pending ownership transfer.'),
+                ]);
+            }
+
+            $transfer = $organisation->ownershipTransfers()->create([
+                'nominated_by_user_id' => $owner->id,
+                'nominee_user_id' => $nominee->id,
+                'status' => OrganisationOwnershipTransferStatus::Pending,
+                'expires_at' => now()->addHours((int) config('organisation_lifecycle.ownership_transfer_hours')),
+            ]);
+
+            $this->recordOrganisationLifecycleEvent->handle(
+                $organisation,
+                OrganisationLifecycleEventType::OwnershipTransferNominated,
+                $owner,
+                metadata: ['transfer_id' => $transfer->id, 'nominee_user_id' => $nominee->id],
+            );
+
+            return $transfer;
+        });
+    }
+}

--- a/app/Actions/Organisations/PlaceOrganisationAccessHold.php
+++ b/app/Actions/Organisations/PlaceOrganisationAccessHold.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Actions\Organisations;
+
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Enums\OrganisationLifecycleEventType;
+use App\Models\Organisation;
+use App\Models\OrganisationAccessHold;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+
+class PlaceOrganisationAccessHold
+{
+    public function __construct(
+        private InvalidateOrganisationAccess $invalidateOrganisationAccess,
+        private RecordOrganisationLifecycleEvent $recordOrganisationLifecycleEvent,
+    ) {}
+
+    public function handle(
+        Organisation $organisation,
+        string $issuer,
+        string $reason,
+        OrganisationAccessScope $scope,
+        OrganisationAccessLevel $accessLevel,
+        Carbon $reviewAt,
+        ?Carbon $expiresAt = null,
+        ?User $issuerUser = null,
+        ?string $incidentUuid = null,
+    ): OrganisationAccessHold {
+        if ($accessLevel === OrganisationAccessLevel::Full || $reviewAt->isPast() || $expiresAt?->isPast()) {
+            throw new InvalidArgumentException('Access holds must restrict access and use future review and expiry times.');
+        }
+
+        return DB::transaction(function () use ($organisation, $issuer, $reason, $scope, $accessLevel, $reviewAt, $expiresAt, $issuerUser, $incidentUuid): OrganisationAccessHold {
+            $hold = $organisation->accessHolds()->create([
+                'issuer_user_id' => $issuerUser?->id,
+                'issuer' => $issuer,
+                'reason' => $reason,
+                'scope' => $scope,
+                'access_level' => $accessLevel,
+                'incident_uuid' => $incidentUuid,
+                'starts_at' => now(),
+                'review_at' => $reviewAt,
+                'expires_at' => $expiresAt,
+            ]);
+
+            $this->invalidateOrganisationAccess->handle($organisation);
+            $this->recordOrganisationLifecycleEvent->handle(
+                $organisation,
+                OrganisationLifecycleEventType::AccessHoldPlaced,
+                $issuerUser,
+                metadata: [
+                    'access_hold_id' => $hold->id,
+                    'issuer' => $issuer,
+                    'reason' => $reason,
+                    'scope' => $scope->value,
+                    'access_level' => $accessLevel->value,
+                    'incident_uuid' => $incidentUuid,
+                    'review_at' => $reviewAt->toISOString(),
+                    'expires_at' => $expiresAt?->toISOString(),
+                ],
+            );
+
+            return $hold;
+        });
+    }
+}

--- a/app/Actions/Organisations/RecordOrganisationLifecycleEvent.php
+++ b/app/Actions/Organisations/RecordOrganisationLifecycleEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Actions\Organisations;
+
+use App\Enums\OrganisationLifecycleEventType;
+use App\Enums\OrganisationStatus;
+use App\Models\Organisation;
+use App\Models\OrganisationLifecycleEvent;
+use App\Models\User;
+
+class RecordOrganisationLifecycleEvent
+{
+    /** @param array<string, mixed> $metadata */
+    public function handle(
+        Organisation $organisation,
+        OrganisationLifecycleEventType $type,
+        ?User $actor = null,
+        ?OrganisationStatus $fromStatus = null,
+        ?OrganisationStatus $toStatus = null,
+        array $metadata = [],
+    ): OrganisationLifecycleEvent {
+        return $organisation->lifecycleEvents()->create([
+            'actor_user_id' => $actor?->id,
+            'type' => $type,
+            'from_status' => $fromStatus,
+            'to_status' => $toStatus,
+            'metadata' => $metadata,
+            'occurred_at' => now(),
+        ]);
+    }
+}

--- a/app/Actions/Organisations/ReleaseOrganisationAccessHold.php
+++ b/app/Actions/Organisations/ReleaseOrganisationAccessHold.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Actions\Organisations;
+
+use App\Enums\OrganisationLifecycleEventType;
+use App\Models\OrganisationAccessHold;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class ReleaseOrganisationAccessHold
+{
+    public function __construct(
+        private InvalidateOrganisationAccess $invalidateOrganisationAccess,
+        private RecordOrganisationLifecycleEvent $recordOrganisationLifecycleEvent,
+    ) {}
+
+    public function handle(OrganisationAccessHold $hold, string $releasedBy, string $reason, ?User $releasedByUser = null): OrganisationAccessHold
+    {
+        return DB::transaction(function () use ($hold, $releasedBy, $reason, $releasedByUser): OrganisationAccessHold {
+            $hold = OrganisationAccessHold::lockForUpdate()->findOrFail($hold->id);
+
+            if ($hold->released_at !== null) {
+                return $hold;
+            }
+
+            $hold->update([
+                'released_at' => now(),
+                'released_by_user_id' => $releasedByUser?->id,
+                'released_by' => $releasedBy,
+                'release_reason' => $reason,
+            ]);
+
+            $organisation = $hold->organisation;
+            $this->invalidateOrganisationAccess->handle($organisation);
+            $this->recordOrganisationLifecycleEvent->handle(
+                $organisation,
+                OrganisationLifecycleEventType::AccessHoldReleased,
+                $releasedByUser,
+                metadata: [
+                    'access_hold_id' => $hold->id,
+                    'released_by' => $releasedBy,
+                    'reason' => $reason,
+                ],
+            );
+
+            return $hold;
+        });
+    }
+}

--- a/app/Actions/Organisations/ResolveOrganisationAccess.php
+++ b/app/Actions/Organisations/ResolveOrganisationAccess.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Actions\Organisations;
+
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Enums\OrganisationRole;
+use App\Enums\OrganisationStatus;
+use App\Models\Organisation;
+use App\Models\User;
+
+class ResolveOrganisationAccess
+{
+    public function handle(Organisation $organisation, OrganisationAccessScope $scope): OrganisationAccessLevel
+    {
+        $access = $organisation->status->accessFor($scope);
+        $now = now();
+
+        $holds = $organisation->accessHolds()
+            ->whereNull('released_at')
+            ->where('starts_at', '<=', $now)
+            ->where(fn ($query) => $query->whereNull('expires_at')->orWhere('expires_at', '>', $now))
+            ->whereIn('scope', [OrganisationAccessScope::All->value, $scope->value])
+            ->get();
+
+        foreach ($holds as $hold) {
+            if ($hold->access_level->rank() > $access->rank()) {
+                $access = $hold->access_level;
+            }
+        }
+
+        return $access;
+    }
+
+    public function allowsStaffCapability(Organisation $organisation, ?User $user, string $capability): bool
+    {
+        $access = $this->handle($organisation, OrganisationAccessScope::Staff);
+        $isAdministrator = $user?->ownsOrganisation($organisation)
+            || $user?->organisationRole($organisation) === OrganisationRole::OrganisationAdministrator;
+
+        return match ($capability) {
+            'full' => $access === OrganisationAccessLevel::Full,
+            'administration' => $access === OrganisationAccessLevel::Full
+                || ($organisation->status === OrganisationStatus::Pending
+                    && $access === OrganisationAccessLevel::RecoveryOnly
+                    && $isAdministrator),
+            'recovery' => $access->isAtMost(OrganisationAccessLevel::ReadOnly)
+                || ($access === OrganisationAccessLevel::RecoveryOnly && $isAdministrator),
+            'membership' => $access->isAtMost(OrganisationAccessLevel::RecoveryOnly),
+            default => $access->isAtMost(OrganisationAccessLevel::ReadOnly),
+        };
+    }
+}

--- a/app/Actions/Organisations/TransitionOrganisationStatus.php
+++ b/app/Actions/Organisations/TransitionOrganisationStatus.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Actions\Organisations;
+
+use App\Enums\OrganisationLifecycleEventType;
+use App\Enums\OrganisationStatus;
+use App\Models\Organisation;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+class TransitionOrganisationStatus
+{
+    public function __construct(
+        private InvalidateOrganisationAccess $invalidateOrganisationAccess,
+        private RecordOrganisationLifecycleEvent $recordOrganisationLifecycleEvent,
+    ) {}
+
+    public function handle(Organisation $organisation, OrganisationStatus $toStatus, ?User $actor = null): Organisation
+    {
+        return DB::transaction(function () use ($organisation, $toStatus, $actor): Organisation {
+            $organisation = Organisation::withTrashed()->lockForUpdate()->findOrFail($organisation->id);
+            $fromStatus = $organisation->status;
+
+            if (! in_array($toStatus, $fromStatus->allowedTransitions(), true)) {
+                throw ValidationException::withMessages([
+                    'status' => __('The organisation cannot move from :from to :to.', [
+                        'from' => $fromStatus->value,
+                        'to' => $toStatus->value,
+                    ]),
+                ]);
+            }
+
+            if ($toStatus === OrganisationStatus::Deleted && $organisation->deletion_scheduled_for?->isFuture() !== false) {
+                throw ValidationException::withMessages([
+                    'status' => __('The organisation is still within its deletion recovery period.'),
+                ]);
+            }
+
+            if ($toStatus === OrganisationStatus::Active && $organisation->accessHolds()
+                ->whereNull('released_at')
+                ->where('starts_at', '<=', now())
+                ->where(fn ($query) => $query->whereNull('expires_at')->orWhere('expires_at', '>', now()))
+                ->exists()) {
+                throw ValidationException::withMessages([
+                    'status' => __('Active Access Holds must be released before the organisation can be reactivated.'),
+                ]);
+            }
+
+            $attributes = [
+                'status' => $toStatus,
+                'status_changed_at' => now(),
+            ];
+
+            if ($toStatus === OrganisationStatus::ScheduledForDeletion) {
+                $attributes['deletion_scheduled_for'] = now()->addDays((int) config('organisation_lifecycle.deletion_recovery_days'));
+            } elseif ($fromStatus === OrganisationStatus::ScheduledForDeletion) {
+                $attributes['deletion_scheduled_for'] = null;
+            }
+
+            if ($toStatus === OrganisationStatus::Deleted) {
+                $organisation->previousSlugs()->create([
+                    'slug' => $organisation->slug,
+                    'redirect_until' => now(),
+                    'quarantined_until' => now()->addDays((int) config('organisation_lifecycle.slug_quarantine_days')),
+                ]);
+                $attributes['slug'] = 'deleted-'.$organisation->id.'-'.Str::lower((string) Str::ulid());
+            }
+
+            $organisation->update($attributes);
+            $this->invalidateOrganisationAccess->handle($organisation);
+            $this->recordOrganisationLifecycleEvent->handle(
+                $organisation,
+                OrganisationLifecycleEventType::StatusChanged,
+                $actor,
+                $fromStatus,
+                $toStatus,
+                ['deletion_scheduled_for' => $organisation->deletion_scheduled_for?->toISOString()],
+            );
+
+            if (in_array($toStatus, [OrganisationStatus::ScheduledForDeletion, OrganisationStatus::Deleted], true)) {
+                User::where('current_organisation_id', $organisation->id)
+                    ->each(function (User $user) use ($organisation): void {
+                        $user->update([
+                            'current_organisation_id' => $user->fallbackOrganisation($organisation)?->id,
+                        ]);
+                    });
+            }
+
+            if ($toStatus === OrganisationStatus::Deleted) {
+                $organisation->delete();
+            }
+
+            return $organisation;
+        });
+    }
+}

--- a/app/Concerns/GeneratesUniqueOrganisationSlugs.php
+++ b/app/Concerns/GeneratesUniqueOrganisationSlugs.php
@@ -3,6 +3,7 @@
 namespace App\Concerns;
 
 use App\Models\Organisation;
+use App\Models\OrganisationSlug;
 use Illuminate\Support\Str;
 
 trait GeneratesUniqueOrganisationSlugs
@@ -24,7 +25,15 @@ trait GeneratesUniqueOrganisationSlugs
             $query->where('id', '!=', $excludeId);
         }
 
-        $existingSlugs = $query->pluck('slug');
+        $existingSlugs = $query->pluck('slug')
+            ->merge(OrganisationSlug::query()
+                ->where('quarantined_until', '>', now())
+                ->where(function ($query) use ($defaultSlug) {
+                    $query->where('slug', $defaultSlug)
+                        ->orWhere('slug', 'like', $defaultSlug.'-%');
+                })
+                ->pluck('slug'))
+            ->unique();
 
         $maxSuffix = $existingSlugs
             ->map(function (string $slug) use ($defaultSlug): ?int {

--- a/app/Concerns/HasOrganisations.php
+++ b/app/Concerns/HasOrganisations.php
@@ -6,6 +6,7 @@ use App\Data\OrganisationPermissions;
 use App\Data\UserOrganisation;
 use App\Enums\OrganisationPermission;
 use App\Enums\OrganisationRole;
+use App\Enums\OrganisationStatus;
 use App\Models\Membership;
 use App\Models\Organisation;
 use App\Models\Program;
@@ -194,12 +195,18 @@ trait HasOrganisations
     {
         return new OrganisationPermissions(
             canUpdateOrganisation: $this->hasOrganisationPermission($organisation, OrganisationPermission::UpdateOrganisation),
-            canDeleteOrganisation: $this->hasOrganisationPermission($organisation, OrganisationPermission::DeleteOrganisation),
+            canDeleteOrganisation: in_array($organisation->status, [OrganisationStatus::Pending, OrganisationStatus::Archived], true)
+                && $this->hasOrganisationPermission($organisation, OrganisationPermission::DeleteOrganisation),
             canAddMember: $this->hasOrganisationPermission($organisation, OrganisationPermission::AddMember),
             canUpdateMember: $this->hasOrganisationPermission($organisation, OrganisationPermission::UpdateMember),
             canRemoveMember: $this->hasOrganisationPermission($organisation, OrganisationPermission::RemoveMember),
             canCreateInvitation: $this->hasOrganisationPermission($organisation, OrganisationPermission::CreateInvitation),
             canCancelInvitation: $this->hasOrganisationPermission($organisation, OrganisationPermission::CancelInvitation),
+            canTransitionOrganisation: $this->ownsOrganisation($organisation),
+            canChangeOrganisationSlug: $this->ownsOrganisation($organisation)
+                && in_array($organisation->status, [OrganisationStatus::Pending, OrganisationStatus::Active], true),
+            canTransferOwnership: $this->ownsOrganisation($organisation)
+                && in_array($organisation->status, [OrganisationStatus::Pending, OrganisationStatus::Active], true),
         );
     }
 

--- a/app/Console/Commands/PurgeScheduledOrganisations.php
+++ b/app/Console/Commands/PurgeScheduledOrganisations.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Organisations\TransitionOrganisationStatus;
+use App\Enums\OrganisationStatus;
+use App\Models\Organisation;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+#[Signature('organisations:purge-scheduled')]
+#[Description('Soft-delete Organisations whose recovery period has ended')]
+class PurgeScheduledOrganisations extends Command
+{
+    /**
+     * Execute the console command.
+     */
+    public function handle(TransitionOrganisationStatus $transitionOrganisationStatus): int
+    {
+        Organisation::query()
+            ->where('status', OrganisationStatus::ScheduledForDeletion)
+            ->where('deletion_scheduled_for', '<=', now())
+            ->chunkById(100, function ($organisations) use ($transitionOrganisationStatus): void {
+                foreach ($organisations as $organisation) {
+                    $transitionOrganisationStatus->handle($organisation, OrganisationStatus::Deleted);
+                }
+            });
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Data/OrganisationPermissions.php
+++ b/app/Data/OrganisationPermissions.php
@@ -12,7 +12,26 @@ readonly class OrganisationPermissions
         public bool $canRemoveMember,
         public bool $canCreateInvitation,
         public bool $canCancelInvitation,
+        public bool $canTransitionOrganisation,
+        public bool $canChangeOrganisationSlug,
+        public bool $canTransferOwnership,
     ) {
         //
+    }
+
+    public function constrainedByAccess(bool $canAdminister, bool $canRecover): self
+    {
+        return new self(
+            canUpdateOrganisation: $canAdminister && $this->canUpdateOrganisation,
+            canDeleteOrganisation: $canRecover && $this->canDeleteOrganisation,
+            canAddMember: $canAdminister && $this->canAddMember,
+            canUpdateMember: $canAdminister && $this->canUpdateMember,
+            canRemoveMember: $canAdminister && $this->canRemoveMember,
+            canCreateInvitation: $canAdminister && $this->canCreateInvitation,
+            canCancelInvitation: $canAdminister && $this->canCancelInvitation,
+            canTransitionOrganisation: $canRecover && $this->canTransitionOrganisation,
+            canChangeOrganisationSlug: $canAdminister && $this->canChangeOrganisationSlug,
+            canTransferOwnership: $canAdminister && $this->canTransferOwnership,
+        );
     }
 }

--- a/app/Enums/OrganisationAccessLevel.php
+++ b/app/Enums/OrganisationAccessLevel.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Enums;
+
+enum OrganisationAccessLevel: string
+{
+    case Full = 'full';
+    case ReadOnly = 'read_only';
+    case RecoveryOnly = 'recovery_only';
+    case Denied = 'denied';
+
+    public function rank(): int
+    {
+        return match ($this) {
+            self::Full => 0,
+            self::ReadOnly => 1,
+            self::RecoveryOnly => 2,
+            self::Denied => 3,
+        };
+    }
+
+    public function isAtMost(self $maximum): bool
+    {
+        return $this->rank() <= $maximum->rank();
+    }
+}

--- a/app/Enums/OrganisationAccessScope.php
+++ b/app/Enums/OrganisationAccessScope.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Enums;
+
+enum OrganisationAccessScope: string
+{
+    case All = 'all';
+    case Staff = 'staff';
+    case Public = 'public';
+    case Jobs = 'jobs';
+    case Forms = 'forms';
+    case Cache = 'cache';
+    case Search = 'search';
+    case SignedLinks = 'signed_links';
+}

--- a/app/Enums/OrganisationLifecycleEventType.php
+++ b/app/Enums/OrganisationLifecycleEventType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums;
+
+enum OrganisationLifecycleEventType: string
+{
+    case StatusChanged = 'status_changed';
+    case AccessHoldPlaced = 'access_hold_placed';
+    case AccessHoldReleased = 'access_hold_released';
+    case OwnershipTransferNominated = 'ownership_transfer_nominated';
+    case OwnershipTransferAccepted = 'ownership_transfer_accepted';
+    case OwnershipTransferCancelled = 'ownership_transfer_cancelled';
+    case SlugChanged = 'slug_changed';
+}

--- a/app/Enums/OrganisationOwnershipTransferStatus.php
+++ b/app/Enums/OrganisationOwnershipTransferStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum OrganisationOwnershipTransferStatus: string
+{
+    case Pending = 'pending';
+    case Accepted = 'accepted';
+    case Cancelled = 'cancelled';
+    case Expired = 'expired';
+}

--- a/app/Enums/OrganisationStatus.php
+++ b/app/Enums/OrganisationStatus.php
@@ -8,4 +8,30 @@ enum OrganisationStatus: string
     case Active = 'active';
     case Archived = 'archived';
     case ScheduledForDeletion = 'scheduled_for_deletion';
+    case Deleted = 'deleted';
+
+    /**
+     * @return array<self>
+     */
+    public function allowedTransitions(): array
+    {
+        return match ($this) {
+            self::Pending => [self::Active, self::ScheduledForDeletion],
+            self::Active => [self::Archived],
+            self::Archived => [self::Active, self::ScheduledForDeletion],
+            self::ScheduledForDeletion => [self::Archived, self::Deleted],
+            self::Deleted => [],
+        };
+    }
+
+    public function accessFor(OrganisationAccessScope $scope): OrganisationAccessLevel
+    {
+        return match ($this) {
+            self::Active => OrganisationAccessLevel::Full,
+            self::Pending, self::Archived, self::ScheduledForDeletion => $scope === OrganisationAccessScope::Staff
+                ? OrganisationAccessLevel::RecoveryOnly
+                : OrganisationAccessLevel::Denied,
+            self::Deleted => OrganisationAccessLevel::Denied,
+        };
+    }
 }

--- a/app/Http/Controllers/Organisations/OrganisationController.php
+++ b/app/Http/Controllers/Organisations/OrganisationController.php
@@ -3,13 +3,16 @@
 namespace App\Http\Controllers\Organisations;
 
 use App\Actions\Organisations\CreateOrganisation;
+use App\Actions\Organisations\ResolveOrganisationAccess;
+use App\Actions\Organisations\TransitionOrganisationStatus;
+use App\Enums\OrganisationOwnershipTransferStatus;
 use App\Enums\OrganisationRole;
+use App\Enums\OrganisationStatus;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Organisations\DeleteOrganisationRequest;
 use App\Http\Requests\Organisations\SaveOrganisationRequest;
 use App\Models\Membership;
 use App\Models\Organisation;
-use App\Models\User;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -46,9 +49,27 @@ class OrganisationController extends Controller
     /**
      * Show the organisation edit page.
      */
-    public function edit(Request $request, Organisation $organisation): Response
-    {
+    public function edit(
+        Request $request,
+        Organisation $organisation,
+        ResolveOrganisationAccess $resolveOrganisationAccess,
+    ): Response {
         $user = $request->user();
+        $permissions = $user->toOrganisationPermissions($organisation)->constrainedByAccess(
+            canAdminister: $resolveOrganisationAccess->allowsStaffCapability($organisation, $user, 'administration'),
+            canRecover: $resolveOrganisationAccess->allowsStaffCapability($organisation, $user, 'recovery'),
+        );
+        $memberships = $organisation->memberships()
+            ->with(['user', 'programs'])
+            ->get();
+        $pendingOwnershipTransfer = $organisation->ownershipTransfers()
+            ->with(['nominatedBy', 'nominee'])
+            ->where('status', OrganisationOwnershipTransferStatus::Pending)
+            ->where('expires_at', '>', now())
+            ->where(fn ($query) => $query
+                ->where('nominated_by_user_id', $user->id)
+                ->orWhere('nominee_user_id', $user->id))
+            ->first();
 
         return Inertia::render('organisations/edit', [
             'organisation' => [
@@ -57,9 +78,7 @@ class OrganisationController extends Controller
                 'slug' => $organisation->slug,
                 'status' => $organisation->status->value,
             ],
-            'members' => $organisation->memberships()
-                ->with(['user', 'programs'])
-                ->get()
+            'members' => $memberships
                 ->map(function (Membership $membership) {
                     $member = $membership->user;
 
@@ -91,8 +110,48 @@ class OrganisationController extends Controller
                     'role_label' => $invitation->role->label(),
                     'created_at' => $invitation->created_at->toISOString(),
                 ]),
-            'permissions' => $user->toOrganisationPermissions($organisation),
+            'permissions' => $permissions,
             'availableRoles' => OrganisationRole::assignable(),
+            'allowedTransitions' => $user->ownsOrganisation($organisation)
+                ? collect($organisation->status->allowedTransitions())
+                    ->reject(fn (OrganisationStatus $status) => in_array($status, [
+                        OrganisationStatus::ScheduledForDeletion,
+                        OrganisationStatus::Deleted,
+                    ], true))
+                    ->map(fn (OrganisationStatus $status) => $status->value)
+                    ->values()
+                : [],
+            'ownerCandidates' => $user->ownsOrganisation($organisation)
+                ? $memberships
+                    ->reject(fn (Membership $membership) => $membership->is_owner)
+                    ->map(fn (Membership $membership) => [
+                        'id' => $membership->user->id,
+                        'name' => $membership->user->name,
+                    ])
+                    ->values()
+                : [],
+            'ownershipTransfer' => $pendingOwnershipTransfer === null ? null : [
+                'id' => $pendingOwnershipTransfer->id,
+                'nomineeUserId' => $pendingOwnershipTransfer->nominee_user_id,
+                'nomineeName' => $pendingOwnershipTransfer->nominee->name,
+                'nominatedByName' => $pendingOwnershipTransfer->nominatedBy->name,
+                'expiresAt' => $pendingOwnershipTransfer->expires_at->toISOString(),
+                'canAccept' => $pendingOwnershipTransfer->nominee_user_id === $user->id,
+            ],
+            'accessHolds' => $organisation->accessHolds()
+                ->whereNull('released_at')
+                ->where('starts_at', '<=', now())
+                ->where(fn ($query) => $query->whereNull('expires_at')->orWhere('expires_at', '>', now()))
+                ->orderByDesc('created_at')
+                ->get()
+                ->map(fn ($hold) => [
+                    'id' => $hold->id,
+                    'reason' => $hold->reason,
+                    'scope' => $hold->scope->value,
+                    'accessLevel' => $hold->access_level->value,
+                    'reviewAt' => $hold->review_at->toISOString(),
+                    'expiresAt' => $hold->expires_at?->toISOString(),
+                ]),
         ]);
     }
 
@@ -136,24 +195,35 @@ class OrganisationController extends Controller
         Gate::authorize('leave', $organisation);
 
         $user = $request->user();
-        $wasCurrentOrganisation = $user->isCurrentOrganisation($organisation);
+        DB::transaction(function () use ($organisation, $user): void {
+            $organisation = Organisation::whereKey($organisation->id)->lockForUpdate()->firstOrFail();
+            $membership = $organisation->memberships()
+                ->where('user_id', $user->id)
+                ->lockForUpdate()
+                ->firstOrFail();
 
-        $fallbackOrganisation = $wasCurrentOrganisation
-            ? $user->fallbackOrganisation($organisation)
-            : null;
+            abort_if(
+                $membership->is_owner && $organisation->owners()->count() <= 1,
+                403,
+                __('The last organisation owner cannot leave.'),
+            );
 
-        $organisation->memberships()
-            ->where('user_id', $user->id)
-            ->delete();
+            $wasCurrentOrganisation = $user->isCurrentOrganisation($organisation);
+            $fallbackOrganisation = $wasCurrentOrganisation
+                ? $user->fallbackOrganisation($organisation)
+                : null;
 
-        if ($wasCurrentOrganisation) {
-            if ($fallbackOrganisation) {
-                $user->switchOrganisation($fallbackOrganisation);
-            } else {
-                $user->update(['current_organisation_id' => null]);
-                $user->unsetRelation('currentOrganisation');
+            $membership->delete();
+
+            if ($wasCurrentOrganisation) {
+                if ($fallbackOrganisation) {
+                    $user->switchOrganisation($fallbackOrganisation);
+                } else {
+                    $user->update(['current_organisation_id' => null]);
+                    $user->unsetRelation('currentOrganisation');
+                }
             }
-        }
+        });
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('You left the organisation ":name"', ['name' => $organisation->name])]);
 
@@ -163,43 +233,22 @@ class OrganisationController extends Controller
     /**
      * Delete the specified organisation.
      */
-    public function destroy(DeleteOrganisationRequest $request, Organisation $organisation): RedirectResponse
-    {
-        $user = $request->user();
-        $wasCurrentOrganisation = $user->isCurrentOrganisation($organisation);
-        $fallbackOrganisation = $wasCurrentOrganisation
-            ? $user->fallbackOrganisation($organisation)
-            : null;
+    public function destroy(
+        DeleteOrganisationRequest $request,
+        Organisation $organisation,
+        TransitionOrganisationStatus $transitionOrganisationStatus,
+    ): RedirectResponse {
+        $transitionOrganisationStatus->handle(
+            $organisation,
+            OrganisationStatus::ScheduledForDeletion,
+            $request->user(),
+        );
 
-        DB::transaction(function () use ($user, $organisation) {
-            User::where('current_organisation_id', $organisation->id)
-                ->where('id', '!=', $user->id)
-                ->each(function (User $affectedUser) use ($organisation) {
-                    $fallbackOrganisation = $affectedUser->fallbackOrganisation($organisation);
+        Inertia::flash('toast', [
+            'type' => 'success',
+            'message' => __('Organisation scheduled for deletion after a 30-day recovery period.'),
+        ]);
 
-                    if ($fallbackOrganisation) {
-                        $affectedUser->switchOrganisation($fallbackOrganisation);
-                    } else {
-                        $affectedUser->update(['current_organisation_id' => null]);
-                    }
-                });
-
-            $organisation->invitations()->delete();
-            $organisation->memberships()->delete();
-            $organisation->delete();
-        });
-
-        if ($wasCurrentOrganisation) {
-            if ($fallbackOrganisation) {
-                $user->switchOrganisation($fallbackOrganisation);
-            } else {
-                $user->update(['current_organisation_id' => null]);
-                $user->unsetRelation('currentOrganisation');
-            }
-        }
-
-        Inertia::flash('toast', ['type' => 'success', 'message' => __('Organisation deleted.')]);
-
-        return to_route('organisations.index');
+        return to_route('organisations.edit', $organisation);
     }
 }

--- a/app/Http/Controllers/Organisations/OrganisationLifecycleController.php
+++ b/app/Http/Controllers/Organisations/OrganisationLifecycleController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Organisations\TransitionOrganisationStatus;
+use App\Enums\OrganisationStatus;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\TransitionOrganisationRequest;
+use App\Models\Organisation;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+
+class OrganisationLifecycleController extends Controller
+{
+    public function update(
+        TransitionOrganisationRequest $request,
+        Organisation $organisation,
+        TransitionOrganisationStatus $transitionOrganisationStatus,
+    ): RedirectResponse {
+        $transitionOrganisationStatus->handle(
+            $organisation,
+            OrganisationStatus::from($request->validated('status')),
+            $request->user(),
+        );
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Organisation status updated.')]);
+
+        return to_route('organisations.edit', $organisation);
+    }
+}

--- a/app/Http/Controllers/Organisations/OrganisationMemberController.php
+++ b/app/Http/Controllers/Organisations/OrganisationMemberController.php
@@ -48,21 +48,31 @@ class OrganisationMemberController extends Controller
     {
         Gate::authorize('removeMember', $organisation);
 
-        abort_if($organisation->owner()?->is($user), 403, __('The organisation owner cannot be removed.'));
+        DB::transaction(function () use ($organisation, $user): void {
+            $organisation = Organisation::whereKey($organisation->id)->lockForUpdate()->firstOrFail();
+            $membership = $organisation->memberships()
+                ->where('user_id', $user->id)
+                ->lockForUpdate()
+                ->firstOrFail();
 
-        $organisation->memberships()
-            ->where('user_id', $user->id)
-            ->delete();
+            abort_if(
+                $membership->is_owner && $organisation->owners()->count() <= 1,
+                403,
+                __('The last organisation owner cannot be removed.'),
+            );
 
-        if ($user->isCurrentOrganisation($organisation)) {
-            $fallbackOrganisation = $user->fallbackOrganisation($organisation);
+            $membership->delete();
 
-            if ($fallbackOrganisation) {
-                $user->switchOrganisation($fallbackOrganisation);
-            } else {
-                $user->update(['current_organisation_id' => null]);
+            if ($user->isCurrentOrganisation($organisation)) {
+                $fallbackOrganisation = $user->fallbackOrganisation($organisation);
+
+                if ($fallbackOrganisation) {
+                    $user->switchOrganisation($fallbackOrganisation);
+                } else {
+                    $user->update(['current_organisation_id' => null]);
+                }
             }
-        }
+        });
 
         Inertia::flash('toast', ['type' => 'success', 'message' => __('Member removed.')]);
 

--- a/app/Http/Controllers/Organisations/OrganisationOwnershipTransferController.php
+++ b/app/Http/Controllers/Organisations/OrganisationOwnershipTransferController.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Organisations\AcceptOrganisationOwnershipTransfer;
+use App\Actions\Organisations\NominateOrganisationOwnershipTransfer;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\AcceptOrganisationOwnershipTransferRequest;
+use App\Http\Requests\Organisations\CreateOrganisationOwnershipTransferRequest;
+use App\Models\Organisation;
+use App\Models\OrganisationOwnershipTransfer;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+
+class OrganisationOwnershipTransferController extends Controller
+{
+    public function store(
+        CreateOrganisationOwnershipTransferRequest $request,
+        Organisation $organisation,
+        NominateOrganisationOwnershipTransfer $nominateOrganisationOwnershipTransfer,
+    ): RedirectResponse {
+        $nominee = User::query()->findOrFail($request->integer('nominee_user_id'));
+        $nominateOrganisationOwnershipTransfer->handle($organisation, $request->user(), $nominee);
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Ownership transfer nominated.')]);
+
+        return to_route('organisations.edit', $organisation);
+    }
+
+    public function update(
+        AcceptOrganisationOwnershipTransferRequest $request,
+        Organisation $organisation,
+        OrganisationOwnershipTransfer $transfer,
+        AcceptOrganisationOwnershipTransfer $acceptOrganisationOwnershipTransfer,
+    ): RedirectResponse {
+        abort_unless($transfer->organisation_id === $organisation->id, 404);
+
+        $acceptOrganisationOwnershipTransfer->handle($transfer, $request->user());
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Ownership transfer accepted.')]);
+
+        return to_route('organisations.edit', $organisation);
+    }
+}

--- a/app/Http/Controllers/Organisations/OrganisationSlugController.php
+++ b/app/Http/Controllers/Organisations/OrganisationSlugController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Organisations\ChangeOrganisationSlug;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\UpdateOrganisationSlugRequest;
+use App\Models\Organisation;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+
+class OrganisationSlugController extends Controller
+{
+    public function update(
+        UpdateOrganisationSlugRequest $request,
+        Organisation $organisation,
+        ChangeOrganisationSlug $changeOrganisationSlug,
+    ): RedirectResponse {
+        $organisation = $changeOrganisationSlug->handle($organisation, $request->validated('slug'), $request->user());
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Organisation slug updated.')]);
+
+        return to_route('organisations.edit', $organisation);
+    }
+}

--- a/app/Http/Middleware/EnsureOrganisationAccess.php
+++ b/app/Http/Middleware/EnsureOrganisationAccess.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Actions\Organisations\ResolveOrganisationAccess;
+use App\Models\Organisation;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureOrganisationAccess
+{
+    public function __construct(private ResolveOrganisationAccess $resolveOrganisationAccess) {}
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next, string $capability = 'read'): Response
+    {
+        $organisation = $request->route('current_organisation') ?? $request->route('organisation');
+
+        if (is_string($organisation)) {
+            $organisation = Organisation::where('slug', $organisation)->first();
+        }
+
+        abort_unless($organisation instanceof Organisation, 404);
+
+        abort_unless(
+            $this->resolveOrganisationAccess->allowsStaffCapability($organisation, $request->user(), $capability),
+            403,
+        );
+
+        return $next($request);
+    }
+}

--- a/app/Http/Requests/Organisations/AcceptOrganisationOwnershipTransferRequest.php
+++ b/app/Http/Requests/Organisations/AcceptOrganisationOwnershipTransferRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Models\OrganisationOwnershipTransfer;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class AcceptOrganisationOwnershipTransferRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        $transfer = $this->route('transfer');
+
+        return $transfer instanceof OrganisationOwnershipTransfer
+            && $transfer->nominee_user_id === $this->user()?->id;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            //
+        ];
+    }
+}

--- a/app/Http/Requests/Organisations/CreateOrganisationOwnershipTransferRequest.php
+++ b/app/Http/Requests/Organisations/CreateOrganisationOwnershipTransferRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Models\Organisation;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class CreateOrganisationOwnershipTransferRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('transferOwnership', $this->route('organisation')) ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $organisation = $this->route('organisation');
+        $organisationId = $organisation instanceof Organisation ? $organisation->id : 0;
+
+        return [
+            'nominee_user_id' => [
+                'required',
+                'integer',
+                Rule::exists('organisation_members', 'user_id')->where('organisation_id', $organisationId),
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/Organisations/TransitionOrganisationRequest.php
+++ b/app/Http/Requests/Organisations/TransitionOrganisationRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Enums\OrganisationStatus;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TransitionOrganisationRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('transition', $this->route('organisation')) ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => [
+                'required',
+                Rule::in([
+                    OrganisationStatus::Active->value,
+                    OrganisationStatus::Archived->value,
+                ]),
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/Organisations/UpdateOrganisationSlugRequest.php
+++ b/app/Http/Requests/Organisations/UpdateOrganisationSlugRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Rules\OrganisationName;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateOrganisationSlugRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->user()?->can('changeSlug', $this->route('organisation')) ?? false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'slug' => ['required', 'string', 'max:63', 'regex:/^[a-z0-9]+(?:-[a-z0-9]+)*$/', new OrganisationName],
+        ];
+    }
+
+    /** @return array<string, string> */
+    public function messages(): array
+    {
+        return [
+            'slug.regex' => __('The slug may only contain lowercase letters, numbers, and single hyphens.'),
+        ];
+    }
+}

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Support\Carbon;
 
 /**
@@ -19,6 +20,10 @@ use Illuminate\Support\Carbon;
  * @property string $name
  * @property string $slug
  * @property OrganisationStatus $status
+ * @property Carbon|null $status_changed_at
+ * @property Carbon|null $deletion_scheduled_for
+ * @property Carbon|null $signed_links_invalidated_at
+ * @property int $access_version
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property Carbon|null $deleted_at
@@ -26,7 +31,7 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, Membership> $memberships
  * @property-read Collection<int, User> $members
  */
-#[Fillable(['name', 'slug', 'status'])]
+#[Fillable(['name', 'slug', 'status', 'status_changed_at', 'deletion_scheduled_for', 'signed_links_invalidated_at', 'access_version'])]
 class Organisation extends Model
 {
     /** @use HasFactory<OrganisationFactory> */
@@ -48,23 +53,29 @@ class Organisation extends Model
             if (empty($organisation->slug)) {
                 $organisation->slug = static::generateUniqueOrganisationSlug($organisation->name);
             }
-        });
 
-        static::updating(function (Organisation $organisation) {
-            if ($organisation->isDirty('name')) {
-                $organisation->slug = static::generateUniqueOrganisationSlug($organisation->name, $organisation->id);
-            }
+            $organisation->status_changed_at ??= Carbon::now();
         });
     }
 
     /**
      * Get the organisation owner.
      */
-    public function owner(): ?Model
+    public function owner(): ?User
     {
         return $this->members()
             ->wherePivot('is_owner', true)
             ->first();
+    }
+
+    /**
+     * Get the organisation's owners.
+     *
+     * @return BelongsToMany<User, $this, Membership, 'pivot'>
+     */
+    public function owners(): BelongsToMany
+    {
+        return $this->members()->wherePivot('is_owner', true);
     }
 
     /**
@@ -110,6 +121,30 @@ class Organisation extends Model
         return $this->hasMany(Program::class);
     }
 
+    /** @return HasMany<OrganisationAccessHold, $this> */
+    public function accessHolds(): HasMany
+    {
+        return $this->hasMany(OrganisationAccessHold::class);
+    }
+
+    /** @return HasMany<OrganisationLifecycleEvent, $this> */
+    public function lifecycleEvents(): HasMany
+    {
+        return $this->hasMany(OrganisationLifecycleEvent::class);
+    }
+
+    /** @return HasMany<OrganisationOwnershipTransfer, $this> */
+    public function ownershipTransfers(): HasMany
+    {
+        return $this->hasMany(OrganisationOwnershipTransfer::class);
+    }
+
+    /** @return HasMany<OrganisationSlug, $this> */
+    public function previousSlugs(): HasMany
+    {
+        return $this->hasMany(OrganisationSlug::class);
+    }
+
     /**
      * Get the attributes that should be cast.
      *
@@ -119,6 +154,10 @@ class Organisation extends Model
     {
         return [
             'status' => OrganisationStatus::class,
+            'status_changed_at' => 'datetime',
+            'deletion_scheduled_for' => 'datetime',
+            'signed_links_invalidated_at' => 'datetime',
+            'access_version' => 'integer',
         ];
     }
 
@@ -128,5 +167,41 @@ class Organisation extends Model
     public function getRouteKeyName(): string
     {
         return 'slug';
+    }
+
+    public function resolveRouteBinding(mixed $value, mixed $field = null): ?Model
+    {
+        $organisation = parent::resolveRouteBinding($value, $field);
+
+        if ($organisation !== null || ! is_string($value) || ($field !== null && $field !== 'slug')) {
+            return $organisation;
+        }
+
+        $previousSlug = OrganisationSlug::query()
+            ->with('organisation')
+            ->whereHas('organisation')
+            ->where('slug', $value)
+            ->where('redirect_until', '>', now())
+            ->first();
+
+        if ($previousSlug === null) {
+            return null;
+        }
+
+        $segments = request()->segments();
+        $segmentIndex = array_search($value, $segments, true);
+
+        if ($segmentIndex === false) {
+            return null;
+        }
+
+        $segments[$segmentIndex] = $previousSlug->organisation->slug;
+        $url = url(implode('/', $segments));
+
+        if (request()->getQueryString() !== null) {
+            $url .= '?'.request()->getQueryString();
+        }
+
+        throw new HttpResponseException(redirect($url, request()->isMethodSafe() ? 302 : 307));
     }
 }

--- a/app/Models/OrganisationAccessHold.php
+++ b/app/Models/OrganisationAccessHold.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use Database\Factories\OrganisationAccessHoldFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property OrganisationAccessScope $scope
+ * @property OrganisationAccessLevel $access_level
+ * @property Carbon $starts_at
+ * @property Carbon $review_at
+ * @property Carbon|null $expires_at
+ * @property Carbon|null $released_at
+ */
+#[Fillable(['organisation_id', 'issuer_user_id', 'issuer', 'reason', 'scope', 'access_level', 'incident_uuid', 'starts_at', 'review_at', 'expires_at', 'released_at', 'released_by_user_id', 'released_by', 'release_reason'])]
+class OrganisationAccessHold extends Model
+{
+    /** @use HasFactory<OrganisationAccessHoldFactory> */
+    use HasFactory, HasUlids;
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function issuerUser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'issuer_user_id');
+    }
+
+    public function isActiveAt(Carbon $at): bool
+    {
+        return $this->released_at === null
+            && $this->starts_at->lte($at)
+            && ($this->expires_at === null || $this->expires_at->gt($at));
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'scope' => OrganisationAccessScope::class,
+            'access_level' => OrganisationAccessLevel::class,
+            'starts_at' => 'datetime',
+            'review_at' => 'datetime',
+            'expires_at' => 'datetime',
+            'released_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/OrganisationLifecycleEvent.php
+++ b/app/Models/OrganisationLifecycleEvent.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\OrganisationLifecycleEventType;
+use App\Enums\OrganisationStatus;
+use Database\Factories\OrganisationLifecycleEventFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable(['organisation_id', 'actor_user_id', 'type', 'from_status', 'to_status', 'metadata', 'occurred_at'])]
+class OrganisationLifecycleEvent extends Model
+{
+    /** @use HasFactory<OrganisationLifecycleEventFactory> */
+    use HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function actor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'actor_user_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'type' => OrganisationLifecycleEventType::class,
+            'from_status' => OrganisationStatus::class,
+            'to_status' => OrganisationStatus::class,
+            'metadata' => 'array',
+            'occurred_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/OrganisationOwnershipTransfer.php
+++ b/app/Models/OrganisationOwnershipTransfer.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\OrganisationOwnershipTransferStatus;
+use Database\Factories\OrganisationOwnershipTransferFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property int $nominated_by_user_id
+ * @property int $nominee_user_id
+ * @property OrganisationOwnershipTransferStatus $status
+ * @property Carbon $expires_at
+ * @property Carbon|null $accepted_at
+ * @property Carbon|null $cancelled_at
+ * @property-read User $nominatedBy
+ * @property-read User $nominee
+ */
+#[Fillable(['organisation_id', 'nominated_by_user_id', 'nominee_user_id', 'status', 'expires_at', 'accepted_at', 'cancelled_at'])]
+class OrganisationOwnershipTransfer extends Model
+{
+    /** @use HasFactory<OrganisationOwnershipTransferFactory> */
+    use HasFactory, HasUlids;
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function nominatedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'nominated_by_user_id');
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function nominee(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'nominee_user_id');
+    }
+
+    public function isPending(): bool
+    {
+        return $this->status === OrganisationOwnershipTransferStatus::Pending
+            && $this->expires_at->isFuture();
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'status' => OrganisationOwnershipTransferStatus::class,
+            'expires_at' => 'datetime',
+            'accepted_at' => 'datetime',
+            'cancelled_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/OrganisationSlug.php
+++ b/app/Models/OrganisationSlug.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\OrganisationSlugFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $organisation_id
+ * @property string $slug
+ * @property Carbon $redirect_until
+ * @property Carbon $quarantined_until
+ */
+#[Fillable(['organisation_id', 'slug', 'redirect_until', 'quarantined_until'])]
+class OrganisationSlug extends Model
+{
+    /** @use HasFactory<OrganisationSlugFactory> */
+    use HasFactory;
+
+    public $timestamps = false;
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'redirect_until' => 'datetime',
+            'quarantined_until' => 'datetime',
+        ];
+    }
+}

--- a/app/Policies/OrganisationPolicy.php
+++ b/app/Policies/OrganisationPolicy.php
@@ -3,6 +3,7 @@
 namespace App\Policies;
 
 use App\Enums\OrganisationPermission;
+use App\Enums\OrganisationStatus;
 use App\Models\Organisation;
 use App\Models\User;
 
@@ -40,13 +41,32 @@ class OrganisationPolicy
         return $user->hasOrganisationPermission($organisation, OrganisationPermission::UpdateOrganisation);
     }
 
+    public function transition(User $user, Organisation $organisation): bool
+    {
+        return $user->ownsOrganisation($organisation);
+    }
+
+    public function changeSlug(User $user, Organisation $organisation): bool
+    {
+        return $user->ownsOrganisation($organisation);
+    }
+
+    public function transferOwnership(User $user, Organisation $organisation): bool
+    {
+        return $user->ownsOrganisation($organisation);
+    }
+
     /**
      * Determine whether the user can leave the organisation.
      */
     public function leave(User $user, Organisation $organisation): bool
     {
-        return $user->belongsToOrganisation($organisation)
-            && ! $user->ownsOrganisation($organisation);
+        if (! $user->belongsToOrganisation($organisation)) {
+            return false;
+        }
+
+        return ! $user->ownsOrganisation($organisation)
+            || $organisation->owners()->whereKeyNot($user->id)->exists();
     }
 
     /**
@@ -94,6 +114,7 @@ class OrganisationPolicy
      */
     public function delete(User $user, Organisation $organisation): bool
     {
-        return $user->hasOrganisationPermission($organisation, OrganisationPermission::DeleteOrganisation);
+        return in_array($organisation->status, [OrganisationStatus::Pending, OrganisationStatus::Archived], true)
+            && $user->hasOrganisationPermission($organisation, OrganisationPermission::DeleteOrganisation);
     }
 }

--- a/config/organisation_lifecycle.php
+++ b/config/organisation_lifecycle.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'deletion_recovery_days' => 30,
+    'ownership_transfer_hours' => 72,
+    'slug_redirect_days' => 30,
+    'slug_quarantine_days' => 90,
+];

--- a/database/factories/OrganisationAccessHoldFactory.php
+++ b/database/factories/OrganisationAccessHoldFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Models\Organisation;
+use App\Models\OrganisationAccessHold;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<OrganisationAccessHold>
+ */
+class OrganisationAccessHoldFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => Organisation::factory(),
+            'issuer_user_id' => User::factory(),
+            'issuer' => fake()->name(),
+            'reason' => fake()->sentence(),
+            'scope' => OrganisationAccessScope::All,
+            'access_level' => OrganisationAccessLevel::ReadOnly,
+            'starts_at' => now(),
+            'review_at' => now()->addDay(),
+            'expires_at' => now()->addDays(7),
+        ];
+    }
+}

--- a/database/factories/OrganisationFactory.php
+++ b/database/factories/OrganisationFactory.php
@@ -28,6 +28,28 @@ class OrganisationFactory extends Factory
         ];
     }
 
+    public function active(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => OrganisationStatus::Active,
+        ]);
+    }
+
+    public function archived(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => OrganisationStatus::Archived,
+        ]);
+    }
+
+    public function scheduledForDeletion(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => OrganisationStatus::ScheduledForDeletion,
+            'deletion_scheduled_for' => now()->addDays(30),
+        ]);
+    }
+
     /**
      * Indicate that the organisation has been deleted.
      */

--- a/database/factories/OrganisationLifecycleEventFactory.php
+++ b/database/factories/OrganisationLifecycleEventFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\OrganisationLifecycleEventType;
+use App\Models\Organisation;
+use App\Models\OrganisationLifecycleEvent;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<OrganisationLifecycleEvent>
+ */
+class OrganisationLifecycleEventFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => Organisation::factory(),
+            'actor_user_id' => User::factory(),
+            'type' => OrganisationLifecycleEventType::StatusChanged,
+            'metadata' => [],
+            'occurred_at' => now(),
+        ];
+    }
+}

--- a/database/factories/OrganisationOwnershipTransferFactory.php
+++ b/database/factories/OrganisationOwnershipTransferFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\OrganisationOwnershipTransferStatus;
+use App\Models\Organisation;
+use App\Models\OrganisationOwnershipTransfer;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<OrganisationOwnershipTransfer>
+ */
+class OrganisationOwnershipTransferFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => Organisation::factory(),
+            'nominated_by_user_id' => User::factory(),
+            'nominee_user_id' => User::factory(),
+            'status' => OrganisationOwnershipTransferStatus::Pending,
+            'expires_at' => now()->addHours(72),
+        ];
+    }
+}

--- a/database/factories/OrganisationSlugFactory.php
+++ b/database/factories/OrganisationSlugFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Organisation;
+use App\Models\OrganisationSlug;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<OrganisationSlug>
+ */
+class OrganisationSlugFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => Organisation::factory(),
+            'slug' => fake()->unique()->slug(2),
+            'redirect_until' => now()->addDays(30),
+            'quarantined_until' => now()->addDays(120),
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -43,7 +43,7 @@ class UserFactory extends Factory
     public function configure(): static
     {
         return $this->afterCreating(function ($user) {
-            $organisation = Organisation::factory()->create();
+            $organisation = Organisation::factory()->active()->create();
 
             $organisation->members()->attach($user, [
                 'is_owner' => true,

--- a/database/migrations/2026_08_30_150920_create_organisation_access_holds_table.php
+++ b/database/migrations/2026_08_30_150920_create_organisation_access_holds_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('organisation_access_holds', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('issuer_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('issuer');
+            $table->text('reason');
+            $table->string('scope');
+            $table->string('access_level');
+            $table->uuid('incident_uuid')->nullable();
+            $table->timestamp('starts_at');
+            $table->timestamp('review_at');
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('released_at')->nullable();
+            $table->foreignId('released_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('released_by')->nullable();
+            $table->text('release_reason')->nullable();
+            $table->timestamps();
+
+            $table->index(['organisation_id', 'starts_at', 'expires_at'], 'organisation_access_holds_active_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('organisation_access_holds');
+    }
+};

--- a/database/migrations/2026_08_30_150921_create_organisation_lifecycle_events_table.php
+++ b/database/migrations/2026_08_30_150921_create_organisation_lifecycle_events_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('organisation_lifecycle_events', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('actor_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('type');
+            $table->string('from_status')->nullable();
+            $table->string('to_status')->nullable();
+            $table->json('metadata');
+            $table->timestamp('occurred_at');
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['organisation_id', 'occurred_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('organisation_lifecycle_events');
+    }
+};

--- a/database/migrations/2026_08_30_150922_create_organisation_ownership_transfers_table.php
+++ b/database/migrations/2026_08_30_150922_create_organisation_ownership_transfers_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('organisation_ownership_transfers', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('nominated_by_user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('nominee_user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('status');
+            $table->timestamp('expires_at');
+            $table->timestamp('accepted_at')->nullable();
+            $table->timestamp('cancelled_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['organisation_id', 'status']);
+            $table->index(['nominee_user_id', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('organisation_ownership_transfers');
+    }
+};

--- a/database/migrations/2026_08_30_150923_create_organisation_slugs_table.php
+++ b/database/migrations/2026_08_30_150923_create_organisation_slugs_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('organisation_slugs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->string('slug')->unique();
+            $table->timestamp('redirect_until');
+            $table->timestamp('quarantined_until');
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['quarantined_until']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('organisation_slugs');
+    }
+};

--- a/database/migrations/2026_08_30_150938_add_lifecycle_fields_to_organisations_table.php
+++ b/database/migrations/2026_08_30_150938_add_lifecycle_fields_to_organisations_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('organisations', function (Blueprint $table) {
+            $table->timestamp('status_changed_at')->nullable()->after('status');
+            $table->timestamp('deletion_scheduled_for')->nullable()->after('status_changed_at');
+            $table->timestamp('signed_links_invalidated_at')->nullable()->after('deletion_scheduled_for');
+            $table->unsignedBigInteger('access_version')->default(1)->after('signed_links_invalidated_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('organisations', function (Blueprint $table) {
+            $table->dropColumn([
+                'status_changed_at',
+                'deletion_scheduled_for',
+                'signed_links_invalidated_at',
+                'access_version',
+            ]);
+        });
+    }
+};

--- a/resources/js/components/delete-organisation-modal.tsx
+++ b/resources/js/components/delete-organisation-modal.tsx
@@ -51,11 +51,14 @@ export default function DeleteOrganisationModal({
                     {({ errors, processing }) => (
                         <>
                             <DialogHeader>
-                                <DialogTitle>Are you sure?</DialogTitle>
+                                <DialogTitle>
+                                    Schedule organisation deletion?
+                                </DialogTitle>
                                 <DialogDescription>
-                                    This action cannot be undone. This will
-                                    permanently delete the organisation{' '}
-                                    <strong>"{organisation.name}"</strong>.
+                                    This starts a 30-day recovery period for{' '}
+                                    <strong>"{organisation.name}"</strong>. The
+                                    organisation becomes read-only and can be
+                                    restored before the period ends.
                                 </DialogDescription>
                             </DialogHeader>
 
@@ -96,7 +99,7 @@ export default function DeleteOrganisationModal({
                                         !canDeleteOrganisation || processing
                                     }
                                 >
-                                    Delete organisation
+                                    Schedule deletion
                                 </Button>
                             </DialogFooter>
                         </>

--- a/resources/js/pages/organisations/edit.tsx
+++ b/resources/js/pages/organisations/edit.tsx
@@ -1,5 +1,5 @@
 import { Form, Head, router } from '@inertiajs/react';
-import { ChevronDown, Mail, UserPlus, X } from 'lucide-react';
+import { ChevronDown, Mail, ShieldAlert, UserPlus, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import CancelInvitationModal from '@/components/cancel-invitation-modal';
 import DeleteOrganisationModal from '@/components/delete-organisation-modal';
@@ -27,8 +27,17 @@ import {
 } from '@/components/ui/tooltip';
 import { useInitials } from '@/hooks/use-initials';
 import { edit, index, update } from '@/routes/organisations';
+import { update as updateLifecycle } from '@/routes/organisations/lifecycle';
 import { update as updateMember } from '@/routes/organisations/members';
+import {
+    store as storeOwnershipTransfer,
+    update as acceptOwnershipTransfer,
+} from '@/routes/organisations/ownership-transfers';
+import { update as updateSlug } from '@/routes/organisations/slug';
 import type {
+    OrganisationAccessHold,
+    OrganisationOwnerCandidate,
+    OrganisationOwnershipTransfer,
     ProgramOption,
     RoleOption,
     Organisation,
@@ -44,6 +53,10 @@ type Props = {
     permissions: OrganisationPermissions;
     availableRoles: RoleOption[];
     programs: ProgramOption[];
+    allowedTransitions: string[];
+    ownerCandidates: OrganisationOwnerCandidate[];
+    ownershipTransfer: OrganisationOwnershipTransfer | null;
+    accessHolds: OrganisationAccessHold[];
 };
 
 export default function OrganisationEdit({
@@ -53,6 +66,10 @@ export default function OrganisationEdit({
     permissions,
     availableRoles,
     programs,
+    allowedTransitions,
+    ownerCandidates,
+    ownershipTransfer,
+    accessHolds,
 }: Props) {
     const getInitials = useInitials();
 
@@ -73,6 +90,11 @@ export default function OrganisationEdit({
                 : `View ${organisation.name}`,
         [permissions.canUpdateOrganisation, organisation.name],
     );
+
+    const statusLabel = (status: string) =>
+        status
+            .replaceAll('_', ' ')
+            .replace(/^./, (letter) => letter.toUpperCase());
 
     const updateMemberRole = (member: OrganisationMember, newRole: string) => {
         router.visit(updateMember([organisation.slug, member.id]), {
@@ -118,6 +140,34 @@ export default function OrganisationEdit({
 
             <div className="flex flex-col space-y-10">
                 <div className="space-y-6">
+                    <div className="flex items-center gap-3">
+                        <Badge variant="outline">
+                            {statusLabel(organisation.status ?? 'pending')}
+                        </Badge>
+                    </div>
+
+                    {accessHolds.map((hold) => (
+                        <div
+                            key={hold.id}
+                            className="border-destructive/40 bg-destructive/5 flex gap-3 rounded-lg border p-4"
+                            data-test="organisation-access-hold"
+                        >
+                            <ShieldAlert className="text-destructive mt-0.5 size-5 shrink-0" />
+                            <div className="space-y-1">
+                                <p className="font-medium">
+                                    Access hold: {statusLabel(hold.accessLevel)}
+                                </p>
+                                <p className="text-muted-foreground text-sm">
+                                    {hold.reason}
+                                </p>
+                                <p className="text-muted-foreground text-xs">
+                                    Scope: {statusLabel(hold.scope)} · Review by{' '}
+                                    {new Date(hold.reviewAt).toLocaleString()}
+                                </p>
+                            </div>
+                        </div>
+                    ))}
+
                     {permissions.canUpdateOrganisation ? (
                         <>
                             <Heading
@@ -168,6 +218,147 @@ export default function OrganisationEdit({
                         </>
                     )}
                 </div>
+
+                {permissions.canChangeOrganisationSlug ? (
+                    <div className="space-y-6">
+                        <Heading
+                            variant="small"
+                            title="Organisation address"
+                            description="Changing the slug redirects the old address temporarily, then quarantines it"
+                        />
+                        <Form
+                            {...updateSlug.form(organisation.slug)}
+                            className="space-y-4"
+                        >
+                            {({ errors, processing }) => (
+                                <>
+                                    <div className="grid gap-2">
+                                        <Label htmlFor="slug">Slug</Label>
+                                        <Input
+                                            id="slug"
+                                            name="slug"
+                                            defaultValue={organisation.slug}
+                                            required
+                                        />
+                                        <InputError message={errors.slug} />
+                                    </div>
+                                    <Button type="submit" disabled={processing}>
+                                        Change slug
+                                    </Button>
+                                </>
+                            )}
+                        </Form>
+                    </div>
+                ) : null}
+
+                {permissions.canTransitionOrganisation &&
+                allowedTransitions.length > 0 ? (
+                    <div className="space-y-6">
+                        <Heading
+                            variant="small"
+                            title="Organisation lifecycle"
+                            description="Lifecycle changes are audited and immediately recompute access"
+                        />
+                        <div className="flex flex-wrap gap-3">
+                            {allowedTransitions.map((status) => (
+                                <Form
+                                    key={status}
+                                    {...updateLifecycle.form(organisation.slug)}
+                                >
+                                    {({ processing }) => (
+                                        <>
+                                            <input
+                                                type="hidden"
+                                                name="status"
+                                                value={status}
+                                            />
+                                            <Button
+                                                type="submit"
+                                                variant="outline"
+                                                disabled={processing}
+                                            >
+                                                Move to {statusLabel(status)}
+                                            </Button>
+                                        </>
+                                    )}
+                                </Form>
+                            ))}
+                        </div>
+                    </div>
+                ) : null}
+
+                {ownershipTransfer ? (
+                    <div className="space-y-4 rounded-lg border p-4">
+                        <Heading
+                            variant="small"
+                            title="Pending ownership transfer"
+                            description={`${ownershipTransfer.nominatedByName} nominated ${ownershipTransfer.nomineeName}`}
+                        />
+                        {ownershipTransfer.canAccept ? (
+                            <Form
+                                {...acceptOwnershipTransfer.form([
+                                    organisation.slug,
+                                    ownershipTransfer.id,
+                                ])}
+                            >
+                                {({ processing }) => (
+                                    <Button type="submit" disabled={processing}>
+                                        Accept ownership
+                                    </Button>
+                                )}
+                            </Form>
+                        ) : null}
+                    </div>
+                ) : permissions.canTransferOwnership &&
+                  ownerCandidates.length > 0 ? (
+                    <div className="space-y-6">
+                        <Heading
+                            variant="small"
+                            title="Transfer ownership"
+                            description="The nominated member must explicitly accept within 72 hours"
+                        />
+                        <Form
+                            {...storeOwnershipTransfer.form(organisation.slug)}
+                            className="space-y-4"
+                        >
+                            {({ errors, processing }) => (
+                                <>
+                                    <div className="grid gap-2">
+                                        <Label htmlFor="nominee_user_id">
+                                            New owner
+                                        </Label>
+                                        <select
+                                            id="nominee_user_id"
+                                            name="nominee_user_id"
+                                            className="border-input bg-background h-9 rounded-md border px-3 text-sm"
+                                            required
+                                        >
+                                            <option value="">
+                                                Select a member
+                                            </option>
+                                            {ownerCandidates.map(
+                                                (candidate) => (
+                                                    <option
+                                                        key={candidate.id}
+                                                        value={candidate.id}
+                                                    >
+                                                        {candidate.name}
+                                                    </option>
+                                                ),
+                                            )}
+                                        </select>
+                                        <InputError
+                                            message={errors.nominee_user_id}
+                                        />
+                                    </div>
+                                    <Button type="submit" disabled={processing}>
+                                        Nominate new owner
+                                    </Button>
+                                </>
+                            )}
+                        </Form>
+                    </div>
+                ) : null}
 
                 <div className="space-y-6">
                     <div className="flex items-center justify-between">
@@ -402,15 +593,15 @@ export default function OrganisationEdit({
                     <div className="space-y-6">
                         <Heading
                             variant="small"
-                            title="Delete organisation"
-                            description="Permanently delete your organisation"
+                            title="Schedule organisation deletion"
+                            description="Start the 30-day recovery period"
                         />
                         <div className="space-y-4 rounded-lg border border-red-100 bg-red-50 p-4 dark:border-red-200/10 dark:bg-red-700/10">
                             <div className="relative space-y-0.5 text-red-600 dark:text-red-100">
                                 <p className="font-medium">Warning</p>
                                 <p className="text-sm">
-                                    Please proceed with caution, this cannot be
-                                    undone.
+                                    The organisation remains recoverable for 30
+                                    days before deletion.
                                 </p>
                             </div>
                             <Button
@@ -418,7 +609,7 @@ export default function OrganisationEdit({
                                 data-test="delete-organisation-button"
                                 onClick={() => setDeleteDialogOpen(true)}
                             >
-                                Delete organisation
+                                Schedule deletion
                             </Button>
                         </div>
                     </div>

--- a/resources/js/types/organisations.ts
+++ b/resources/js/types/organisations.ts
@@ -59,6 +59,32 @@ export type OrganisationPermissions = {
     canRemoveMember: boolean;
     canCreateInvitation: boolean;
     canCancelInvitation: boolean;
+    canTransitionOrganisation: boolean;
+    canChangeOrganisationSlug: boolean;
+    canTransferOwnership: boolean;
+};
+
+export type OrganisationAccessHold = {
+    id: string;
+    reason: string;
+    scope: string;
+    accessLevel: string;
+    reviewAt: string;
+    expiresAt: string | null;
+};
+
+export type OrganisationOwnershipTransfer = {
+    id: string;
+    nomineeUserId: number;
+    nomineeName: string;
+    nominatedByName: string;
+    expiresAt: string;
+    canAccept: boolean;
+};
+
+export type OrganisationOwnerCandidate = {
+    id: number;
+    name: string;
 };
 
 export type RoleOption = {

--- a/routes/console.php
+++ b/routes/console.php
@@ -9,3 +9,8 @@ Schedule::call(function () {
         ->where('expires_at', '<', now())
         ->delete();
 })->daily()->description('Delete expired organisation invitations');
+
+Schedule::command('organisations:purge-scheduled')
+    ->daily()
+    ->onOneServer()
+    ->withoutOverlapping(60);

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -3,11 +3,15 @@
 use App\Http\Controllers\Auth\MfaChallengeController;
 use App\Http\Controllers\Organisations\OrganisationController;
 use App\Http\Controllers\Organisations\OrganisationInvitationController;
+use App\Http\Controllers\Organisations\OrganisationLifecycleController;
 use App\Http\Controllers\Organisations\OrganisationMemberController;
+use App\Http\Controllers\Organisations\OrganisationOwnershipTransferController;
+use App\Http\Controllers\Organisations\OrganisationSlugController;
 use App\Http\Controllers\Settings\OtherBrowserSessionController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\RecoveryCodeAcknowledgementController;
 use App\Http\Controllers\Settings\SecurityController;
+use App\Http\Middleware\EnsureOrganisationAccess;
 use App\Http\Middleware\EnsureOrganisationMembership;
 use App\Http\Middleware\EnsureRecentMfa;
 use App\Http\Middleware\EnsureRecentPassword;
@@ -57,17 +61,22 @@ Route::middleware(['auth', 'verified'])->group(function () {
             ->name('security.other-browser-sessions.destroy');
 
         Route::middleware(EnsureOrganisationMembership::class)->group(function () {
-            Route::get('settings/organisations/{organisation}', [OrganisationController::class, 'edit'])->name('organisations.edit');
-            Route::patch('settings/organisations/{organisation}', [OrganisationController::class, 'update'])->middleware([EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.update');
-            Route::delete('settings/organisations/{organisation}', [OrganisationController::class, 'destroy'])->middleware([EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.destroy');
-            Route::post('settings/organisations/{organisation}/switch', [OrganisationController::class, 'switch'])->name('organisations.switch');
+            Route::get('settings/organisations/{organisation}', [OrganisationController::class, 'edit'])->middleware(EnsureOrganisationAccess::class.':recovery')->name('organisations.edit');
+            Route::patch('settings/organisations/{organisation}', [OrganisationController::class, 'update'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.update');
+            Route::delete('settings/organisations/{organisation}', [OrganisationController::class, 'destroy'])->middleware([EnsureOrganisationAccess::class.':recovery', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.destroy');
+            Route::post('settings/organisations/{organisation}/switch', [OrganisationController::class, 'switch'])->middleware(EnsureOrganisationAccess::class.':full')->name('organisations.switch');
             Route::delete('settings/organisations/{organisation}/leave', [OrganisationController::class, 'leave'])->name('organisations.leave');
 
-            Route::patch('settings/organisations/{organisation}/members/{user}', [OrganisationMemberController::class, 'update'])->middleware([EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.members.update');
-            Route::delete('settings/organisations/{organisation}/members/{user}', [OrganisationMemberController::class, 'destroy'])->middleware([EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.members.destroy');
+            Route::patch('settings/organisations/{organisation}/lifecycle', [OrganisationLifecycleController::class, 'update'])->middleware([EnsureOrganisationAccess::class.':recovery', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.lifecycle.update');
+            Route::patch('settings/organisations/{organisation}/slug', [OrganisationSlugController::class, 'update'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.slug.update');
+            Route::post('settings/organisations/{organisation}/ownership-transfers', [OrganisationOwnershipTransferController::class, 'store'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.ownership-transfers.store');
+            Route::patch('settings/organisations/{organisation}/ownership-transfers/{transfer}', [OrganisationOwnershipTransferController::class, 'update'])->middleware([EnsureOrganisationAccess::class.':membership', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.ownership-transfers.update');
 
-            Route::post('settings/organisations/{organisation}/invitations', [OrganisationInvitationController::class, 'store'])->middleware([EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.invitations.store');
-            Route::delete('settings/organisations/{organisation}/invitations/{invitation}', [OrganisationInvitationController::class, 'destroy'])->middleware([EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.invitations.destroy');
+            Route::patch('settings/organisations/{organisation}/members/{user}', [OrganisationMemberController::class, 'update'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.members.update');
+            Route::delete('settings/organisations/{organisation}/members/{user}', [OrganisationMemberController::class, 'destroy'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.members.destroy');
+
+            Route::post('settings/organisations/{organisation}/invitations', [OrganisationInvitationController::class, 'store'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.invitations.store');
+            Route::delete('settings/organisations/{organisation}/invitations/{invitation}', [OrganisationInvitationController::class, 'destroy'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.invitations.destroy');
         });
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,14 +2,17 @@
 
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Organisations\OrganisationInvitationController;
+use App\Http\Middleware\EnsureOrganisationAccess;
 use App\Http\Middleware\EnsureOrganisationMembership;
 use App\Http\Middleware\EnsureStaffSecurityRequirements;
+use App\Models\Organisation;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 
 Route::inertia('/', 'welcome')->name('home');
+Route::model('current_organisation', Organisation::class);
 
 Route::get('/source-and-licence', fn (): View => view('source-and-licence', [
     'repository' => config('source.repository'),
@@ -22,7 +25,7 @@ Route::get('/source-and-licence/license', fn (): Response => response(
 ))->name('source-and-licence.license');
 
 Route::prefix('{current_organisation}')
-    ->middleware(['auth', 'verified', EnsureStaffSecurityRequirements::class, EnsureOrganisationMembership::class])
+    ->middleware(['auth', 'verified', EnsureStaffSecurityRequirements::class, EnsureOrganisationMembership::class, EnsureOrganisationAccess::class.':full'])
     ->group(function () {
         Route::get('dashboard', DashboardController::class)->name('dashboard');
     });

--- a/tests/Feature/OrganisationAccessHoldTest.php
+++ b/tests/Feature/OrganisationAccessHoldTest.php
@@ -1,0 +1,107 @@
+<?php
+
+use App\Actions\Organisations\PlaceOrganisationAccessHold;
+use App\Actions\Organisations\ReleaseOrganisationAccessHold;
+use App\Actions\Organisations\ResolveOrganisationAccess;
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Enums\OrganisationLifecycleEventType;
+use App\Enums\OrganisationStatus;
+use App\Models\Organisation;
+use App\Models\OrganisationAccessHold;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Inertia\Testing\AssertableInertia as Assert;
+
+it('applies the most restrictive active hold for the requested scope', function () {
+    $organisation = Organisation::factory()->active()->create();
+
+    OrganisationAccessHold::factory()->for($organisation)->create([
+        'scope' => OrganisationAccessScope::Forms,
+        'access_level' => OrganisationAccessLevel::ReadOnly,
+    ]);
+    OrganisationAccessHold::factory()->for($organisation)->create([
+        'scope' => OrganisationAccessScope::All,
+        'access_level' => OrganisationAccessLevel::RecoveryOnly,
+    ]);
+    OrganisationAccessHold::factory()->for($organisation)->create([
+        'scope' => OrganisationAccessScope::All,
+        'access_level' => OrganisationAccessLevel::Denied,
+        'expires_at' => now()->subSecond(),
+    ]);
+
+    $resolver = app(ResolveOrganisationAccess::class);
+
+    expect($resolver->handle($organisation, OrganisationAccessScope::Forms))->toBe(OrganisationAccessLevel::RecoveryOnly)
+        ->and($resolver->handle($organisation, OrganisationAccessScope::Jobs))->toBe(OrganisationAccessLevel::RecoveryOnly)
+        ->and($organisation->fresh()->status)->toBe(OrganisationStatus::Active);
+});
+
+it('records hold placement and release while invalidating organisation access', function () {
+    $organisation = Organisation::factory()->active()->create();
+    $issuer = User::factory()->create();
+    $originalVersion = $organisation->fresh()->access_version;
+
+    $hold = app(PlaceOrganisationAccessHold::class)->handle(
+        $organisation,
+        'security@example.test',
+        'Possible account compromise',
+        OrganisationAccessScope::All,
+        OrganisationAccessLevel::ReadOnly,
+        Carbon::now()->addDay(),
+        Carbon::now()->addWeek(),
+        $issuer,
+        '2f968dae-36f7-4bba-a641-548555642391',
+    );
+
+    expect($organisation->fresh()->access_version)->toBe($originalVersion + 1)
+        ->and($organisation->fresh()->signed_links_invalidated_at)->not->toBeNull()
+        ->and($hold->issuer)->toBe('security@example.test')
+        ->and($hold->review_at)->not->toBeNull();
+    $this->assertDatabaseHas('organisation_lifecycle_events', [
+        'organisation_id' => $organisation->id,
+        'type' => OrganisationLifecycleEventType::AccessHoldPlaced->value,
+    ]);
+
+    app(ReleaseOrganisationAccessHold::class)->handle($hold, 'security@example.test', 'Investigation complete', $issuer);
+
+    expect($hold->fresh()->released_at)->not->toBeNull()
+        ->and($organisation->fresh()->access_version)->toBe($originalVersion + 2)
+        ->and(app(ResolveOrganisationAccess::class)->handle($organisation, OrganisationAccessScope::Staff))
+        ->toBe(OrganisationAccessLevel::Full);
+    $this->assertDatabaseHas('organisation_lifecycle_events', [
+        'organisation_id' => $organisation->id,
+        'type' => OrganisationLifecycleEventType::AccessHoldReleased->value,
+    ]);
+});
+
+it('enforces staff holds on current organisation routes', function () {
+    $owner = User::factory()->create();
+    $organisation = $owner->currentOrganisation;
+    OrganisationAccessHold::factory()->for($organisation)->create([
+        'scope' => OrganisationAccessScope::Staff,
+        'access_level' => OrganisationAccessLevel::ReadOnly,
+    ]);
+
+    $this->actingAs($owner)->get(route('dashboard', $organisation))->assertForbidden();
+    $this
+        ->actingAs($owner)
+        ->get(route('organisations.edit', $organisation))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('permissions.canUpdateOrganisation', false)
+            ->where('permissions.canUpdateMember', false)
+            ->where('permissions.canCreateInvitation', false)
+            ->where('permissions.canTransitionOrganisation', true));
+    $this
+        ->actingAs($owner)
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->patch(route('organisations.update', $organisation), ['name' => 'Blocked rename'])
+        ->assertForbidden();
+});
+
+test('example', function () {
+    $response = $this->get('/');
+
+    $response->assertStatus(200);
+});

--- a/tests/Feature/OrganisationAdministrationTest.php
+++ b/tests/Feature/OrganisationAdministrationTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Actions\Organisations\TransitionOrganisationStatus;
 use App\Enums\OrganisationRole;
 use App\Enums\OrganisationStatus;
 use App\Models\Organisation;
@@ -136,8 +137,8 @@ it('rejects program access from another organisation without changing the member
 
 it('switches to a fresh destination dashboard and recomputes organisation context', function () {
     $user = User::factory()->create();
-    $firstOrganisation = Organisation::factory()->create(['name' => 'HarbourKind']);
-    $secondOrganisation = Organisation::factory()->create(['name' => 'NeighbourLink']);
+    $firstOrganisation = Organisation::factory()->active()->create(['name' => 'HarbourKind']);
+    $secondOrganisation = Organisation::factory()->active()->create(['name' => 'NeighbourLink']);
     $firstProgram = Program::factory()->for($firstOrganisation)->create();
     $secondProgram = Program::factory()->for($secondOrganisation)->create();
 
@@ -206,6 +207,11 @@ it('clears current organisation context when leaving the only organisation', fun
 it('clears current organisation context when deleting the only organisation', function () {
     $user = User::factory()->create();
     $organisation = $user->currentOrganisation;
+    app(TransitionOrganisationStatus::class)->handle(
+        $organisation,
+        OrganisationStatus::Archived,
+        $user,
+    );
 
     $response = $this
         ->actingAs($user)
@@ -214,6 +220,7 @@ it('clears current organisation context when deleting the only organisation', fu
             'name' => $organisation->name,
         ]);
 
-    $response->assertRedirect(route('organisations.index'));
-    expect($user->fresh()->current_organisation_id)->toBeNull();
+    $response->assertRedirect(route('organisations.edit', $organisation));
+    expect($user->fresh()->current_organisation_id)->toBeNull()
+        ->and($organisation->fresh()->status)->toBe(OrganisationStatus::ScheduledForDeletion);
 });

--- a/tests/Feature/OrganisationLifecycleTest.php
+++ b/tests/Feature/OrganisationLifecycleTest.php
@@ -1,0 +1,141 @@
+<?php
+
+use App\Actions\Organisations\TransitionOrganisationStatus;
+use App\Enums\OrganisationLifecycleEventType;
+use App\Enums\OrganisationStatus;
+use App\Models\Organisation;
+use App\Models\User;
+use Illuminate\Validation\ValidationException;
+use Inertia\Testing\AssertableInertia as Assert;
+
+it('supports every approved organisation lifecycle transition', function (OrganisationStatus $from, OrganisationStatus $to) {
+    $organisation = Organisation::factory()->create([
+        'status' => $from,
+        'deletion_scheduled_for' => $from === OrganisationStatus::ScheduledForDeletion ? now()->subSecond() : null,
+    ]);
+
+    app(TransitionOrganisationStatus::class)->handle($organisation, $to);
+
+    $persisted = Organisation::withTrashed()->findOrFail($organisation->id);
+
+    expect($persisted->status)->toBe($to)
+        ->and($persisted->lifecycleEvents()->latest('occurred_at')->first()->type)
+        ->toBe(OrganisationLifecycleEventType::StatusChanged);
+})->with([
+    'pending to active' => [OrganisationStatus::Pending, OrganisationStatus::Active],
+    'pending to scheduled deletion' => [OrganisationStatus::Pending, OrganisationStatus::ScheduledForDeletion],
+    'active to archived' => [OrganisationStatus::Active, OrganisationStatus::Archived],
+    'archived to active' => [OrganisationStatus::Archived, OrganisationStatus::Active],
+    'archived to scheduled deletion' => [OrganisationStatus::Archived, OrganisationStatus::ScheduledForDeletion],
+    'scheduled deletion to archived' => [OrganisationStatus::ScheduledForDeletion, OrganisationStatus::Archived],
+    'scheduled deletion to deleted' => [OrganisationStatus::ScheduledForDeletion, OrganisationStatus::Deleted],
+]);
+
+it('rejects every lifecycle transition outside the approved matrix', function (OrganisationStatus $from, OrganisationStatus $to) {
+    $organisation = Organisation::factory()->create([
+        'status' => $from,
+        'deletion_scheduled_for' => $from === OrganisationStatus::ScheduledForDeletion ? now()->subSecond() : null,
+    ]);
+
+    expect(fn () => app(TransitionOrganisationStatus::class)->handle(
+        $organisation,
+        $to,
+    ))->toThrow(ValidationException::class);
+
+    expect($organisation->fresh()->status)->toBe($from);
+})->with((function (): array {
+    $transitions = [];
+
+    foreach (OrganisationStatus::cases() as $from) {
+        foreach (OrganisationStatus::cases() as $to) {
+            if (! in_array($to, $from->allowedTransitions(), true)) {
+                $transitions["{$from->value} to {$to->value}"] = [$from, $to];
+            }
+        }
+    }
+
+    return $transitions;
+})());
+
+it('schedules deletion with a 30 day recovery period before purging', function () {
+    $this->travelTo(now()->startOfSecond());
+
+    $owner = User::factory()->create();
+    $organisation = $owner->currentOrganisation;
+    app(TransitionOrganisationStatus::class)->handle($organisation, OrganisationStatus::Archived, $owner);
+
+    $this
+        ->actingAs($owner)
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->delete(route('organisations.destroy', $organisation), ['name' => $organisation->name])
+        ->assertRedirect(route('organisations.edit', $organisation));
+
+    expect($organisation->fresh()->status)->toBe(OrganisationStatus::ScheduledForDeletion)
+        ->and($organisation->fresh()->deletion_scheduled_for->equalTo(now()->addDays(30)))->toBeTrue()
+        ->and($owner->fresh()->current_organisation_id)->toBeNull();
+
+    $this->artisan('organisations:purge-scheduled')->assertSuccessful();
+    $this->assertNotSoftDeleted($organisation);
+
+    $this->travel(30)->days();
+    $this->artisan('organisations:purge-scheduled')->assertSuccessful();
+
+    $this->assertSoftDeleted($organisation);
+    expect(Organisation::withTrashed()->findOrFail($organisation->id)->status)->toBe(OrganisationStatus::Deleted)
+        ->and($owner->fresh()->current_organisation_id)->toBeNull();
+    $this->assertDatabaseHas('organisation_slugs', [
+        'organisation_id' => $organisation->id,
+        'slug' => $organisation->slug,
+    ]);
+});
+
+it('lets an owner recover a scheduled organisation before the deadline', function () {
+    $owner = User::factory()->create();
+    $organisation = $owner->currentOrganisation;
+    app(TransitionOrganisationStatus::class)->handle($organisation, OrganisationStatus::Archived, $owner);
+    app(TransitionOrganisationStatus::class)->handle($organisation, OrganisationStatus::ScheduledForDeletion, $owner);
+
+    $this
+        ->actingAs($owner)
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->patch(route('organisations.lifecycle.update', $organisation), [
+            'status' => OrganisationStatus::Archived->value,
+        ])
+        ->assertRedirect(route('organisations.edit', $organisation));
+
+    expect($organisation->fresh()->status)->toBe(OrganisationStatus::Archived)
+        ->and($organisation->fresh()->deletion_scheduled_for)->toBeNull();
+});
+
+it('blocks ordinary work while an organisation is not active', function (OrganisationStatus $status) {
+    $user = User::factory()->create();
+    $organisation = $user->currentOrganisation;
+    $organisation->update(['status' => $status]);
+
+    $this
+        ->actingAs($user)
+        ->get(route('dashboard', $organisation))
+        ->assertForbidden();
+
+    $editResponse = $this
+        ->actingAs($user)
+        ->get(route('organisations.edit', $organisation));
+
+    $editResponse->assertOk();
+
+    if ($status !== OrganisationStatus::Pending) {
+        $editResponse->assertInertia(fn (Assert $page) => $page
+            ->where('permissions.canUpdateOrganisation', false)
+            ->where('permissions.canTransitionOrganisation', true));
+    }
+})->with([
+    OrganisationStatus::Pending,
+    OrganisationStatus::Archived,
+    OrganisationStatus::ScheduledForDeletion,
+]);
+
+test('example', function () {
+    $response = $this->get('/');
+
+    $response->assertStatus(200);
+});

--- a/tests/Feature/OrganisationOwnershipTransferTest.php
+++ b/tests/Feature/OrganisationOwnershipTransferTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use App\Enums\OrganisationLifecycleEventType;
+use App\Enums\OrganisationOwnershipTransferStatus;
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\OrganisationOwnershipTransfer;
+use App\Models\User;
+
+it('requires explicit acceptance before transferring the sole ownership', function () {
+    $owner = User::factory()->create();
+    $nominee = User::factory()->create();
+    $organisation = $owner->currentOrganisation;
+    $organisation->memberships()->create([
+        'user_id' => $nominee->id,
+        'role' => OrganisationRole::OrganisationAdministrator,
+    ]);
+
+    $this
+        ->actingAs($owner)
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->post(route('organisations.ownership-transfers.store', $organisation), [
+            'nominee_user_id' => $nominee->id,
+        ])
+        ->assertRedirect(route('organisations.edit', $organisation));
+
+    $transfer = OrganisationOwnershipTransfer::query()->sole();
+    expect($transfer->status)->toBe(OrganisationOwnershipTransferStatus::Pending)
+        ->and($owner->fresh()->ownsOrganisation($organisation))->toBeTrue()
+        ->and($nominee->fresh()->ownsOrganisation($organisation))->toBeFalse();
+
+    $this
+        ->actingAs($nominee)
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->patch(route('organisations.ownership-transfers.update', [$organisation, $transfer]))
+        ->assertRedirect(route('organisations.edit', $organisation));
+
+    expect($transfer->fresh()->status)->toBe(OrganisationOwnershipTransferStatus::Accepted)
+        ->and($owner->fresh()->ownsOrganisation($organisation))->toBeFalse()
+        ->and($nominee->fresh()->ownsOrganisation($organisation))->toBeTrue();
+    $this->assertDatabaseHas('organisation_lifecycle_events', [
+        'organisation_id' => $organisation->id,
+        'type' => OrganisationLifecycleEventType::OwnershipTransferAccepted->value,
+        'actor_user_id' => $nominee->id,
+    ]);
+});
+
+it('does not let another member accept a transfer', function () {
+    $owner = User::factory()->create();
+    $nominee = User::factory()->create();
+    $otherMember = User::factory()->create();
+    $organisation = $owner->currentOrganisation;
+    $organisation->members()->attach($nominee);
+    $organisation->members()->attach($otherMember);
+    $transfer = OrganisationOwnershipTransfer::factory()->for($organisation)->create([
+        'nominated_by_user_id' => $owner->id,
+        'nominee_user_id' => $nominee->id,
+    ]);
+
+    $this
+        ->actingAs($otherMember)
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->patch(route('organisations.ownership-transfers.update', [$organisation, $transfer]))
+        ->assertForbidden();
+
+    expect($transfer->fresh()->status)->toBe(OrganisationOwnershipTransferStatus::Pending)
+        ->and($owner->fresh()->ownsOrganisation($organisation))->toBeTrue();
+});
+
+it('rejects acceptance after the nomination expires', function () {
+    $owner = User::factory()->create();
+    $nominee = User::factory()->create();
+    $organisation = $owner->currentOrganisation;
+    $organisation->members()->attach($nominee);
+    $transfer = OrganisationOwnershipTransfer::factory()->for($organisation)->create([
+        'nominated_by_user_id' => $owner->id,
+        'nominee_user_id' => $nominee->id,
+        'expires_at' => now()->subSecond(),
+    ]);
+
+    $this
+        ->actingAs($nominee)
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->patch(route('organisations.ownership-transfers.update', [$organisation, $transfer]))
+        ->assertSessionHasErrors('transfer');
+
+    expect($owner->fresh()->ownsOrganisation($organisation))->toBeTrue()
+        ->and($nominee->fresh()->ownsOrganisation($organisation))->toBeFalse();
+});
+
+it('lets an owner leave when another owner remains', function () {
+    $firstOwner = User::factory()->create();
+    $secondOwner = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    $organisation->members()->attach($firstOwner, ['is_owner' => true]);
+    $organisation->members()->attach($secondOwner, ['is_owner' => true]);
+
+    $this
+        ->actingAs($firstOwner)
+        ->delete(route('organisations.leave', $organisation))
+        ->assertRedirect(route('organisations.index'));
+
+    expect($firstOwner->fresh()->belongsToOrganisation($organisation))->toBeFalse()
+        ->and($secondOwner->fresh()->ownsOrganisation($organisation))->toBeTrue();
+});
+
+it('lets an owner remove another owner only when an owner remains', function () {
+    $firstOwner = User::factory()->create();
+    $secondOwner = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    $organisation->members()->attach($firstOwner, ['is_owner' => true]);
+    $organisation->members()->attach($secondOwner, ['is_owner' => true]);
+
+    $this
+        ->actingAs($firstOwner)
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->delete(route('organisations.members.destroy', [$organisation, $secondOwner]))
+        ->assertRedirect(route('organisations.edit', $organisation));
+
+    expect($secondOwner->fresh()->belongsToOrganisation($organisation))->toBeFalse()
+        ->and($firstOwner->fresh()->ownsOrganisation($organisation))->toBeTrue();
+
+    $this
+        ->actingAs($firstOwner)
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->delete(route('organisations.members.destroy', [$organisation, $firstOwner]))
+        ->assertForbidden();
+});
+
+test('example', function () {
+    $response = $this->get('/');
+
+    $response->assertStatus(200);
+});

--- a/tests/Feature/OrganisationSlugTest.php
+++ b/tests/Feature/OrganisationSlugTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use App\Actions\Organisations\ChangeOrganisationSlug;
+use App\Enums\OrganisationLifecycleEventType;
+use App\Models\Organisation;
+use App\Models\User;
+
+it('keeps the organisation slug stable when its display name changes', function () {
+    $owner = User::factory()->create();
+    $organisation = $owner->currentOrganisation;
+    $originalSlug = $organisation->slug;
+
+    $this
+        ->actingAs($owner)
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->patch(route('organisations.update', $organisation), ['name' => 'A completely new name'])
+        ->assertRedirect(route('organisations.edit', $organisation));
+
+    expect($organisation->fresh()->slug)->toBe($originalSlug);
+});
+
+it('changes a slug explicitly and reserves the previous slug', function () {
+    $this->travelTo(now()->startOfSecond());
+
+    $owner = User::factory()->create();
+    $organisation = $owner->currentOrganisation;
+    $oldSlug = $organisation->slug;
+    $originalVersion = $organisation->fresh()->access_version;
+
+    $this
+        ->actingAs($owner)
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->patch(route('organisations.slug.update', $organisation), ['slug' => 'new-community-name'])
+        ->assertRedirect(route('organisations.edit', $organisation->fresh()));
+
+    expect($organisation->fresh()->slug)->toBe('new-community-name')
+        ->and($organisation->fresh()->access_version)->toBe($originalVersion + 1);
+    $this->assertDatabaseHas('organisation_slugs', [
+        'organisation_id' => $organisation->id,
+        'slug' => $oldSlug,
+        'redirect_until' => now()->addDays(30),
+        'quarantined_until' => now()->addDays(120),
+    ]);
+    $this->assertDatabaseHas('organisation_lifecycle_events', [
+        'organisation_id' => $organisation->id,
+        'type' => OrganisationLifecycleEventType::SlugChanged->value,
+    ]);
+
+    $this
+        ->actingAs($owner)
+        ->get("/settings/organisations/{$oldSlug}?tab=members")
+        ->assertRedirect('/settings/organisations/new-community-name?tab=members');
+    $this
+        ->actingAs($owner)
+        ->get("/{$oldSlug}/dashboard")
+        ->assertRedirect('/new-community-name/dashboard');
+
+    $otherOwner = User::factory()->create();
+    $this
+        ->actingAs($otherOwner)
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->patch(route('organisations.slug.update', $otherOwner->currentOrganisation), ['slug' => $oldSlug])
+        ->assertSessionHasErrors('slug');
+});
+
+it('releases a quarantined slug after its reservation expires', function () {
+    $firstOwner = User::factory()->create();
+    $firstOrganisation = $firstOwner->currentOrganisation;
+    $oldSlug = $firstOrganisation->slug;
+
+    $this
+        ->actingAs($firstOwner)
+        ->withSession(['auth.password_confirmed_at' => now()->timestamp])
+        ->patch(route('organisations.slug.update', $firstOrganisation), ['slug' => 'replacement-slug']);
+
+    $this->travel(121)->days();
+    $secondOwner = User::factory()->create();
+
+    app(ChangeOrganisationSlug::class)->handle($secondOwner->currentOrganisation, $oldSlug, $secondOwner);
+
+    expect($secondOwner->currentOrganisation->fresh()->slug)->toBe($oldSlug);
+});
+
+it('does not assign a quarantined slug when creating an organisation', function () {
+    $owner = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create([
+        'name' => 'Old Community',
+        'slug' => 'old-community',
+    ]);
+    $organisation->members()->attach($owner, ['is_owner' => true]);
+    app(ChangeOrganisationSlug::class)->handle($organisation, 'replacement-community', $owner);
+
+    $newOwner = User::factory()->create();
+    $this
+        ->actingAs($newOwner)
+        ->post(route('organisations.store'), ['name' => 'Old Community'])
+        ->assertRedirect();
+
+    $this->assertDatabaseHas('organisations', [
+        'name' => 'Old Community',
+        'slug' => 'old-community-1',
+    ]);
+});
+
+it('does not redirect a previous slug after its organisation is deleted', function () {
+    $owner = User::factory()->create();
+    $organisation = $owner->currentOrganisation;
+    $oldSlug = $organisation->slug;
+    app(ChangeOrganisationSlug::class)->handle($organisation, 'new-deleted-community', $owner);
+    $organisation->delete();
+
+    $this
+        ->actingAs($owner)
+        ->get("/settings/organisations/{$oldSlug}")
+        ->assertNotFound();
+});
+
+test('example', function () {
+    $response = $this->get('/');
+
+    $response->assertStatus(200);
+});

--- a/tests/Feature/Organisations/OrganisationTest.php
+++ b/tests/Feature/Organisations/OrganisationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\Organisations;
 
 use App\Enums\OrganisationRole;
+use App\Enums\OrganisationStatus;
 use App\Http\Middleware\EnsureRecentMfa;
 use App\Http\Middleware\EnsureRecentPassword;
 use App\Http\Middleware\EnsureStaffSecurityRequirements;
@@ -135,7 +136,7 @@ class OrganisationTest extends TestCase
     public function test_the_organisation_edit_page_can_be_rendered()
     {
         $user = User::factory()->create();
-        $organisation = Organisation::factory()->create();
+        $organisation = Organisation::factory()->active()->create();
 
         $organisation->members()->attach($user, ['is_owner' => true]);
 
@@ -207,9 +208,8 @@ class OrganisationTest extends TestCase
 
         $response->assertRedirect();
 
-        $this->assertSoftDeleted('organisations', [
-            'id' => $organisation->id,
-        ]);
+        $this->assertNotSoftDeleted($organisation);
+        $this->assertSame(OrganisationStatus::ScheduledForDeletion, $organisation->fresh()->status);
     }
 
     public function test_organisation_deletion_requires_name_confirmation()
@@ -256,9 +256,8 @@ class OrganisationTest extends TestCase
 
         $response->assertRedirect();
 
-        $this->assertSoftDeleted('organisations', [
-            'id' => $zuluOrganisation->id,
-        ]);
+        $this->assertNotSoftDeleted($zuluOrganisation);
+        $this->assertSame(OrganisationStatus::ScheduledForDeletion, $zuluOrganisation->fresh()->status);
 
         $this->assertEquals($alphaOrganisation->id, $user->fresh()->current_organisation_id);
     }
@@ -280,9 +279,8 @@ class OrganisationTest extends TestCase
 
         $response->assertRedirect();
 
-        $this->assertSoftDeleted('organisations', [
-            'id' => $organisation->id,
-        ]);
+        $this->assertNotSoftDeleted($organisation);
+        $this->assertSame(OrganisationStatus::ScheduledForDeletion, $organisation->fresh()->status);
 
         $this->assertEquals($remainingOrganisation->id, $user->fresh()->current_organisation_id);
     }
@@ -304,9 +302,8 @@ class OrganisationTest extends TestCase
 
         $response->assertRedirect();
 
-        $this->assertSoftDeleted('organisations', [
-            'id' => $organisation->id,
-        ]);
+        $this->assertNotSoftDeleted($organisation);
+        $this->assertSame(OrganisationStatus::ScheduledForDeletion, $organisation->fresh()->status);
 
         $this->assertEquals($currentOrganisation->id, $user->fresh()->current_organisation_id);
     }
@@ -430,7 +427,7 @@ class OrganisationTest extends TestCase
     public function test_users_can_switch_organisations()
     {
         $user = User::factory()->create();
-        $organisation = Organisation::factory()->create();
+        $organisation = Organisation::factory()->active()->create();
 
         $organisation->members()->attach($user, ['role' => OrganisationRole::CaseWorker->value]);
 
@@ -453,6 +450,20 @@ class OrganisationTest extends TestCase
             ->post(route('organisations.switch', $organisation));
 
         $response->assertForbidden();
+    }
+
+    public function test_users_cannot_switch_to_an_inactive_organisation()
+    {
+        $user = User::factory()->create();
+        $organisation = Organisation::factory()->archived()->create();
+        $organisation->members()->attach($user, ['role' => OrganisationRole::CaseWorker->value]);
+
+        $this
+            ->actingAs($user)
+            ->post(route('organisations.switch', $organisation))
+            ->assertForbidden();
+
+        $this->assertNotEquals($organisation->id, $user->fresh()->current_organisation_id);
     }
 
     public function test_guests_cannot_access_organisations()


### PR DESCRIPTION
Closes #4

## Summary

- enforce the approved Organisation lifecycle and scope-aware Access Hold restrictions
- add audited ownership nomination/acceptance with recent-auth protection and transactional last-owner safeguards
- add 30-day deletion recovery, scheduled purge, access invalidation, stable explicit slugs, redirects, and quarantine
- expose lifecycle, hold, slug, deletion, and ownership controls in Organisation settings
- align the M0 milestone and public-host issue terminology with the approved Organisation model

## Verification

- `vendor/bin/pint --dirty --format agent`
- `npm run check`
- `npm run types:check`
- `npm run build`
- `vendor/bin/phpstan analyse --no-progress`
- `php artisan test --compact` (175 tests, 660 assertions)
- rollback and reapply all five new migrations
- reviewed the complete diff against `origin/main`; fixed all findings before push
