### PR TITLE
Enforce Organisation tenant context

### DIFF
--- a/app/Actions/Programs/BuildProgramReport.php
+++ b/app/Actions/Programs/BuildProgramReport.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Actions\Programs;
+
+use App\Actions\Organisations\RecordOrganisationLifecycleEvent;
+use App\Actions\Organisations\ResolveOrganisationAccess;
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Enums\OrganisationLifecycleEventType;
+use App\Models\Program;
+use App\OrganisationCache;
+use App\OrganisationContext;
+use LogicException;
+
+class BuildProgramReport
+{
+    public function __construct(
+        private OrganisationContext $organisationContext,
+        private OrganisationCache $organisationCache,
+        private RecordOrganisationLifecycleEvent $recordOrganisationLifecycleEvent,
+        private ResolveOrganisationAccess $resolveOrganisationAccess,
+    ) {}
+
+    /** @return array{organisation_id: int, program_count: int, program_names: array<int, string>} */
+    public function handle(): array
+    {
+        $organisation = $this->organisationContext->organisation();
+
+        if ($this->resolveOrganisationAccess->handle($organisation, OrganisationAccessScope::Reports)->rank() > OrganisationAccessLevel::ReadOnly->rank()) {
+            throw new LogicException('The Organisation context cannot report on tenant data.');
+        }
+
+        $report = $this->organisationCache->remember('reports:programs', 300, fn (): array => [
+            'organisation_id' => $organisation->id,
+            'program_count' => Program::query()->count(),
+            'program_names' => Program::query()->orderBy('name')->pluck('name')->all(),
+        ]);
+
+        $this->recordOrganisationLifecycleEvent->handle(
+            $organisation,
+            OrganisationLifecycleEventType::ProgramReportGenerated,
+            metadata: ['program_count' => $report['program_count']],
+        );
+
+        return $report;
+    }
+}

--- a/app/Actions/Programs/ExportPrograms.php
+++ b/app/Actions/Programs/ExportPrograms.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Actions\Programs;
+
+use App\Actions\Organisations\RecordOrganisationLifecycleEvent;
+use App\Actions\Organisations\ResolveOrganisationAccess;
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Enums\OrganisationLifecycleEventType;
+use App\Models\Program;
+use App\OrganisationContext;
+use App\OrganisationStorage;
+use LogicException;
+
+class ExportPrograms
+{
+    public function __construct(
+        private OrganisationContext $organisationContext,
+        private OrganisationStorage $organisationStorage,
+        private RecordOrganisationLifecycleEvent $recordOrganisationLifecycleEvent,
+        private ResolveOrganisationAccess $resolveOrganisationAccess,
+    ) {}
+
+    public function handle(): string
+    {
+        $organisation = $this->organisationContext->organisation();
+
+        if ($this->resolveOrganisationAccess->handle($organisation, OrganisationAccessScope::Exports)->rank() > OrganisationAccessLevel::ReadOnly->rank()) {
+            throw new LogicException('The Organisation context cannot export tenant data.');
+        }
+
+        $stream = fopen('php://temp', 'r+');
+
+        if ($stream === false) {
+            throw new \RuntimeException('Unable to create the Program export.');
+        }
+
+        fputcsv($stream, ['id', 'name', 'slug']);
+        Program::query()->orderBy('id')->each(fn (Program $program) => fputcsv($stream, [
+            $program->id,
+            $program->name,
+            $program->slug,
+        ]));
+        rewind($stream);
+        $contents = stream_get_contents($stream);
+        fclose($stream);
+
+        if ($contents === false) {
+            throw new \RuntimeException('Unable to read the Program export.');
+        }
+
+        $path = $this->organisationStorage->put('exports/programs.csv', $contents);
+        $this->recordOrganisationLifecycleEvent->handle(
+            $organisation,
+            OrganisationLifecycleEventType::ProgramExportGenerated,
+            metadata: ['path' => $path],
+        );
+
+        return $path;
+    }
+}

--- a/app/Actions/Programs/SearchPrograms.php
+++ b/app/Actions/Programs/SearchPrograms.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Actions\Programs;
+
+use App\Actions\Organisations\ResolveOrganisationAccess;
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Models\Program;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Collection;
+use LogicException;
+
+class SearchPrograms
+{
+    public function __construct(
+        private OrganisationContext $organisationContext,
+        private ResolveOrganisationAccess $resolveOrganisationAccess,
+    ) {}
+
+    /** @return Collection<int, Program> */
+    public function handle(string $query): Collection
+    {
+        $organisation = $this->organisationContext->organisation();
+
+        if ($this->resolveOrganisationAccess->handle($organisation, OrganisationAccessScope::Search)->rank() > OrganisationAccessLevel::ReadOnly->rank()) {
+            throw new LogicException('The Organisation context cannot search tenant data.');
+        }
+
+        return Program::search($query)
+            ->where('organisation_id', $organisation->id)
+            ->get();
+    }
+}

--- a/app/Concerns/BelongsToOrganisation.php
+++ b/app/Concerns/BelongsToOrganisation.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Concerns;
+
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use LogicException;
+
+trait BelongsToOrganisation
+{
+    public static function bootBelongsToOrganisation(): void
+    {
+        static::addGlobalScope('organisation', function (Builder $builder): void {
+            $organisation = app(OrganisationContext::class)->organisation();
+
+            $builder->where(
+                $builder->getModel()->qualifyColumn('organisation_id'),
+                $organisation->id,
+            );
+        });
+
+        static::creating(function (Model $model): void {
+            $organisationId = app(OrganisationContext::class)->id();
+
+            if ($model->getAttribute('organisation_id') === null) {
+                $model->setAttribute('organisation_id', $organisationId);
+            }
+
+            app(OrganisationContext::class)->ensureOwns((int) $model->getAttribute('organisation_id'));
+        });
+
+        static::saving(function (Model $model): void {
+            if ($model->exists && $model->isDirty('organisation_id')) {
+                throw new LogicException('Organisation ownership is immutable.');
+            }
+
+            if ($model->exists) {
+                app(OrganisationContext::class)->ensureOwns((int) $model->getOriginal('organisation_id'));
+            }
+        });
+
+        static::deleting(function (Model $model): void {
+            app(OrganisationContext::class)->ensureOwns((int) $model->getAttribute('organisation_id'));
+        });
+    }
+}

--- a/app/Concerns/HasOrganisations.php
+++ b/app/Concerns/HasOrganisations.php
@@ -10,6 +10,7 @@ use App\Enums\OrganisationStatus;
 use App\Models\Membership;
 use App\Models\Organisation;
 use App\Models\Program;
+use App\OrganisationContext;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -152,10 +153,15 @@ trait HasOrganisations
     public function toUserOrganisations(bool $includeCurrent = false): Collection
     {
         return $this->organisationMemberships()
-            ->with(['organisation', 'programs'])
+            ->with('organisation')
             ->get()
             ->map(function (Membership $membership) use ($includeCurrent) {
                 $organisation = $membership->organisation;
+
+                app(OrganisationContext::class)->run(
+                    $organisation,
+                    fn () => $membership->load('programs'),
+                );
 
                 return ! $includeCurrent && $this->isCurrentOrganisation($organisation)
                     ? null

--- a/app/Console/Commands/ReportOrganisationPrograms.php
+++ b/app/Console/Commands/ReportOrganisationPrograms.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Organisations\ResolveOrganisationAccess;
+use App\Actions\Programs\BuildProgramReport;
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Models\Organisation;
+use App\OrganisationContext;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+#[Signature('organisations:program-report {organisation : Organisation slug}')]
+#[Description('Generate the scoped Program report for one Organisation')]
+class ReportOrganisationPrograms extends Command
+{
+    /**
+     * Execute the console command.
+     */
+    public function handle(
+        OrganisationContext $organisationContext,
+        ResolveOrganisationAccess $resolveOrganisationAccess,
+        BuildProgramReport $buildProgramReport,
+    ): int {
+        $organisation = Organisation::query()->where('slug', $this->argument('organisation'))->first();
+
+        if ($organisation === null) {
+            $this->error('Organisation not found.');
+
+            return self::FAILURE;
+        }
+
+        if ($resolveOrganisationAccess->handle($organisation, OrganisationAccessScope::Commands) !== OrganisationAccessLevel::Full) {
+            $this->error('Organisation commands are unavailable for this Organisation.');
+
+            return self::FAILURE;
+        }
+
+        $report = $organisationContext->run($organisation, fn (): array => $buildProgramReport->handle());
+        $this->line((string) json_encode($report, JSON_THROW_ON_ERROR));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Enums/OrganisationAccessScope.php
+++ b/app/Enums/OrganisationAccessScope.php
@@ -11,5 +11,10 @@ enum OrganisationAccessScope: string
     case Forms = 'forms';
     case Cache = 'cache';
     case Search = 'search';
+    case Files = 'files';
+    case Exports = 'exports';
+    case Reports = 'reports';
+    case Commands = 'commands';
+    case Audits = 'audits';
     case SignedLinks = 'signed_links';
 }

--- a/app/Enums/OrganisationLifecycleEventType.php
+++ b/app/Enums/OrganisationLifecycleEventType.php
@@ -11,4 +11,7 @@ enum OrganisationLifecycleEventType: string
     case OwnershipTransferAccepted = 'ownership_transfer_accepted';
     case OwnershipTransferCancelled = 'ownership_transfer_cancelled';
     case SlugChanged = 'slug_changed';
+    case ProgramSearchRebuilt = 'program_search_rebuilt';
+    case ProgramReportGenerated = 'program_report_generated';
+    case ProgramExportGenerated = 'program_export_generated';
 }

--- a/app/Http/Controllers/Organisations/ProgramController.php
+++ b/app/Http/Controllers/Organisations/ProgramController.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Programs\BuildProgramReport;
+use App\Actions\Programs\ExportPrograms;
+use App\Actions\Programs\SearchPrograms;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\UpdateProgramRequest;
+use App\Models\Organisation;
+use App\Models\Program;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ProgramController extends Controller
+{
+    public function show(Organisation $organisation, string $program): JsonResponse
+    {
+        $program = $this->findProgram($program);
+        Gate::authorize('view', $program);
+
+        return response()->json($program->only(['id', 'organisation_id', 'name', 'slug']));
+    }
+
+    public function update(UpdateProgramRequest $request, Organisation $organisation, string $program): JsonResponse
+    {
+        $program = $this->findProgram($program);
+        Gate::authorize('update', $program);
+        $program->update($request->validated());
+
+        return response()->json($program->only(['id', 'organisation_id', 'name', 'slug']));
+    }
+
+    public function search(Request $request, Organisation $organisation, SearchPrograms $searchPrograms): JsonResponse
+    {
+        $request->validate(['query' => ['required', 'string', 'max:100']]);
+        Gate::authorize('viewAny', [Program::class, $organisation]);
+
+        return response()->json($searchPrograms->handle($request->string('query')->toString()));
+    }
+
+    public function report(Organisation $organisation, BuildProgramReport $buildProgramReport): JsonResponse
+    {
+        Gate::authorize('viewAny', [Program::class, $organisation]);
+
+        return response()->json($buildProgramReport->handle());
+    }
+
+    public function export(Organisation $organisation, ExportPrograms $exportPrograms): StreamedResponse
+    {
+        Gate::authorize('viewAny', [Program::class, $organisation]);
+
+        return Storage::download($exportPrograms->handle());
+    }
+
+    private function findProgram(string $identifier): Program
+    {
+        return ctype_digit($identifier)
+            ? Program::query()->findOrFail((int) $identifier)
+            : Program::query()->where('slug', $identifier)->firstOrFail();
+    }
+}

--- a/app/Http/Middleware/UseOrganisationContext.php
+++ b/app/Http/Middleware/UseOrganisationContext.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Organisation;
+use App\OrganisationContext;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class UseOrganisationContext
+{
+    public function __construct(private OrganisationContext $organisationContext) {}
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $organisation = $request->route('current_organisation') ?? $request->route('organisation');
+
+        abort_unless($organisation instanceof Organisation, 404);
+
+        return $this->organisationContext->run($organisation, fn (): Response => $next($request));
+    }
+}

--- a/app/Http/Requests/Organisations/UpdateProgramRequest.php
+++ b/app/Http/Requests/Organisations/UpdateProgramRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Models\Organisation;
+use App\Models\Program;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateProgramRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $organisation = $this->route('organisation');
+        $identifier = (string) $this->route('program');
+        $program = ctype_digit($identifier)
+            ? Program::query()->find((int) $identifier)
+            : Program::query()->where('slug', $identifier)->first();
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'required',
+                'string',
+                'max:63',
+                'regex:/^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/',
+                Rule::unique('programs', 'slug')
+                    ->where('organisation_id', $organisation instanceof Organisation ? $organisation->id : 0)
+                    ->ignore($program?->id),
+            ],
+        ];
+    }
+}

--- a/app/Jobs/RebuildProgramSearchDocument.php
+++ b/app/Jobs/RebuildProgramSearchDocument.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Actions\Organisations\RecordOrganisationLifecycleEvent;
+use App\Actions\Organisations\ResolveOrganisationAccess;
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Enums\OrganisationLifecycleEventType;
+use App\Models\Organisation;
+use App\Models\Program;
+use App\OrganisationContext;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use LogicException;
+
+class RebuildProgramSearchDocument implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public int $tries = 1;
+
+    public function __construct(Program $program)
+    {
+        $context = app(OrganisationContext::class);
+        $context->ensureOwns($program->organisation_id);
+        $organisation = $context->organisation();
+
+        $this->organisationId = $organisation->id;
+        $this->accessVersion = $organisation->access_version;
+        $this->programId = $program->id;
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(
+        OrganisationContext $organisationContext,
+        ResolveOrganisationAccess $resolveOrganisationAccess,
+        RecordOrganisationLifecycleEvent $recordOrganisationLifecycleEvent,
+    ): void {
+        $organisation = Organisation::query()->find($this->organisationId);
+
+        if ($organisation === null || $organisation->access_version !== $this->accessVersion) {
+            throw new LogicException('The queued Organisation context is stale or unavailable.');
+        }
+
+        if ($resolveOrganisationAccess->handle($organisation, OrganisationAccessScope::Jobs) !== OrganisationAccessLevel::Full) {
+            throw new LogicException('The Organisation context cannot run tenant jobs.');
+        }
+
+        $organisationContext->run($organisation, function () use ($recordOrganisationLifecycleEvent, $organisation): void {
+            $program = Program::query()->findOrFail($this->programId);
+            $program->searchable();
+            $recordOrganisationLifecycleEvent->handle(
+                $organisation,
+                OrganisationLifecycleEventType::ProgramSearchRebuilt,
+                metadata: ['program_id' => $program->id],
+            );
+        });
+    }
+
+    public int $organisationId;
+
+    public int $accessVersion;
+
+    public int $programId;
+}

--- a/app/Models/Membership.php
+++ b/app/Models/Membership.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\OrganisationRole;
+use App\OrganisationContext;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -64,7 +65,8 @@ class Membership extends Pivot
      */
     public function programs(): BelongsToMany
     {
-        return $this->belongsToMany(Program::class, 'membership_program', 'membership_id', 'program_id');
+        return $this->belongsToMany(Program::class, 'membership_program', 'membership_id', 'program_id')
+            ->withPivotValue('organisation_id', app(OrganisationContext::class)->id());
     }
 
     /**

--- a/app/Models/Program.php
+++ b/app/Models/Program.php
@@ -2,12 +2,16 @@
 
 namespace App\Models;
 
+use App\Concerns\BelongsToOrganisation;
+use App\OrganisationContext;
 use Database\Factories\ProgramFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Laravel\Scout\Searchable;
 
 /**
  * @property int $id
@@ -20,7 +24,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 class Program extends Model
 {
     /** @use HasFactory<ProgramFactory> */
-    use HasFactory;
+    use BelongsToOrganisation, HasFactory, Searchable, SoftDeletes;
 
     /**
      * Get the Organisation that owns the program.
@@ -39,6 +43,18 @@ class Program extends Model
      */
     public function memberships(): BelongsToMany
     {
-        return $this->belongsToMany(Membership::class, 'membership_program', 'program_id', 'membership_id');
+        return $this->belongsToMany(Membership::class, 'membership_program', 'program_id', 'membership_id')
+            ->withPivotValue('organisation_id', app(OrganisationContext::class)->id());
+    }
+
+    /** @return array<string, int|string> */
+    public function toSearchableArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'organisation_id' => $this->organisation_id,
+            'name' => $this->name,
+            'slug' => $this->slug,
+        ];
     }
 }

--- a/app/OrganisationCache.php
+++ b/app/OrganisationCache.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App;
+
+use App\Actions\Organisations\ResolveOrganisationAccess;
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use Closure;
+use Illuminate\Support\Facades\Cache;
+use LogicException;
+
+class OrganisationCache
+{
+    public function __construct(
+        private OrganisationContext $organisationContext,
+        private ResolveOrganisationAccess $resolveOrganisationAccess,
+    ) {}
+
+    public function key(string $key): string
+    {
+        $organisation = $this->organisationContext->organisation();
+
+        if ($this->resolveOrganisationAccess->handle($organisation, OrganisationAccessScope::Cache)->rank() > OrganisationAccessLevel::ReadOnly->rank()) {
+            throw new LogicException('The Organisation context cannot access cached tenant data.');
+        }
+
+        return "organisation:{$organisation->id}:v{$organisation->access_version}:{$key}";
+    }
+
+    /**
+     * @template TValue
+     *
+     * @param  Closure(): TValue  $callback
+     * @return TValue
+     */
+    public function remember(string $key, int $seconds, Closure $callback): mixed
+    {
+        return Cache::remember($this->key($key), $seconds, $callback);
+    }
+}

--- a/app/OrganisationContext.php
+++ b/app/OrganisationContext.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App;
+
+use App\Models\Organisation;
+use Closure;
+use Illuminate\Support\Facades\Context;
+use LogicException;
+
+class OrganisationContext
+{
+    private const ID = 'organisation_id';
+
+    private const ACCESS_VERSION = 'organisation_access_version';
+
+    public function id(): int
+    {
+        $id = Context::get(self::ID);
+
+        if (! is_int($id)) {
+            throw new LogicException('An Organisation context is required.');
+        }
+
+        return $id;
+    }
+
+    public function organisation(): Organisation
+    {
+        $organisation = Organisation::query()->find($this->id());
+        $accessVersion = Context::getHidden(self::ACCESS_VERSION);
+
+        if ($organisation === null || ! is_int($accessVersion) || $organisation->access_version !== $accessVersion) {
+            throw new LogicException('The Organisation context is stale or unavailable.');
+        }
+
+        return $organisation;
+    }
+
+    public function ensureOwns(int $organisationId): void
+    {
+        if ($this->organisation()->id !== $organisationId) {
+            throw new LogicException('The record does not belong to the current Organisation context.');
+        }
+    }
+
+    public function run(Organisation $organisation, Closure $callback): mixed
+    {
+        $organisation = Organisation::query()->find($organisation->id);
+
+        if ($organisation === null) {
+            throw new LogicException('The Organisation context is unavailable.');
+        }
+
+        return Context::scope(
+            $callback,
+            [self::ID => $organisation->id],
+            [self::ACCESS_VERSION => $organisation->access_version],
+        );
+    }
+
+    public function each(Closure $callback): void
+    {
+        Organisation::query()->lazyById()->each(
+            fn (Organisation $organisation) => $this->run(
+                $organisation,
+                fn () => $callback($organisation),
+            ),
+        );
+    }
+}

--- a/app/OrganisationStorage.php
+++ b/app/OrganisationStorage.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App;
+
+use App\Actions\Organisations\ResolveOrganisationAccess;
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use Illuminate\Support\Facades\Storage;
+use InvalidArgumentException;
+use LogicException;
+use RuntimeException;
+
+class OrganisationStorage
+{
+    public function __construct(
+        private OrganisationContext $organisationContext,
+        private ResolveOrganisationAccess $resolveOrganisationAccess,
+    ) {}
+
+    public function path(string $path): string
+    {
+        if ($path === '' || str_starts_with($path, '/') || str_contains($path, '..')) {
+            throw new InvalidArgumentException('Organisation file paths must be relative and cannot traverse directories.');
+        }
+
+        return 'organisations/'.$this->organisationContext->organisation()->id.'/'.$path;
+    }
+
+    public function put(string $path, string $contents): string
+    {
+        $organisation = $this->organisationContext->organisation();
+
+        if ($this->resolveOrganisationAccess->handle($organisation, OrganisationAccessScope::Files) !== OrganisationAccessLevel::Full) {
+            throw new LogicException('The Organisation context cannot write tenant files.');
+        }
+
+        $path = $this->path($path);
+
+        if (! Storage::put($path, $contents)) {
+            throw new RuntimeException('Unable to write the Organisation file.');
+        }
+
+        return $path;
+    }
+}

--- a/app/Policies/ProgramPolicy.php
+++ b/app/Policies/ProgramPolicy.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\Program;
+use App\Models\User;
+
+class ProgramPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user, Organisation $organisation): bool
+    {
+        return $user->organisationRole($organisation) === OrganisationRole::OrganisationAdministrator;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Program $program): bool
+    {
+        $role = $user->organisationRole($program->organisation);
+
+        return $role === OrganisationRole::OrganisationAdministrator
+            || ($role !== null && $user->hasProgramAccess($program));
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Program $program): bool
+    {
+        $role = $user->organisationRole($program->organisation);
+
+        return $role === OrganisationRole::OrganisationAdministrator
+            || ($role === OrganisationRole::ProgramManager && $user->hasProgramAccess($program));
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Program $program): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Program $program): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Program $program): bool
+    {
+        return false;
+    }
+}

--- a/database/migrations/2026_08_30_163118_enforce_organisation_integrity_on_program_memberships.php
+++ b/database/migrations/2026_08_30_163118_enforce_organisation_integrity_on_program_memberships.php
@@ -1,0 +1,123 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('programs', function (Blueprint $table) {
+            $table->softDeletes();
+            $table->unique(['organisation_id', 'id'], 'programs_organisation_id_id_unique');
+        });
+
+        Schema::table('organisation_members', function (Blueprint $table) {
+            $table->unique(['organisation_id', 'id'], 'organisation_members_organisation_id_id_unique');
+        });
+
+        Schema::table('membership_program', function (Blueprint $table) {
+            $table->foreignId('organisation_id')->nullable()->after('id');
+        });
+
+        DB::table('membership_program')->update([
+            'organisation_id' => DB::table('programs')
+                ->select('organisation_id')
+                ->whereColumn('programs.id', 'membership_program.program_id')
+                ->limit(1),
+        ]);
+
+        Schema::table('membership_program', function (Blueprint $table) {
+            $table->foreignId('organisation_id')->nullable(false)->change();
+            $table->foreign('organisation_id', 'membership_program_organisation_foreign')
+                ->references('id')->on('organisations')->cascadeOnDelete();
+            $table->foreign(['organisation_id', 'membership_id'], 'membership_program_membership_tenant_foreign')
+                ->references(['organisation_id', 'id'])->on('organisation_members')->cascadeOnDelete();
+            $table->foreign(['organisation_id', 'program_id'], 'membership_program_program_tenant_foreign')
+                ->references(['organisation_id', 'id'])->on('programs')->cascadeOnDelete();
+        });
+
+        $this->preventProgramOwnershipChanges();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $this->allowProgramOwnershipChanges();
+
+        Schema::table('membership_program', function (Blueprint $table) {
+            $table->dropForeign('membership_program_membership_tenant_foreign');
+            $table->dropForeign('membership_program_program_tenant_foreign');
+            $table->dropForeign('membership_program_organisation_foreign');
+            $table->dropColumn('organisation_id');
+        });
+
+        Schema::table('organisation_members', function (Blueprint $table) {
+            $table->dropUnique('organisation_members_organisation_id_id_unique');
+        });
+
+        Schema::table('programs', function (Blueprint $table) {
+            $table->dropUnique('programs_organisation_id_id_unique');
+            $table->dropSoftDeletes();
+        });
+    }
+
+    private function preventProgramOwnershipChanges(): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                CREATE OR REPLACE FUNCTION prevent_program_organisation_change() RETURNS trigger AS $$
+                BEGIN
+                    IF NEW.organisation_id IS DISTINCT FROM OLD.organisation_id THEN
+                        RAISE EXCEPTION 'Program Organisation ownership is immutable.';
+                    END IF;
+
+                    RETURN NEW;
+                END;
+                $$ LANGUAGE plpgsql;
+
+                CREATE TRIGGER programs_organisation_id_immutable
+                    BEFORE UPDATE OF organisation_id ON programs
+                    FOR EACH ROW
+                    EXECUTE FUNCTION prevent_program_organisation_change();
+                SQL);
+
+            return;
+        }
+
+        if (DB::getDriverName() === 'sqlite') {
+            DB::unprepared(<<<'SQL'
+                CREATE TRIGGER programs_organisation_id_immutable
+                    BEFORE UPDATE OF organisation_id ON programs
+                    FOR EACH ROW
+                    WHEN NEW.organisation_id != OLD.organisation_id
+                BEGIN
+                    SELECT RAISE(ABORT, 'Program Organisation ownership is immutable.');
+                END;
+                SQL);
+        }
+    }
+
+    private function allowProgramOwnershipChanges(): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                DROP TRIGGER IF EXISTS programs_organisation_id_immutable ON programs;
+                DROP FUNCTION IF EXISTS prevent_program_organisation_change();
+                SQL);
+
+            return;
+        }
+
+        if (DB::getDriverName() === 'sqlite') {
+            DB::unprepared('DROP TRIGGER IF EXISTS programs_organisation_id_immutable');
+        }
+    }
+};

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Organisations\OrganisationLifecycleController;
 use App\Http\Controllers\Organisations\OrganisationMemberController;
 use App\Http\Controllers\Organisations\OrganisationOwnershipTransferController;
 use App\Http\Controllers\Organisations\OrganisationSlugController;
+use App\Http\Controllers\Organisations\ProgramController;
 use App\Http\Controllers\Settings\OtherBrowserSessionController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\RecoveryCodeAcknowledgementController;
@@ -16,6 +17,7 @@ use App\Http\Middleware\EnsureOrganisationMembership;
 use App\Http\Middleware\EnsureRecentMfa;
 use App\Http\Middleware\EnsureRecentPassword;
 use App\Http\Middleware\EnsureStaffSecurityRequirements;
+use App\Http\Middleware\UseOrganisationContext;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware(['auth'])->group(function () {
@@ -60,7 +62,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
             ->middleware([EnsureRecentPassword::class, EnsureRecentMfa::class])
             ->name('security.other-browser-sessions.destroy');
 
-        Route::middleware(EnsureOrganisationMembership::class)->group(function () {
+        Route::middleware([EnsureOrganisationMembership::class, UseOrganisationContext::class])->group(function () {
             Route::get('settings/organisations/{organisation}', [OrganisationController::class, 'edit'])->middleware(EnsureOrganisationAccess::class.':recovery')->name('organisations.edit');
             Route::patch('settings/organisations/{organisation}', [OrganisationController::class, 'update'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.update');
             Route::delete('settings/organisations/{organisation}', [OrganisationController::class, 'destroy'])->middleware([EnsureOrganisationAccess::class.':recovery', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.destroy');
@@ -77,6 +79,12 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
             Route::post('settings/organisations/{organisation}/invitations', [OrganisationInvitationController::class, 'store'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.invitations.store');
             Route::delete('settings/organisations/{organisation}/invitations/{invitation}', [OrganisationInvitationController::class, 'destroy'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.invitations.destroy');
+
+            Route::get('settings/organisations/{organisation}/programs/search', [ProgramController::class, 'search'])->middleware(EnsureOrganisationAccess::class)->name('organisations.programs.search');
+            Route::get('settings/organisations/{organisation}/programs/report', [ProgramController::class, 'report'])->middleware(EnsureOrganisationAccess::class)->name('organisations.programs.report');
+            Route::get('settings/organisations/{organisation}/programs/export', [ProgramController::class, 'export'])->middleware(EnsureOrganisationAccess::class)->name('organisations.programs.export');
+            Route::get('settings/organisations/{organisation}/programs/{program}', [ProgramController::class, 'show'])->middleware(EnsureOrganisationAccess::class)->name('organisations.programs.show');
+            Route::patch('settings/organisations/{organisation}/programs/{program}', [ProgramController::class, 'update'])->middleware(EnsureOrganisationAccess::class.':administration')->name('organisations.programs.update');
         });
     });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Organisations\OrganisationInvitationController;
 use App\Http\Middleware\EnsureOrganisationAccess;
 use App\Http\Middleware\EnsureOrganisationMembership;
 use App\Http\Middleware\EnsureStaffSecurityRequirements;
+use App\Http\Middleware\UseOrganisationContext;
 use App\Models\Organisation;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\Response;
@@ -25,7 +26,7 @@ Route::get('/source-and-licence/license', fn (): Response => response(
 ))->name('source-and-licence.license');
 
 Route::prefix('{current_organisation}')
-    ->middleware(['auth', 'verified', EnsureStaffSecurityRequirements::class, EnsureOrganisationMembership::class, EnsureOrganisationAccess::class.':full'])
+    ->middleware(['auth', 'verified', EnsureStaffSecurityRequirements::class, EnsureOrganisationMembership::class, UseOrganisationContext::class, EnsureOrganisationAccess::class.':full'])
     ->group(function () {
         Route::get('dashboard', DashboardController::class)->name('dashboard');
     });

--- a/tests/Feature/OrganisationAdministrationTest.php
+++ b/tests/Feature/OrganisationAdministrationTest.php
@@ -6,6 +6,7 @@ use App\Enums\OrganisationStatus;
 use App\Models\Organisation;
 use App\Models\Program;
 use App\Models\User;
+use App\OrganisationContext;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Schema;
 use Inertia\Testing\AssertableInertia as Assert;
@@ -45,8 +46,10 @@ it('assigns one operational role and program access independently of ownership',
     $owner = User::factory()->create();
     $member = User::factory()->create();
     $organisation = Organisation::factory()->create();
-    $housing = Program::factory()->for($organisation)->create(['name' => 'Housing']);
-    $food = Program::factory()->for($organisation)->create(['name' => 'Food']);
+    [$housing, $food] = app(OrganisationContext::class)->run($organisation, fn (): array => [
+        Program::factory()->for($organisation)->create(['name' => 'Housing']),
+        Program::factory()->for($organisation)->create(['name' => 'Food']),
+    ]);
 
     $organisation->memberships()->create([
         'user_id' => $owner->id,
@@ -67,12 +70,14 @@ it('assigns one operational role and program access independently of ownership',
         ]);
 
     $response->assertRedirect(route('organisations.edit', $organisation));
-    expect($owner->fresh()->ownsOrganisation($organisation))->toBeTrue()
-        ->and($owner->organisationRole($organisation))->toBeNull()
-        ->and($owner->hasProgramAccess($housing))->toBeFalse()
-        ->and($member->fresh()->organisationRole($organisation))->toBe(OrganisationRole::ProgramManager)
-        ->and($member->hasProgramAccess($housing))->toBeTrue()
-        ->and($member->hasProgramAccess($food))->toBeFalse();
+    app(OrganisationContext::class)->run($organisation, function () use ($owner, $member, $organisation, $housing, $food): void {
+        expect($owner->fresh()->ownsOrganisation($organisation))->toBeTrue()
+            ->and($owner->organisationRole($organisation))->toBeNull()
+            ->and($owner->hasProgramAccess($housing))->toBeFalse()
+            ->and($member->fresh()->organisationRole($organisation))->toBe(OrganisationRole::ProgramManager)
+            ->and($member->hasProgramAccess($housing))->toBeTrue()
+            ->and($member->hasProgramAccess($food))->toBeFalse();
+    });
 });
 
 it('lets organisation administrators manage member roles without granting ownership', function () {
@@ -106,7 +111,10 @@ it('rejects program access from another organisation without changing the member
     $member = User::factory()->create();
     $organisation = Organisation::factory()->create();
     $otherOrganisation = Organisation::factory()->create();
-    $otherProgram = Program::factory()->for($otherOrganisation)->create();
+    $otherProgram = app(OrganisationContext::class)->run(
+        $otherOrganisation,
+        fn (): Program => Program::factory()->for($otherOrganisation)->create(),
+    );
 
     $organisation->memberships()->create([
         'user_id' => $owner->id,
@@ -131,27 +139,41 @@ it('rejects program access from another organisation without changing the member
         ->assertSessionHasErrors([
             'program_ids.0' => 'The selected program is not available for this organisation.',
         ]);
-    expect($membership->fresh()->role)->toBe(OrganisationRole::CaseWorker)
-        ->and($membership->programs()->count())->toBe(0);
+    app(OrganisationContext::class)->run($organisation, function () use ($membership): void {
+        expect($membership->fresh()->role)->toBe(OrganisationRole::CaseWorker)
+            ->and($membership->programs()->count())->toBe(0);
+    });
 });
 
 it('switches to a fresh destination dashboard and recomputes organisation context', function () {
     $user = User::factory()->create();
     $firstOrganisation = Organisation::factory()->active()->create(['name' => 'HarbourKind']);
     $secondOrganisation = Organisation::factory()->active()->create(['name' => 'NeighbourLink']);
-    $firstProgram = Program::factory()->for($firstOrganisation)->create();
-    $secondProgram = Program::factory()->for($secondOrganisation)->create();
+    $firstProgram = app(OrganisationContext::class)->run(
+        $firstOrganisation,
+        fn (): Program => Program::factory()->for($firstOrganisation)->create(),
+    );
+    $secondProgram = app(OrganisationContext::class)->run(
+        $secondOrganisation,
+        fn (): Program => Program::factory()->for($secondOrganisation)->create(),
+    );
 
     $firstMembership = $firstOrganisation->memberships()->create([
         'user_id' => $user->id,
         'role' => OrganisationRole::ProgramManager,
     ]);
-    $firstMembership->programs()->attach($firstProgram);
+    app(OrganisationContext::class)->run(
+        $firstOrganisation,
+        fn () => $firstMembership->programs()->attach($firstProgram),
+    );
     $secondMembership = $secondOrganisation->memberships()->create([
         'user_id' => $user->id,
         'role' => OrganisationRole::ExecutiveViewer,
     ]);
-    $secondMembership->programs()->attach($secondProgram);
+    app(OrganisationContext::class)->run(
+        $secondOrganisation,
+        fn () => $secondMembership->programs()->attach($secondProgram),
+    );
     $user->switchOrganisation($firstOrganisation);
 
     $response = $this

--- a/tests/Feature/OrganisationContextTest.php
+++ b/tests/Feature/OrganisationContextTest.php
@@ -1,0 +1,113 @@
+<?php
+
+use App\Actions\Organisations\InvalidateOrganisationAccess;
+use App\Actions\Programs\BuildProgramReport;
+use App\Actions\Programs\ExportPrograms;
+use App\Actions\Programs\SearchPrograms;
+use App\Models\Organisation;
+use App\Models\Program;
+use App\OrganisationCache;
+use App\OrganisationContext;
+use App\OrganisationStorage;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+
+uses(RefreshDatabase::class);
+
+it('fails closed when tenant data is queried or created without an Organisation context', function () {
+    expect(fn () => Program::query()->count())->toThrow(LogicException::class)
+        ->and(fn () => Program::create(['name' => 'No context', 'slug' => 'no-context']))->toThrow(LogicException::class)
+        ->and(fn () => app(OrganisationCache::class)->key('programs'))->toThrow(LogicException::class)
+        ->and(fn () => app(OrganisationStorage::class)->path('exports/programs.csv'))->toThrow(LogicException::class)
+        ->and(fn () => app(SearchPrograms::class)->handle('Program'))->toThrow(LogicException::class)
+        ->and(fn () => app(BuildProgramReport::class)->handle())->toThrow(LogicException::class)
+        ->and(fn () => app(ExportPrograms::class)->handle())->toThrow(LogicException::class);
+});
+
+it('scopes reads and writes to one Organisation and makes ownership immutable', function () {
+    $firstOrganisation = Organisation::factory()->active()->create();
+    $secondOrganisation = Organisation::factory()->active()->create();
+    $context = app(OrganisationContext::class);
+
+    $firstProgram = $context->run($firstOrganisation, fn (): Program => Program::factory()->for($firstOrganisation)->create([
+        'name' => 'Shared name',
+        'slug' => 'shared-name',
+    ]));
+    $context->run($secondOrganisation, fn (): Program => Program::factory()->for($secondOrganisation)->create([
+        'name' => 'Shared name',
+        'slug' => 'shared-name',
+    ]));
+
+    $context->run($firstOrganisation, function () use ($firstProgram, $secondOrganisation): void {
+        expect(Program::query()->pluck('id')->all())->toBe([$firstProgram->id]);
+
+        $firstProgram->organisation_id = $secondOrganisation->id;
+
+        expect(fn () => $firstProgram->save())->toThrow(LogicException::class, 'immutable');
+    });
+});
+
+it('rejects mismatched ownership and stale contexts', function () {
+    $firstOrganisation = Organisation::factory()->active()->create();
+    $secondOrganisation = Organisation::factory()->active()->create();
+    $context = app(OrganisationContext::class);
+
+    $context->run($firstOrganisation, function () use ($context, $firstOrganisation, $secondOrganisation): void {
+        expect(fn () => Program::factory()->for($secondOrganisation)->create())
+            ->toThrow(LogicException::class, 'does not belong');
+
+        app(InvalidateOrganisationAccess::class)->handle($firstOrganisation);
+
+        expect(fn () => $context->organisation())->toThrow(LogicException::class, 'stale')
+            ->and(fn () => Program::query()->count())->toThrow(LogicException::class, 'stale')
+            ->and(fn () => app(OrganisationCache::class)->key('programs'))->toThrow(LogicException::class, 'stale')
+            ->and(fn () => app(OrganisationStorage::class)->path('exports/programs.csv'))->toThrow(LogicException::class, 'stale')
+            ->and(fn () => app(SearchPrograms::class)->handle('Program'))->toThrow(LogicException::class, 'stale')
+            ->and(fn () => app(BuildProgramReport::class)->handle())->toThrow(LogicException::class, 'stale')
+            ->and(fn () => app(ExportPrograms::class)->handle())->toThrow(LogicException::class, 'stale');
+    });
+});
+
+it('isolates each Organisation during tenant iteration and restores the empty context', function () {
+    $organisations = Organisation::factory()->count(2)->active()->create();
+    $context = app(OrganisationContext::class);
+
+    foreach ($organisations as $organisation) {
+        $context->run($organisation, fn (): Program => Program::factory()->for($organisation)->create());
+    }
+
+    $visited = [];
+    $context->each(function (Organisation $organisation) use (&$visited): void {
+        $visited[$organisation->id] = Program::query()->count();
+    });
+
+    expect($visited)->toBe([
+        $organisations[0]->id => 1,
+        $organisations[1]->id => 1,
+    ])->and(fn () => $context->id())->toThrow(LogicException::class);
+});
+
+it('enforces scoped Program slug uniqueness in the database', function () {
+    $organisation = Organisation::factory()->active()->create();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($organisation): void {
+        Program::factory()->for($organisation)->create(['slug' => 'duplicate']);
+
+        expect(fn () => Program::factory()->for($organisation)->create(['slug' => 'duplicate']))
+            ->toThrow(QueryException::class);
+    });
+});
+
+it('rejects Program ownership changes at the database boundary', function () {
+    $firstOrganisation = Organisation::factory()->active()->create();
+    $secondOrganisation = Organisation::factory()->active()->create();
+    $program = app(OrganisationContext::class)->run(
+        $firstOrganisation,
+        fn (): Program => Program::factory()->for($firstOrganisation)->create(),
+    );
+
+    expect(fn () => DB::table('programs')->where('id', $program->id)->update([
+        'organisation_id' => $secondOrganisation->id,
+    ]))->toThrow(QueryException::class);
+});

--- a/tests/Feature/ProgramTenantBoundaryTest.php
+++ b/tests/Feature/ProgramTenantBoundaryTest.php
@@ -1,0 +1,197 @@
+<?php
+
+use App\Actions\Programs\BuildProgramReport;
+use App\Actions\Programs\ExportPrograms;
+use App\Actions\Programs\SearchPrograms;
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\Program;
+use App\Models\User;
+use App\OrganisationContext;
+use App\OrganisationStorage;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+uses(RefreshDatabase::class);
+
+beforeEach(fn () => Cache::flush());
+
+function createProgramBoundaryFixture(): array
+{
+    $user = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    $otherOrganisation = Organisation::factory()->active()->create();
+    $membership = $organisation->memberships()->create([
+        'user_id' => $user->id,
+        'role' => OrganisationRole::ProgramManager,
+    ]);
+    $program = app(OrganisationContext::class)->run(
+        $organisation,
+        fn (): Program => Program::factory()->for($organisation)->create(['name' => 'Neighbour Support', 'slug' => 'neighbour-support']),
+    );
+    $otherProgram = app(OrganisationContext::class)->run(
+        $otherOrganisation,
+        fn (): Program => Program::factory()->for($otherOrganisation)->create(['name' => 'Neighbour Secret', 'slug' => 'neighbour-secret']),
+    );
+    app(OrganisationContext::class)->run(
+        $organisation,
+        fn () => $membership->programs()->attach($program),
+    );
+
+    return compact('user', 'organisation', 'otherOrganisation', 'membership', 'program', 'otherProgram');
+}
+
+it('returns not found for cross-Organisation Program identifiers and permits an assigned Program', function () {
+    extract(createProgramBoundaryFixture());
+
+    $this->actingAs($user)
+        ->getJson(route('organisations.programs.show', [$organisation, $program->id]))
+        ->assertOk()
+        ->assertJsonPath('id', $program->id);
+
+    $this->actingAs($user)
+        ->getJson(route('organisations.programs.show', [$organisation, $otherProgram->id]))
+        ->assertNotFound();
+    $this->actingAs($user)
+        ->getJson(route('organisations.programs.show', [$organisation, $otherProgram->slug]))
+        ->assertNotFound();
+
+    $this->actingAs($user)
+        ->getJson(route('organisations.programs.report', $organisation))
+        ->assertForbidden();
+});
+
+it('allows Organisation administrators to use tenant-scoped search reports and exports', function () {
+    $administrator = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    $otherOrganisation = Organisation::factory()->active()->create();
+    $organisation->memberships()->create([
+        'user_id' => $administrator->id,
+        'role' => OrganisationRole::OrganisationAdministrator,
+    ]);
+    app(OrganisationContext::class)->run(
+        $organisation,
+        fn (): Program => Program::factory()->for($organisation)->create(['name' => 'Visible Program']),
+    );
+    app(OrganisationContext::class)->run(
+        $otherOrganisation,
+        fn (): Program => Program::factory()->for($otherOrganisation)->create(['name' => 'Hidden Program']),
+    );
+    Storage::fake();
+
+    $this->actingAs($administrator)
+        ->getJson(route('organisations.programs.search', [$organisation, 'query' => 'Program']))
+        ->assertOk()
+        ->assertJsonCount(1)
+        ->assertJsonPath('0.name', 'Visible Program');
+    $this->actingAs($administrator)
+        ->getJson(route('organisations.programs.report', $organisation))
+        ->assertOk()
+        ->assertJsonPath('program_count', 1)
+        ->assertJsonMissing(['Hidden Program']);
+    $export = $this->actingAs($administrator)
+        ->get(route('organisations.programs.export', $organisation))
+        ->assertOk();
+
+    expect($export->streamedContent())->toContain('Visible Program')->not->toContain('Hidden Program');
+});
+
+it('does not let ownership alone grant operational Program access', function () {
+    $owner = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    $organisation->memberships()->create(['user_id' => $owner->id, 'is_owner' => true]);
+    $program = app(OrganisationContext::class)->run(
+        $organisation,
+        fn (): Program => Program::factory()->for($organisation)->create(),
+    );
+
+    $this->actingAs($owner)
+        ->getJson(route('organisations.programs.show', [$organisation, $program]))
+        ->assertForbidden();
+    $this->actingAs($owner)
+        ->getJson(route('organisations.programs.report', $organisation))
+        ->assertForbidden();
+});
+
+it('updates only a Program assigned to an authorised Program manager', function () {
+    extract(createProgramBoundaryFixture());
+
+    $this->actingAs($user)
+        ->patchJson(route('organisations.programs.update', [$organisation, $program]), [
+            'name' => 'Updated Support',
+            'slug' => 'updated-support',
+            'organisation_id' => $otherOrganisation->id,
+        ])
+        ->assertOk()
+        ->assertJsonPath('name', 'Updated Support')
+        ->assertJsonPath('organisation_id', $organisation->id);
+
+    expect(DB::table('programs')->where('id', $program->id)->value('organisation_id'))
+        ->toBe($organisation->id);
+});
+
+it('validates Program slug uniqueness within the current Organisation', function () {
+    extract(createProgramBoundaryFixture());
+    $secondProgram = app(OrganisationContext::class)->run(
+        $organisation,
+        fn (): Program => Program::factory()->for($organisation)->create(['slug' => 'second-program']),
+    );
+
+    $this->actingAs($user)
+        ->patchJson(route('organisations.programs.update', [$organisation, $program]), [
+            'name' => $program->name,
+            'slug' => $secondProgram->slug,
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('slug');
+});
+
+it('scopes search reports exports caches and soft deletes to the current Organisation', function () {
+    extract(createProgramBoundaryFixture());
+    Storage::fake();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($organisation, $program, $otherProgram): void {
+        $searchResults = app(SearchPrograms::class)->handle('Neighbour');
+        $report = app(BuildProgramReport::class)->handle();
+        $path = app(ExportPrograms::class)->handle();
+
+        expect($searchResults->pluck('id')->all())->toBe([$program->id])
+            ->and($report)->toMatchArray([
+                'organisation_id' => $organisation->id,
+                'program_count' => 1,
+                'program_names' => ['Neighbour Support'],
+            ])
+            ->and($path)->toBe("organisations/{$organisation->id}/exports/programs.csv")
+            ->and(Storage::get($path))->toContain('Neighbour Support')->not->toContain('Neighbour Secret');
+
+        expect(Program::query()->whereKey($otherProgram->id)->exists())->toBeFalse();
+
+        $program->delete();
+
+        expect(Program::query()->count())->toBe(0)
+            ->and(app(SearchPrograms::class)->handle('Neighbour'))->toHaveCount(0);
+    });
+});
+
+it('rejects cross-Organisation membership associations at the database boundary', function () {
+    extract(createProgramBoundaryFixture());
+
+    expect(fn () => DB::table('membership_program')->insert([
+        'organisation_id' => $organisation->id,
+        'membership_id' => $membership->id,
+        'program_id' => $otherProgram->id,
+    ]))->toThrow(QueryException::class);
+});
+
+it('does not report a tenant file as stored when the filesystem write fails', function () {
+    $organisation = Organisation::factory()->active()->create();
+    Storage::shouldReceive('put')->once()->andReturnFalse();
+
+    app(OrganisationContext::class)->run($organisation, function (): void {
+        expect(fn () => app(OrganisationStorage::class)->put('exports/programs.csv', 'contents'))
+            ->toThrow(RuntimeException::class, 'Unable to write');
+    });
+});

--- a/tests/Feature/RebuildProgramSearchDocumentTest.php
+++ b/tests/Feature/RebuildProgramSearchDocumentTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Actions\Organisations\InvalidateOrganisationAccess;
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Enums\OrganisationLifecycleEventType;
+use App\Jobs\RebuildProgramSearchDocument;
+use App\Models\Organisation;
+use App\Models\OrganisationAccessHold;
+use App\Models\Program;
+use App\OrganisationContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('captures tenant identity and audits a scoped search rebuild', function () {
+    $organisation = Organisation::factory()->active()->create();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($organisation): void {
+        $program = Program::factory()->for($organisation)->create();
+        $job = new RebuildProgramSearchDocument($program);
+
+        expect($job->organisationId)->toBe($organisation->id)
+            ->and($job->programId)->toBe($program->id);
+
+        app()->call([$job, 'handle']);
+    });
+
+    $this->assertDatabaseHas('organisation_lifecycle_events', [
+        'organisation_id' => $organisation->id,
+        'type' => OrganisationLifecycleEventType::ProgramSearchRebuilt->value,
+    ]);
+});
+
+it('rejects a job whose captured Organisation context has become stale', function () {
+    $organisation = Organisation::factory()->active()->create();
+    $job = app(OrganisationContext::class)->run($organisation, function () use ($organisation): RebuildProgramSearchDocument {
+        return new RebuildProgramSearchDocument(Program::factory()->for($organisation)->create());
+    });
+    app(InvalidateOrganisationAccess::class)->handle($organisation);
+
+    expect(fn () => app()->call([$job, 'handle']))
+        ->toThrow(LogicException::class, 'stale');
+});
+
+it('rejects tenant jobs when the Jobs scope is restricted', function () {
+    $organisation = Organisation::factory()->active()->create();
+    $job = app(OrganisationContext::class)->run($organisation, function () use ($organisation): RebuildProgramSearchDocument {
+        return new RebuildProgramSearchDocument(Program::factory()->for($organisation)->create());
+    });
+    OrganisationAccessHold::factory()->create([
+        'organisation_id' => $organisation->id,
+        'scope' => OrganisationAccessScope::Jobs,
+        'access_level' => OrganisationAccessLevel::ReadOnly,
+    ]);
+
+    expect(fn () => app()->call([$job, 'handle']))
+        ->toThrow(LogicException::class, 'cannot run tenant jobs');
+});

--- a/tests/Feature/ReportOrganisationProgramsTest.php
+++ b/tests/Feature/ReportOrganisationProgramsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Models\Organisation;
+use App\Models\OrganisationAccessHold;
+use App\Models\Program;
+use App\OrganisationContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
+
+uses(RefreshDatabase::class);
+
+it('reports only the requested Organisation and leaves no tenant context behind', function () {
+    Cache::flush();
+    $firstOrganisation = Organisation::factory()->active()->create(['slug' => 'first']);
+    $secondOrganisation = Organisation::factory()->active()->create(['slug' => 'second']);
+    $context = app(OrganisationContext::class);
+    $context->run($firstOrganisation, fn (): Program => Program::factory()->for($firstOrganisation)->create(['name' => 'First Program']));
+    $context->run($secondOrganisation, fn (): Program => Program::factory()->for($secondOrganisation)->create(['name' => 'Secret Program']));
+
+    expect(Artisan::call('organisations:program-report', ['organisation' => 'first']))->toBe(0)
+        ->and(Artisan::output())->toContain('"organisation_id":'.$firstOrganisation->id)
+        ->toContain('First Program')
+        ->not->toContain('Secret Program');
+
+    expect(fn () => $context->id())->toThrow(LogicException::class);
+});
+
+it('fails commands for unknown Organisations and restricted command scope', function () {
+    $organisation = Organisation::factory()->active()->create();
+    OrganisationAccessHold::factory()->create([
+        'organisation_id' => $organisation->id,
+        'scope' => OrganisationAccessScope::Commands,
+        'access_level' => OrganisationAccessLevel::Denied,
+    ]);
+
+    $this->artisan('organisations:program-report', ['organisation' => 'missing'])
+        ->expectsOutput('Organisation not found.')
+        ->assertFailed();
+    $this->artisan('organisations:program-report', ['organisation' => $organisation->slug])
+        ->expectsOutput('Organisation commands are unavailable for this Organisation.')
+        ->assertFailed();
+});


### PR DESCRIPTION
Closes #5

## Summary
- add an explicit, stale-aware Organisation context and fail-closed Program model scope
- enforce immutable ownership and composite cross-Organisation relationship constraints in PostgreSQL and SQLite
- carry tenant boundaries through HTTP, policies, jobs, commands, cache, Scout search, files, exports, audits, and reports
- add adversarial tenant-isolation coverage, including identifier guessing, soft deletion, iteration, and database-level attacks

## Verification
- `composer ci:check`
- `npm test`
- `npm run build`
- `npm run licenses:check`
- full 194-test PHP suite on SQLite
- full 194-test PHP suite on PostgreSQL 18-compatible local service
- DCO check against `origin/main`
- post-implementation review against `origin/main`