### PR TITLE
Link memberships to Parties and scoped roles

### DIFF
--- a/app/Actions/Organisations/AcceptOrganisationInvitation.php
+++ b/app/Actions/Organisations/AcceptOrganisationInvitation.php
@@ -2,8 +2,12 @@
 
 namespace App\Actions\Organisations;
 
+use App\Enums\PartyKind;
+use App\Models\Membership;
 use App\Models\OrganisationInvitation;
+use App\Models\Party;
 use App\Models\User;
+use App\OrganisationContext;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
@@ -17,19 +21,77 @@ class AcceptOrganisationInvitation
                 ->lockForUpdate()
                 ->findOrFail($invitation->id);
 
-            if (! $invitation->isPending() || ! $invitation->isFor($user)) {
+            if (! $user->hasVerifiedEmail() || ! $invitation->isPending() || ! $invitation->isFor($user)) {
                 throw ValidationException::withMessages([
                     'invitation' => __('This invitation is invalid or unavailable.'),
                 ]);
             }
 
-            $invitation->organisation->memberships()->firstOrCreate(
-                ['user_id' => $user->id],
-                ['role' => $invitation->role],
-            );
+            if ($invitation->organisation->memberships()->where('user_id', $user->id)->exists()) {
+                throw ValidationException::withMessages([
+                    'invitation' => __('You already have an active membership in this organisation.'),
+                ]);
+            }
+
+            app(OrganisationContext::class)->run($invitation->organisation, function () use ($user, $invitation): void {
+                $invitation->load('roleAssignments');
+                $party = $this->resolveParty($invitation);
+                $initialAssignments = $invitation->roleAssignments;
+
+                $membership = Membership::query()->create([
+                    'organisation_id' => $invitation->organisation_id,
+                    'user_id' => $user->id,
+                    'person_party_id' => $party->id,
+                    'is_owner' => $invitation->offers_ownership,
+                    'role' => null,
+                    'accepted_at' => now(),
+                ]);
+
+                if ($initialAssignments->isEmpty()) {
+                    $membership->roleAssignments()->create([
+                        'organisation_id' => $invitation->organisation_id,
+                        'role' => $invitation->role,
+                    ]);
+                } else {
+                    $membership->roleAssignments()->createMany(
+                        $initialAssignments->map(fn ($assignment) => [
+                            'organisation_id' => $invitation->organisation_id,
+                            'role' => $assignment->role,
+                            'program_id' => $assignment->program_id,
+                        ])->all(),
+                    );
+                }
+
+                $membership->update([
+                    'role' => $initialAssignments->isEmpty()
+                        ? $invitation->role
+                        : $initialAssignments->first()->role,
+                ]);
+            });
 
             $invitation->update(['accepted_at' => now()]);
             $user->switchOrganisation($invitation->organisation);
         });
+    }
+
+    private function resolveParty(OrganisationInvitation $invitation): Party
+    {
+        if ($invitation->person_party_id !== null) {
+            return Party::query()
+                ->whereKey($invitation->person_party_id)
+                ->where('kind', PartyKind::Person->value)
+                ->firstOrFail();
+        }
+
+        if ($invitation->new_person_name === null) {
+            throw ValidationException::withMessages([
+                'invitation' => __('This invitation does not specify a person Party.'),
+            ]);
+        }
+
+        return Party::query()->create([
+            'kind' => PartyKind::Person,
+            'display_name' => $invitation->new_person_name,
+        ]);
     }
 }

--- a/app/Actions/Organisations/AcceptOrganisationOwnershipTransfer.php
+++ b/app/Actions/Organisations/AcceptOrganisationOwnershipTransfer.php
@@ -8,6 +8,7 @@ use App\Models\Membership;
 use App\Models\Organisation;
 use App\Models\OrganisationOwnershipTransfer;
 use App\Models\User;
+use App\OrganisationContext;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 
@@ -30,14 +31,21 @@ class AcceptOrganisationOwnershipTransfer
 
             $nominatorMembership = Membership::where('organisation_id', $organisation->id)
                 ->where('user_id', $transfer->nominated_by_user_id)
+                ->whereNull('ended_at')
                 ->lockForUpdate()
                 ->first();
             $nomineeMembership = Membership::where('organisation_id', $organisation->id)
                 ->where('user_id', $nominee->id)
+                ->whereNull('ended_at')
                 ->lockForUpdate()
                 ->first();
 
-            if (! $nominatorMembership?->is_owner || $nomineeMembership === null) {
+            $membershipOnHold = app(OrganisationContext::class)->run(
+                $organisation,
+                fn (): bool => $nominatorMembership?->isHeld() === true || $nomineeMembership?->isHeld() === true,
+            );
+
+            if (! $nominatorMembership?->is_owner || $nomineeMembership === null || $membershipOnHold) {
                 throw ValidationException::withMessages(['transfer' => __('This ownership transfer is no longer valid.')]);
             }
 

--- a/app/Actions/Organisations/IssueOrganisationInvitation.php
+++ b/app/Actions/Organisations/IssueOrganisationInvitation.php
@@ -3,25 +3,104 @@
 namespace App\Actions\Organisations;
 
 use App\Data\IssuedOrganisationInvitation;
+use App\Enums\OrganisationPermission;
 use App\Enums\OrganisationRole;
 use App\Models\Organisation;
+use App\Models\Party;
 use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
 class IssueOrganisationInvitation
 {
-    public function handle(Organisation $organisation, User $inviter, string $email, OrganisationRole $role): IssuedOrganisationInvitation
-    {
-        $token = Str::random(64);
+    /**
+     * @param  array<int, array{role: string, program_id: int|null}>  $roleAssignments
+     */
+    public function handle(
+        Organisation $organisation,
+        User $inviter,
+        string $email,
+        int|OrganisationRole|null $personPartyId = null,
+        ?string $newPersonName = null,
+        array $roleAssignments = [],
+        bool $offersOwnership = false,
+    ): IssuedOrganisationInvitation {
+        if (! $inviter->hasOrganisationPermission($organisation, OrganisationPermission::CreateInvitation)) {
+            throw ValidationException::withMessages([
+                'invitation' => __('You are not allowed to invite members to this organisation.'),
+            ]);
+        }
 
-        $invitation = $organisation->invitations()->create([
-            'token_hash' => hash('sha256', $token),
-            'email' => Str::lower($email),
-            'role' => $role,
-            'invited_by' => $inviter->id,
-            'expires_at' => now()->addHours(72),
-        ]);
+        if ($personPartyId instanceof OrganisationRole) {
+            $roleAssignments = [['role' => $personPartyId->value, 'program_id' => null]];
+            $personPartyId = null;
+            $newPersonName = $email;
+        }
 
-        return new IssuedOrganisationInvitation($invitation, $token);
+        if ($roleAssignments === []) {
+            throw ValidationException::withMessages(['role_assignments' => __('At least one operational role is required.')]);
+        }
+
+        $assignmentKeys = collect($roleAssignments)->map(
+            fn (array $assignment) => $assignment['role'].':'.($assignment['program_id'] ?? 'organisation'),
+        );
+
+        if ($assignmentKeys->duplicates()->isNotEmpty()) {
+            throw ValidationException::withMessages([
+                'role_assignments' => __('Each role and scope combination may only be proposed once.'),
+            ]);
+        }
+
+        $includesAdministrator = collect($roleAssignments)->contains(
+            fn (array $assignment) => $assignment['role'] === OrganisationRole::OrganisationAdministrator->value,
+        );
+
+        if (($offersOwnership || $includesAdministrator) && ! $inviter->ownsOrganisation($organisation)) {
+            throw ValidationException::withMessages([
+                'role_assignments' => __('Only an organisation owner can appoint another owner or organisation administrator.'),
+            ]);
+        }
+
+        return DB::transaction(fn () => app(OrganisationContext::class)->run($organisation, function () use (
+            $organisation,
+            $inviter,
+            $email,
+            $personPartyId,
+            $newPersonName,
+            $roleAssignments,
+            $offersOwnership,
+        ): IssuedOrganisationInvitation {
+            if ($personPartyId !== null) {
+                Party::query()->whereKey($personPartyId)->where('kind', 'person')->firstOrFail();
+            } elseif (blank($newPersonName)) {
+                throw ValidationException::withMessages(['new_person_name' => __('A new person Party name is required.')]);
+            }
+
+            $token = Str::random(64);
+            $firstRole = OrganisationRole::from($roleAssignments[0]['role']);
+
+            $invitation = $organisation->invitations()->create([
+                'token_hash' => hash('sha256', $token),
+                'email' => Str::lower($email),
+                'person_party_id' => $personPartyId,
+                'new_person_name' => $newPersonName,
+                'role' => $firstRole,
+                'offers_ownership' => $offersOwnership,
+                'invited_by' => $inviter->id,
+                'expires_at' => now()->addHours(72),
+            ]);
+
+            $invitation->roleAssignments()->createMany(
+                collect($roleAssignments)->map(fn (array $assignment) => [
+                    'organisation_id' => $organisation->id,
+                    'role' => OrganisationRole::from($assignment['role']),
+                    'program_id' => $assignment['program_id'] ?? null,
+                ])->all(),
+            );
+
+            return new IssuedOrganisationInvitation($invitation, $token);
+        }));
     }
 }

--- a/app/Actions/Organisations/ResolveOrganisationAccess.php
+++ b/app/Actions/Organisations/ResolveOrganisationAccess.php
@@ -36,7 +36,7 @@ class ResolveOrganisationAccess
     {
         $access = $this->handle($organisation, OrganisationAccessScope::Staff);
         $isAdministrator = $user?->ownsOrganisation($organisation)
-            || $user?->organisationRole($organisation) === OrganisationRole::OrganisationAdministrator;
+            || $user?->hasOrganisationRole($organisation, OrganisationRole::OrganisationAdministrator);
 
         return match ($capability) {
             'full' => $access === OrganisationAccessLevel::Full,

--- a/app/Concerns/HasOrganisations.php
+++ b/app/Concerns/HasOrganisations.php
@@ -10,6 +10,7 @@ use App\Enums\OrganisationStatus;
 use App\Models\Membership;
 use App\Models\Organisation;
 use App\Models\Program;
+use App\Models\RoleAssignment;
 use App\OrganisationContext;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -28,7 +29,8 @@ trait HasOrganisations
     public function organisations(): BelongsToMany
     {
         return $this->belongsToMany(Organisation::class, 'organisation_members', 'user_id', 'organisation_id')
-            ->withPivot(['role', 'is_owner'])
+            ->withPivot(['id', 'person_party_id', 'role', 'is_owner', 'accepted_at', 'ended_at'])
+            ->wherePivotNull('ended_at')
             ->withTimestamps();
     }
 
@@ -46,7 +48,8 @@ trait HasOrganisations
             'id',
             'id',
             'organisation_id',
-        )->where('organisation_members.is_owner', true);
+        )->where('organisation_members.is_owner', true)
+            ->whereNull('organisation_members.ended_at');
     }
 
     /**
@@ -55,6 +58,12 @@ trait HasOrganisations
      * @return HasMany<Membership, $this>
      */
     public function organisationMemberships(): HasMany
+    {
+        return $this->hasMany(Membership::class, 'user_id')->whereNull('ended_at');
+    }
+
+    /** @return HasMany<Membership, $this> */
+    public function organisationMembershipHistory(): HasMany
     {
         return $this->hasMany(Membership::class, 'user_id');
     }
@@ -113,7 +122,10 @@ trait HasOrganisations
             return false;
         }
 
-        return $membership->is_owner;
+        return $membership->is_owner && ! app(OrganisationContext::class)->run(
+            $organisation,
+            fn () => $membership->isHeld(),
+        );
     }
 
     /**
@@ -121,7 +133,32 @@ trait HasOrganisations
      */
     public function organisationRole(Organisation $organisation): ?OrganisationRole
     {
-        return $this->organisationMembership($organisation)?->role;
+        $membership = $this->organisationMembership($organisation);
+
+        if ($membership === null) {
+            return null;
+        }
+
+        return app(OrganisationContext::class)->run($organisation, function () use ($membership): ?OrganisationRole {
+            if ($membership->isHeld()) {
+                return null;
+            }
+
+            return $membership->roleAssignments()
+                ->whereNull('ended_at')
+                ->orderByRaw("CASE role WHEN 'organisation_administrator' THEN 0 ELSE 1 END")
+                ->first()?->role;
+        });
+    }
+
+    public function hasOrganisationRole(Organisation $organisation, OrganisationRole $role, ?Program $program = null): bool
+    {
+        $membership = $this->organisationMembership($organisation);
+
+        return $membership !== null && app(OrganisationContext::class)->run(
+            $organisation,
+            fn () => $membership->hasRole($role, $program),
+        );
     }
 
     /**
@@ -139,10 +176,26 @@ trait HasOrganisations
      */
     public function hasProgramAccess(Program $program): bool
     {
-        return $this->organisationMemberships()
-            ->where('organisation_id', $program->organisation_id)
-            ->whereHas('programs', fn ($query) => $query->whereKey($program->id))
-            ->exists();
+        $membership = $this->organisationMembership($program->organisation);
+
+        if ($membership === null) {
+            return false;
+        }
+
+        return app(OrganisationContext::class)->run($program->organisation, function () use ($membership, $program): bool {
+            if ($membership->isHeld()) {
+                return false;
+            }
+
+            if ($membership->programs()->exists()) {
+                return $membership->programs()->whereKey($program->id)->exists();
+            }
+
+            return $membership->roleAssignments()
+                ->whereNull('ended_at')
+                ->where(fn ($query) => $query->whereNull('program_id')->orWhere('program_id', $program->id))
+                ->exists();
+        });
     }
 
     /**
@@ -160,7 +213,7 @@ trait HasOrganisations
 
                 app(OrganisationContext::class)->run(
                     $organisation,
-                    fn () => $membership->load('programs'),
+                    fn () => $membership->load(['programs', 'roleAssignments']),
                 );
 
                 return ! $includeCurrent && $this->isCurrentOrganisation($organisation)
@@ -177,7 +230,10 @@ trait HasOrganisations
     public function toUserOrganisation(Organisation $organisation, ?Membership $membership = null): UserOrganisation
     {
         $membership ??= $this->organisationMembership($organisation);
-        $role = $membership?->role;
+        $roleAssignment = $membership?->roleAssignments
+            ->whereNull('ended_at')
+            ->first();
+        $role = $roleAssignment?->role;
 
         return new UserOrganisation(
             id: $organisation->id,
@@ -187,9 +243,15 @@ trait HasOrganisations
             roleLabel: $role?->label(),
             isOwner: $membership !== null && $membership->is_owner,
             status: $organisation->status->value,
-            programIds: $membership === null
-                ? []
-                : $membership->programs->sortBy('id')->pluck('id')->values()->all(),
+            programIds: $membership === null ? [] : $membership->roleAssignments
+                ->whereNull('ended_at')
+                ->whereNotNull('program_id')
+                ->pluck('program_id')
+                ->merge($membership->programs->pluck('id'))
+                ->unique()
+                ->sort()
+                ->values()
+                ->all(),
             isCurrent: $this->isCurrentOrganisation($organisation),
         );
     }
@@ -229,7 +291,26 @@ trait HasOrganisations
      */
     public function hasOrganisationPermission(Organisation $organisation, OrganisationPermission $permission): bool
     {
-        return $this->ownsOrganisation($organisation)
-            || ($this->organisationRole($organisation)?->hasPermission($permission) ?? false);
+        if ($this->ownsOrganisation($organisation)) {
+            return true;
+        }
+
+        $membership = $this->organisationMembership($organisation);
+
+        if ($membership === null) {
+            return false;
+        }
+
+        return app(OrganisationContext::class)->run($organisation, function () use ($membership, $permission): bool {
+            if ($membership->isHeld()) {
+                return false;
+            }
+
+            return $membership->roleAssignments()
+                ->whereNull('ended_at')
+                ->whereNull('program_id')
+                ->get()
+                ->contains(fn (RoleAssignment $assignment) => $assignment->role->hasPermission($permission));
+        });
     }
 }

--- a/app/Enums/PartyKind.php
+++ b/app/Enums/PartyKind.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum PartyKind: string
+{
+    case Person = 'person';
+    case Household = 'household';
+    case Organisation = 'organisation';
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\OrganisationInvitation;
+use App\OrganisationContext;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -23,14 +24,31 @@ class DashboardController extends Controller
                 ->orWhere('expires_at', '>=', now()))
             ->latest()
             ->get()
-            ->map(fn (OrganisationInvitation $invitation) => [
-                'id' => $invitation->id,
-                'inviterName' => $invitation->inviter->name,
-                'organisation' => [
-                    'name' => $invitation->organisation->name,
-                    'slug' => $invitation->organisation->slug,
-                ],
-            ]);
+            ->map(function (OrganisationInvitation $invitation): array {
+                app(OrganisationContext::class)->run(
+                    $invitation->organisation,
+                    fn () => $invitation->load(['personParty', 'roleAssignments.program']),
+                );
+
+                return [
+                    'id' => $invitation->id,
+                    'inviterName' => $invitation->inviter->name,
+                    'personName' => $invitation->person_party_id === null
+                        ? $invitation->new_person_name
+                        : $invitation->personParty->display_name,
+                    'offersOwnership' => $invitation->offers_ownership,
+                    'roleAssignments' => $invitation->roleAssignments->map(fn ($assignment) => [
+                        'roleLabel' => $assignment->role->label(),
+                        'scopeLabel' => $assignment->program_id === null
+                            ? 'Organisation-wide'
+                            : $assignment->program->name,
+                    ])->values()->all(),
+                    'organisation' => [
+                        'name' => $invitation->organisation->name,
+                        'slug' => $invitation->organisation->slug,
+                    ],
+                ];
+            });
 
         return Inertia::render('dashboard', [
             'pendingInvitations' => $pendingInvitations,

--- a/app/Http/Controllers/Organisations/MembershipHoldController.php
+++ b/app/Http/Controllers/Organisations/MembershipHoldController.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\CreateMembershipHoldRequest;
+use App\Models\MembershipHold;
+use App\Models\Organisation;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+
+class MembershipHoldController extends Controller
+{
+    public function store(CreateMembershipHoldRequest $request, Organisation $organisation, User $user): RedirectResponse
+    {
+        Gate::authorize('updateMember', $organisation);
+
+        DB::transaction(function () use ($request, $organisation, $user): void {
+            $membership = $organisation->memberships()
+                ->where('user_id', $user->id)
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            abort_if($request->user()->is($user), 403, __('You cannot place your own membership on hold.'));
+            abort_if($membership->isHeld(), 422, __('This membership already has an active hold.'));
+            abort_if(
+                $membership->is_owner && ! $request->user()->ownsOrganisation($organisation),
+                403,
+                __('Only an organisation owner can place another owner on hold.'),
+            );
+
+            if ($membership->is_owner) {
+                $organisation->memberships()->where('is_owner', true)->lockForUpdate()->get();
+
+                abort_if(! $organisation->hasOtherCapableOwner($membership), 403, __('The last capable organisation owner cannot be placed on hold.'));
+            }
+
+            $membership->holds()->create([
+                'organisation_id' => $organisation->id,
+                'reason' => $request->validated('reason'),
+                'starts_at' => now(),
+                'review_at' => $request->date('review_at'),
+                'expires_at' => $request->date('expires_at'),
+                'issued_by' => $request->user()->id,
+            ]);
+        });
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Membership placed on hold.')]);
+
+        return to_route('organisations.edit', $organisation);
+    }
+
+    public function destroy(Request $request, Organisation $organisation, User $user, int $hold): RedirectResponse
+    {
+        Gate::authorize('updateMember', $organisation);
+
+        DB::transaction(function () use ($request, $organisation, $user, $hold): void {
+            $membership = $organisation->memberships()->where('user_id', $user->id)->lockForUpdate()->firstOrFail();
+            $hold = MembershipHold::query()->lockForUpdate()->findOrFail($hold);
+
+            abort_unless($hold->membership_id === $membership->id, 404);
+            abort_if($request->user()->is($user), 403, __('You cannot release your own membership hold.'));
+            abort_if($hold->released_at !== null, 422, __('This Membership Hold has already been released.'));
+
+            $hold->update([
+                'released_at' => now(),
+                'released_by' => $request->user()->id,
+            ]);
+        });
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Membership hold released.')]);
+
+        return to_route('organisations.edit', $organisation);
+    }
+}

--- a/app/Http/Controllers/Organisations/OrganisationController.php
+++ b/app/Http/Controllers/Organisations/OrganisationController.php
@@ -8,11 +8,13 @@ use App\Actions\Organisations\TransitionOrganisationStatus;
 use App\Enums\OrganisationOwnershipTransferStatus;
 use App\Enums\OrganisationRole;
 use App\Enums\OrganisationStatus;
+use App\Enums\PartyKind;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Organisations\DeleteOrganisationRequest;
 use App\Http\Requests\Organisations\SaveOrganisationRequest;
 use App\Models\Membership;
 use App\Models\Organisation;
+use App\Models\OrganisationInvitationRoleAssignment;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
@@ -60,7 +62,7 @@ class OrganisationController extends Controller
             canRecover: $resolveOrganisationAccess->allowsStaffCapability($organisation, $user, 'recovery'),
         );
         $memberships = $organisation->memberships()
-            ->with(['user', 'programs'])
+            ->with(['user', 'personParty', 'roleAssignments.program', 'holds'])
             ->get();
         $pendingOwnershipTransfer = $organisation->ownershipTransfers()
             ->with(['nominatedBy', 'nominee'])
@@ -79,7 +81,7 @@ class OrganisationController extends Controller
                 'status' => $organisation->status->value,
             ],
             'members' => $memberships
-                ->map(function (Membership $membership) {
+                ->map(function (Membership $membership) use ($organisation, $permissions, $user) {
                     $member = $membership->user;
 
                     return [
@@ -87,10 +89,34 @@ class OrganisationController extends Controller
                         'name' => $member->name,
                         'email' => $member->email,
                         'avatar' => $member->avatar ?? null,
+                        'person_party' => [
+                            'id' => $membership->personParty->id,
+                            'display_name' => $membership->personParty->display_name,
+                        ],
+                        'role_assignments' => $membership->roleAssignments
+                            ->whereNull('ended_at')
+                            ->map(fn ($assignment) => [
+                                'id' => $assignment->id,
+                                'role' => $assignment->role->value,
+                                'role_label' => $assignment->role->label(),
+                                'program_id' => $assignment->program_id,
+                                'scope_label' => $assignment->program_id === null
+                                    ? __('Organisation-wide')
+                                    : $assignment->program->name,
+                            ])
+                            ->values(),
                         'role' => $membership->role?->value,
                         'role_label' => $membership->role?->label() ?? __('No operational role'),
                         'is_owner' => $membership->is_owner,
                         'program_ids' => $membership->programs->sortBy('name')->pluck('id')->values()->all(),
+                        'can_manage_roles' => $permissions->canUpdateMember
+                            && ($user->ownsOrganisation($organisation) || ! $member->is($user)),
+                        'can_manage_hold' => $permissions->canUpdateMember
+                            && ! $member->is($user)
+                            && (! $membership->is_owner || $user->ownsOrganisation($organisation)),
+                        'hold' => $membership->holds
+                            ->first(fn ($hold) => $hold->isActive())
+                            ?->only(['id', 'reason', 'review_at', 'expires_at']),
                     ];
                 }),
             'programs' => $organisation->programs()
@@ -102,16 +128,32 @@ class OrganisationController extends Controller
                 ->where(fn ($query) => $query
                     ->whereNull('expires_at')
                     ->orWhere('expires_at', '>=', now()))
+                ->with(['personParty', 'roleAssignments.program'])
                 ->get()
                 ->map(fn ($invitation) => [
                     'id' => $invitation->id,
                     'email' => $invitation->email,
-                    'role' => $invitation->role->value,
-                    'role_label' => $invitation->role->label(),
+                    'person_name' => $invitation->person_party_id === null
+                        ? $invitation->new_person_name
+                        : $invitation->personParty->display_name,
+                    'offers_ownership' => $invitation->offers_ownership,
+                    'role_assignments' => $invitation->roleAssignments
+                        ->map($this->toInvitationRoleAssignment(...))
+                        ->values()
+                        ->all(),
                     'created_at' => $invitation->created_at->toISOString(),
                 ]),
             'permissions' => $permissions,
-            'availableRoles' => OrganisationRole::assignable(),
+            'availableRoles' => collect(OrganisationRole::assignable())
+                ->when(
+                    ! $user->ownsOrganisation($organisation),
+                    fn ($roles) => $roles->reject(fn (array $role) => $role['value'] === OrganisationRole::OrganisationAdministrator->value),
+                )
+                ->values(),
+            'personParties' => $organisation->parties()
+                ->where('kind', PartyKind::Person->value)
+                ->orderBy('display_name')
+                ->get(['id', 'display_name']),
             'allowedTransitions' => $user->ownsOrganisation($organisation)
                 ? collect($organisation->status->allowedTransitions())
                     ->reject(fn (OrganisationStatus $status) => in_array($status, [
@@ -203,7 +245,7 @@ class OrganisationController extends Controller
                 ->firstOrFail();
 
             abort_if(
-                $membership->is_owner && $organisation->owners()->count() <= 1,
+                $membership->is_owner && ! $organisation->hasOtherCapableOwner($membership),
                 403,
                 __('The last organisation owner cannot leave.'),
             );
@@ -213,7 +255,7 @@ class OrganisationController extends Controller
                 ? $user->fallbackOrganisation($organisation)
                 : null;
 
-            $membership->delete();
+            $membership->end();
 
             if ($wasCurrentOrganisation) {
                 if ($fallbackOrganisation) {
@@ -250,5 +292,18 @@ class OrganisationController extends Controller
         ]);
 
         return to_route('organisations.edit', $organisation);
+    }
+
+    /** @return array{role: string, role_label: string, program_id: int|null, scope_label: string} */
+    private function toInvitationRoleAssignment(OrganisationInvitationRoleAssignment $assignment): array
+    {
+        $programId = $assignment->program_id;
+
+        return [
+            'role' => $assignment->role->value,
+            'role_label' => $assignment->role->label(),
+            'program_id' => $programId,
+            'scope_label' => $programId === null ? 'Organisation-wide' : $assignment->program->name,
+        ];
     }
 }

--- a/app/Http/Controllers/Organisations/OrganisationInvitationController.php
+++ b/app/Http/Controllers/Organisations/OrganisationInvitationController.php
@@ -4,7 +4,6 @@ namespace App\Http\Controllers\Organisations;
 
 use App\Actions\Organisations\AcceptOrganisationInvitation;
 use App\Actions\Organisations\IssueOrganisationInvitation;
-use App\Enums\OrganisationRole;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Organisations\CreateOrganisationInvitationRequest;
 use App\Http\Requests\Organisations\RespondToOrganisationInvitationRequest;
@@ -31,7 +30,10 @@ class OrganisationInvitationController extends Controller
             $organisation,
             $request->user(),
             $request->validated('email'),
-            OrganisationRole::from($request->validated('role')),
+            $request->integer('person_party_id') ?: null,
+            $request->validated('new_person_name'),
+            $request->validated('role_assignments'),
+            $request->boolean('offers_ownership'),
         );
 
         Notification::route('mail', $issuedInvitation->invitation->email)

--- a/app/Http/Controllers/Organisations/OrganisationMemberController.php
+++ b/app/Http/Controllers/Organisations/OrganisationMemberController.php
@@ -27,16 +27,29 @@ class OrganisationMemberController extends Controller
                 ->lockForUpdate()
                 ->firstOrFail();
 
-            $membership->update([
-                'role' => OrganisationRole::from($request->validated('role')),
-            ]);
+            $endedAt = now();
+            $membership->roleAssignments()->whereNull('ended_at')->update(['ended_at' => $endedAt]);
 
-            if ($request->has('program_ids')) {
-                $membership->programs()->sync($request->validated('program_ids', []));
-            }
+            $assignments = collect($request->roleAssignments());
+            $membership->roleAssignments()->createMany(
+                $assignments->map(fn (array $assignment) => [
+                    'organisation_id' => $organisation->id,
+                    'role' => OrganisationRole::from($assignment['role']),
+                    'program_id' => $assignment['program_id'],
+                ])->all(),
+            );
+
+            $membership->update([
+                'role' => $assignments->first() === null
+                    ? null
+                    : OrganisationRole::from($assignments->first()['role']),
+            ]);
+            $membership->programs()->sync(
+                $assignments->pluck('program_id')->filter()->unique()->values()->all(),
+            );
         });
 
-        Inertia::flash('toast', ['type' => 'success', 'message' => __('Member role updated.')]);
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Member roles updated.')]);
 
         return to_route('organisations.edit', ['organisation' => $organisation->slug]);
     }
@@ -56,12 +69,12 @@ class OrganisationMemberController extends Controller
                 ->firstOrFail();
 
             abort_if(
-                $membership->is_owner && $organisation->owners()->count() <= 1,
+                $membership->is_owner && ! $organisation->hasOtherCapableOwner($membership),
                 403,
                 __('The last organisation owner cannot be removed.'),
             );
 
-            $membership->delete();
+            $membership->end();
 
             if ($user->isCurrentOrganisation($organisation)) {
                 $fallbackOrganisation = $user->fallbackOrganisation($organisation);

--- a/app/Http/Middleware/EnsureOrganisationMembership.php
+++ b/app/Http/Middleware/EnsureOrganisationMembership.php
@@ -40,14 +40,11 @@ class EnsureOrganisationMembership
             return;
         }
 
-        $role = $user->organisationRole($organisation);
-
         $requiredRole = OrganisationRole::tryFrom($minimumRole);
 
         abort_if(
             $requiredRole === null ||
-            $role === null ||
-            $role !== $requiredRole,
+            ! $user->hasOrganisationRole($organisation, $requiredRole),
             403,
         );
     }

--- a/app/Http/Requests/Organisations/CreateMembershipHoldRequest.php
+++ b/app/Http/Requests/Organisations/CreateMembershipHoldRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class CreateMembershipHoldRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'reason' => ['required', 'string', 'min:10', 'max:2000'],
+            'review_at' => ['required', 'date', 'after:now'],
+            'expires_at' => ['nullable', 'date', 'after:review_at'],
+        ];
+    }
+}

--- a/app/Http/Requests/Organisations/CreateOrganisationInvitationRequest.php
+++ b/app/Http/Requests/Organisations/CreateOrganisationInvitationRequest.php
@@ -4,10 +4,12 @@ namespace App\Http\Requests\Organisations;
 
 use App\Enums\OrganisationRole;
 use App\Models\Organisation;
+use App\Models\Party;
 use App\Rules\UniqueOrganisationInvitation;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class CreateOrganisationInvitationRequest extends FormRequest
 {
@@ -24,7 +26,74 @@ class CreateOrganisationInvitationRequest extends FormRequest
 
         return [
             'email' => ['required', 'string', 'email', 'max:255', new UniqueOrganisationInvitation($organisation)],
-            'role' => ['required', 'string', Rule::in(array_column(OrganisationRole::assignable(), 'value'))],
+            'person_party_id' => [
+                'nullable',
+                'integer',
+                Rule::prohibitedIf(fn () => $this->filled('new_person_name')),
+                Rule::exists(Party::class, 'id')
+                    ->where('organisation_id', $organisation->id)
+                    ->where('kind', 'person'),
+            ],
+            'new_person_name' => ['nullable', 'required_without:person_party_id', 'string', 'max:255'],
+            'role_assignments' => ['required', 'array', 'min:1', 'max:20'],
+            'role_assignments.*.role' => ['required', 'string', Rule::in(array_column(OrganisationRole::assignable(), 'value'))],
+            'role_assignments.*.program_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('programs', 'id')->where('organisation_id', $organisation->id),
+            ],
+            'offers_ownership' => ['sometimes', 'boolean'],
         ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if (! $this->has('role_assignments') && $this->filled('role')) {
+            $this->merge([
+                'role_assignments' => [[
+                    'role' => $this->input('role'),
+                    'program_id' => null,
+                ]],
+            ]);
+        }
+
+    }
+
+    /** @return array<int, \Closure(Validator): void> */
+    public function after(): array
+    {
+        return [function (Validator $validator): void {
+            if ($this->filled('role') && $validator->errors()->has('role_assignments.0.role')) {
+                $validator->errors()->add('role', __('The selected role is invalid.'));
+            }
+
+            $organisation = $this->route('organisation');
+
+            if (! $organisation instanceof Organisation || $this->user() === null) {
+                return;
+            }
+
+            $assignments = collect((array) $this->input('role_assignments', []));
+            $offersOwnership = $this->boolean('offers_ownership');
+
+            if (! $this->user()->ownsOrganisation($organisation)
+                && ($offersOwnership || $assignments->contains('role', OrganisationRole::OrganisationAdministrator->value))) {
+                $validator->errors()->add('role_assignments', __('Only an organisation owner can appoint another owner or organisation administrator.'));
+            }
+
+            if ($assignments->contains(fn (mixed $assignment) => is_array($assignment)
+                && ($assignment['role'] ?? null) === OrganisationRole::OrganisationAdministrator->value
+                && ($assignment['program_id'] ?? null) !== null)) {
+                $validator->errors()->add('role_assignments', __('Organisation administrator must have organisation-wide scope.'));
+            }
+
+            $keys = $assignments->map(fn (mixed $assignment) => is_array($assignment)
+                ? ($assignment['role'] ?? '').':'.($assignment['program_id'] ?? 'organisation')
+                : '');
+
+            if ($keys->duplicates()->isNotEmpty()) {
+                $validator->errors()->add('role_assignments', __('Each role and scope combination may only be proposed once.'));
+            }
+        }];
     }
 }

--- a/app/Http/Requests/Organisations/CreateOrganisationOwnershipTransferRequest.php
+++ b/app/Http/Requests/Organisations/CreateOrganisationOwnershipTransferRequest.php
@@ -31,7 +31,9 @@ class CreateOrganisationOwnershipTransferRequest extends FormRequest
             'nominee_user_id' => [
                 'required',
                 'integer',
-                Rule::exists('organisation_members', 'user_id')->where('organisation_id', $organisationId),
+                Rule::exists('organisation_members', 'user_id')
+                    ->where('organisation_id', $organisationId)
+                    ->whereNull('ended_at'),
             ],
         ];
     }

--- a/app/Http/Requests/Organisations/UpdateOrganisationMemberRequest.php
+++ b/app/Http/Requests/Organisations/UpdateOrganisationMemberRequest.php
@@ -4,9 +4,11 @@ namespace App\Http\Requests\Organisations;
 
 use App\Enums\OrganisationRole;
 use App\Models\Organisation;
+use App\Models\User;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class UpdateOrganisationMemberRequest extends FormRequest
 {
@@ -21,14 +23,76 @@ class UpdateOrganisationMemberRequest extends FormRequest
         $organisationId = $organisation instanceof Organisation ? $organisation->id : 0;
 
         return [
-            'role' => ['required', 'string', Rule::in(array_column(OrganisationRole::assignable(), 'value'))],
-            'program_ids' => ['sometimes', 'array'],
-            'program_ids.*' => [
+            'role_assignments' => ['present', 'array', 'max:20'],
+            'role_assignments.*.role' => ['required', 'string', Rule::in(array_column(OrganisationRole::assignable(), 'value'))],
+            'role_assignments.*.program_id' => [
+                'nullable',
                 'integer',
-                'distinct',
                 Rule::exists('programs', 'id')->where('organisation_id', $organisationId),
             ],
         ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if (! $this->has('role_assignments') && $this->filled('role')) {
+            $programIds = $this->input('program_ids', []);
+            $assignments = collect(is_array($programIds) && $programIds !== [] ? $programIds : [null])
+                ->map(fn (mixed $programId) => [
+                    'role' => $this->input('role'),
+                    'program_id' => $programId,
+                ])
+                ->all();
+
+            $this->merge(['role_assignments' => $assignments]);
+        }
+    }
+
+    /** @return array<int, \Closure(Validator): void> */
+    public function after(): array
+    {
+        return [function (Validator $validator): void {
+            if ($this->filled('role') && $validator->errors()->has('role_assignments.0.role')) {
+                $validator->errors()->add('role', __('The selected role is invalid.'));
+            }
+
+            if ($this->has('program_ids')) {
+                foreach (array_keys((array) $this->input('program_ids')) as $index) {
+                    if ($validator->errors()->has("role_assignments.{$index}.program_id")) {
+                        $validator->errors()->add("program_ids.{$index}", __('The selected program is not available for this organisation.'));
+                    }
+                }
+            }
+
+            $organisation = $this->route('organisation');
+            $target = $this->route('user');
+            $actor = $this->user();
+
+            if (! $organisation instanceof Organisation || ! $target instanceof User || $actor === null) {
+                return;
+            }
+
+            $assignments = collect((array) $this->input('role_assignments', []));
+
+            if (! $actor->ownsOrganisation($organisation)
+                && ($actor->is($target) || $assignments->contains('role', OrganisationRole::OrganisationAdministrator->value))) {
+                $validator->errors()->add('role_assignments', __('Organisation administrators cannot alter their own access or appoint another organisation administrator.'));
+            }
+
+            if ($assignments->contains(fn (mixed $assignment) => is_array($assignment)
+                && ($assignment['role'] ?? null) === OrganisationRole::OrganisationAdministrator->value
+                && ($assignment['program_id'] ?? null) !== null)) {
+                $validator->errors()->add('role_assignments', __('Organisation administrator must have organisation-wide scope.'));
+            }
+
+            $keys = $assignments->map(fn (mixed $assignment) => is_array($assignment)
+                ? ($assignment['role'] ?? '').':'.($assignment['program_id'] ?? 'organisation')
+                : '');
+
+            if ($keys->duplicates()->isNotEmpty()) {
+                $validator->errors()->add('role_assignments', __('Each role and scope combination may only be assigned once.'));
+            }
+        }];
     }
 
     /**
@@ -39,7 +103,19 @@ class UpdateOrganisationMemberRequest extends FormRequest
     public function messages(): array
     {
         return [
-            'program_ids.*.exists' => __('The selected program is not available for this organisation.'),
+            'role_assignments.*.program_id.exists' => __('The selected program is not available for this organisation.'),
         ];
+    }
+
+    /** @return array<int, array{role: string, program_id: int|null}> */
+    public function roleAssignments(): array
+    {
+        return array_map(
+            fn (array $assignment): array => [
+                'role' => (string) $assignment['role'],
+                'program_id' => ($assignment['program_id'] ?? null) === null ? null : (int) $assignment['program_id'],
+            ],
+            $this->safe()->array('role_assignments'),
+        );
     }
 }

--- a/app/Models/Membership.php
+++ b/app/Models/Membership.php
@@ -3,25 +3,36 @@
 namespace App\Models;
 
 use App\Enums\OrganisationRole;
+use App\Enums\PartyKind;
 use App\OrganisationContext;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
+use LogicException;
 
 /**
  * @property int $id
  * @property int $organisation_id
  * @property int $user_id
+ * @property int|null $person_party_id
  * @property OrganisationRole|null $role
  * @property bool $is_owner
+ * @property Carbon|null $accepted_at
+ * @property Carbon|null $ended_at
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property-read Organisation $organisation
  * @property-read User $user
+ * @property-read Party $personParty
+ * @property-read Collection<int, RoleAssignment> $roleAssignments
+ * @property-read Collection<int, MembershipHold> $holds
  */
-#[Fillable(['organisation_id', 'user_id', 'role', 'is_owner'])]
+#[Fillable(['organisation_id', 'user_id', 'person_party_id', 'role', 'is_owner', 'accepted_at', 'ended_at'])]
 class Membership extends Pivot
 {
     /**
@@ -37,6 +48,52 @@ class Membership extends Pivot
      * @var bool
      */
     public $incrementing = true;
+
+    protected static function booted(): void
+    {
+        static::creating(function (Membership $membership): void {
+            $membership->accepted_at ??= Carbon::now();
+
+            if ($membership->person_party_id !== null) {
+                $partyExists = Party::withoutGlobalScopes()
+                    ->whereKey($membership->person_party_id)
+                    ->where('organisation_id', $membership->organisation_id)
+                    ->where('kind', PartyKind::Person->value)
+                    ->exists();
+
+                if (! $partyExists) {
+                    throw new LogicException('A Membership must link to a person Party in the same Organisation.');
+                }
+
+                return;
+            }
+
+            $organisation = Organisation::query()->findOrFail($membership->organisation_id);
+            $user = User::query()->findOrFail($membership->user_id);
+
+            $membership->person_party_id = app(OrganisationContext::class)->run(
+                $organisation,
+                fn () => Party::query()->create([
+                    'kind' => PartyKind::Person,
+                    'display_name' => $user->name,
+                ])->id,
+            );
+        });
+
+        static::created(function (Membership $membership): void {
+            if ($membership->role === null) {
+                return;
+            }
+
+            app(OrganisationContext::class)->run(
+                $membership->organisation,
+                fn () => $membership->roleAssignments()->create([
+                    'organisation_id' => $membership->organisation_id,
+                    'role' => $membership->role,
+                ]),
+            );
+        });
+    }
 
     /**
      * Get the organisation that the membership belongs to.
@@ -56,6 +113,65 @@ class Membership extends Pivot
     public function user(): BelongsTo
     {
         return $this->belongsTo(User::class);
+    }
+
+    /** @return BelongsTo<Party, $this> */
+    public function personParty(): BelongsTo
+    {
+        return $this->belongsTo(Party::class, 'person_party_id')->withTrashed();
+    }
+
+    /** @return HasMany<RoleAssignment, $this> */
+    public function roleAssignments(): HasMany
+    {
+        return $this->hasMany(RoleAssignment::class, 'membership_id', 'id');
+    }
+
+    /** @return HasMany<MembershipHold, $this> */
+    public function holds(): HasMany
+    {
+        return $this->hasMany(MembershipHold::class, 'membership_id', 'id');
+    }
+
+    public function isHeld(): bool
+    {
+        $now = now();
+
+        return $this->holds()
+            ->whereNull('released_at')
+            ->where('starts_at', '<=', $now)
+            ->where(fn (Builder $query) => $query->whereNull('expires_at')->orWhere('expires_at', '>', $now))
+            ->exists();
+    }
+
+    public function hasRole(OrganisationRole $role, ?Program $program = null): bool
+    {
+        if ($this->ended_at !== null || $this->isHeld()) {
+            return false;
+        }
+
+        return $this->roleAssignments()
+            ->whereNull('ended_at')
+            ->where('role', $role->value)
+            ->when(
+                $program === null,
+                fn (Builder $query) => $query->whereNull('program_id'),
+                fn (Builder $query) => $query->where(fn (Builder $scope) => $scope
+                    ->whereNull('program_id')
+                    ->orWhere('program_id', $program->id)),
+            )
+            ->exists();
+    }
+
+    public function end(): void
+    {
+        if ($this->ended_at !== null) {
+            return;
+        }
+
+        $endedAt = now();
+        $this->update(['ended_at' => $endedAt]);
+        $this->roleAssignments()->whereNull('ended_at')->update(['ended_at' => $endedAt]);
     }
 
     /**
@@ -79,6 +195,8 @@ class Membership extends Pivot
         return [
             'role' => OrganisationRole::class,
             'is_owner' => 'boolean',
+            'accepted_at' => 'datetime',
+            'ended_at' => 'datetime',
         ];
     }
 }

--- a/app/Models/MembershipHold.php
+++ b/app/Models/MembershipHold.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use Database\Factories\MembershipHoldFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $organisation_id
+ * @property int $membership_id
+ * @property string $reason
+ * @property Carbon $starts_at
+ * @property Carbon $review_at
+ * @property Carbon|null $expires_at
+ * @property Carbon|null $released_at
+ * @property int $issued_by
+ * @property int|null $released_by
+ */
+#[Fillable(['organisation_id', 'membership_id', 'reason', 'starts_at', 'review_at', 'expires_at', 'released_at', 'issued_by', 'released_by'])]
+class MembershipHold extends Model
+{
+    /** @use HasFactory<MembershipHoldFactory> */
+    use BelongsToOrganisation, HasFactory;
+
+    /** @return BelongsTo<Membership, $this> */
+    public function membership(): BelongsTo
+    {
+        return $this->belongsTo(Membership::class);
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function issuer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'issued_by');
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function releaser(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'released_by');
+    }
+
+    public function isActive(): bool
+    {
+        return $this->released_at === null
+            && ! $this->starts_at->isFuture()
+            && ($this->expires_at === null || $this->expires_at->isFuture());
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'starts_at' => 'datetime',
+            'review_at' => 'datetime',
+            'expires_at' => 'datetime',
+            'released_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Concerns\GeneratesUniqueOrganisationSlugs;
 use App\Enums\OrganisationStatus;
+use App\OrganisationContext;
 use Database\Factories\OrganisationFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Collection;
@@ -68,6 +69,15 @@ class Organisation extends Model
             ->first();
     }
 
+    public function hasOtherCapableOwner(Membership $membership): bool
+    {
+        return app(OrganisationContext::class)->run($this, fn (): bool => $this->memberships()
+            ->where('is_owner', true)
+            ->whereKeyNot($membership->id)
+            ->get()
+            ->contains(fn (Membership $ownerMembership) => ! $ownerMembership->isHeld()));
+    }
+
     /**
      * Get the organisation's owners.
      *
@@ -87,7 +97,8 @@ class Organisation extends Model
     {
         return $this->belongsToMany(User::class, 'organisation_members', 'organisation_id', 'user_id')
             ->using(Membership::class)
-            ->withPivot(['role', 'is_owner'])
+            ->withPivot(['id', 'person_party_id', 'role', 'is_owner', 'accepted_at', 'ended_at'])
+            ->wherePivotNull('ended_at')
             ->withTimestamps();
     }
 
@@ -97,6 +108,12 @@ class Organisation extends Model
      * @return HasMany<Membership, $this>
      */
     public function memberships(): HasMany
+    {
+        return $this->hasMany(Membership::class)->whereNull('ended_at');
+    }
+
+    /** @return HasMany<Membership, $this> */
+    public function membershipHistory(): HasMany
     {
         return $this->hasMany(Membership::class);
     }
@@ -119,6 +136,12 @@ class Organisation extends Model
     public function programs(): HasMany
     {
         return $this->hasMany(Program::class);
+    }
+
+    /** @return HasMany<Party, $this> */
+    public function parties(): HasMany
+    {
+        return $this->hasMany(Party::class);
     }
 
     /** @return HasMany<OrganisationAccessHold, $this> */

--- a/app/Models/OrganisationInvitation.php
+++ b/app/Models/OrganisationInvitation.php
@@ -5,9 +5,11 @@ namespace App\Models;
 use App\Enums\OrganisationRole;
 use Database\Factories\OrganisationInvitationFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Carbon;
 
 /**
@@ -16,6 +18,9 @@ use Illuminate\Support\Carbon;
  * @property int $organisation_id
  * @property string $email
  * @property OrganisationRole $role
+ * @property int|null $person_party_id
+ * @property string|null $new_person_name
+ * @property bool $offers_ownership
  * @property int $invited_by
  * @property Carbon|null $expires_at
  * @property Carbon|null $accepted_at
@@ -25,8 +30,10 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  * @property-read Organisation $organisation
  * @property-read User $inviter
+ * @property-read Party|null $personParty
+ * @property-read Collection<int, OrganisationInvitationRoleAssignment> $roleAssignments
  */
-#[Fillable(['token_hash', 'organisation_id', 'email', 'role', 'invited_by', 'expires_at', 'accepted_at', 'revoked_at', 'revoked_by'])]
+#[Fillable(['token_hash', 'organisation_id', 'email', 'person_party_id', 'new_person_name', 'role', 'offers_ownership', 'invited_by', 'expires_at', 'accepted_at', 'revoked_at', 'revoked_by'])]
 class OrganisationInvitation extends Model
 {
     /** @use HasFactory<OrganisationInvitationFactory> */
@@ -57,6 +64,18 @@ class OrganisationInvitation extends Model
     public function inviter(): BelongsTo
     {
         return $this->belongsTo(User::class, 'invited_by');
+    }
+
+    /** @return BelongsTo<Party, $this> */
+    public function personParty(): BelongsTo
+    {
+        return $this->belongsTo(Party::class, 'person_party_id')->withTrashed();
+    }
+
+    /** @return HasMany<OrganisationInvitationRoleAssignment, $this> */
+    public function roleAssignments(): HasMany
+    {
+        return $this->hasMany(OrganisationInvitationRoleAssignment::class);
     }
 
     /**
@@ -102,6 +121,7 @@ class OrganisationInvitation extends Model
     {
         return [
             'role' => OrganisationRole::class,
+            'offers_ownership' => 'boolean',
             'expires_at' => 'datetime',
             'accepted_at' => 'datetime',
             'revoked_at' => 'datetime',

--- a/app/Models/OrganisationInvitationRoleAssignment.php
+++ b/app/Models/OrganisationInvitationRoleAssignment.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\OrganisationRole;
+use Database\Factories\OrganisationInvitationRoleAssignmentFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $organisation_id
+ * @property int $organisation_invitation_id
+ * @property OrganisationRole $role
+ * @property int|null $program_id
+ * @property-read OrganisationInvitation $invitation
+ * @property-read Program|null $program
+ */
+#[Fillable(['organisation_id', 'organisation_invitation_id', 'role', 'program_id'])]
+class OrganisationInvitationRoleAssignment extends Model
+{
+    /** @use HasFactory<OrganisationInvitationRoleAssignmentFactory> */
+    use BelongsToOrganisation, HasFactory;
+
+    /** @return BelongsTo<OrganisationInvitation, $this> */
+    public function invitation(): BelongsTo
+    {
+        return $this->belongsTo(OrganisationInvitation::class, 'organisation_invitation_id');
+    }
+
+    /** @return BelongsTo<Program, $this> */
+    public function program(): BelongsTo
+    {
+        return $this->belongsTo(Program::class)->withTrashed();
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['role' => OrganisationRole::class];
+    }
+}

--- a/app/Models/Party.php
+++ b/app/Models/Party.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\PartyKind;
+use Database\Factories\PartyFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * @property int $id
+ * @property int $organisation_id
+ * @property PartyKind $kind
+ * @property string $display_name
+ * @property-read Organisation $organisation
+ * @property-read Collection<int, Membership> $memberships
+ */
+#[Fillable(['organisation_id', 'kind', 'display_name'])]
+class Party extends Model
+{
+    /** @use HasFactory<PartyFactory> */
+    use BelongsToOrganisation, HasFactory, SoftDeletes;
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return HasMany<Membership, $this> */
+    public function memberships(): HasMany
+    {
+        return $this->hasMany(Membership::class, 'person_party_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['kind' => PartyKind::class];
+    }
+}

--- a/app/Models/RoleAssignment.php
+++ b/app/Models/RoleAssignment.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\OrganisationRole;
+use Database\Factories\RoleAssignmentFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $organisation_id
+ * @property int $membership_id
+ * @property OrganisationRole $role
+ * @property int|null $program_id
+ * @property Carbon|null $ended_at
+ * @property-read Membership $membership
+ * @property-read Program|null $program
+ */
+#[Fillable(['organisation_id', 'membership_id', 'role', 'program_id', 'ended_at'])]
+class RoleAssignment extends Model
+{
+    /** @use HasFactory<RoleAssignmentFactory> */
+    use BelongsToOrganisation, HasFactory;
+
+    /** @return BelongsTo<Membership, $this> */
+    public function membership(): BelongsTo
+    {
+        return $this->belongsTo(Membership::class);
+    }
+
+    /** @return BelongsTo<Program, $this> */
+    public function program(): BelongsTo
+    {
+        return $this->belongsTo(Program::class)->withTrashed();
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'role' => OrganisationRole::class,
+            'ended_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Notifications/Organisations/OrganisationInvitation.php
+++ b/app/Notifications/Organisations/OrganisationInvitation.php
@@ -47,9 +47,13 @@ class OrganisationInvitation extends Notification
                 'inviterName' => $inviter->name,
                 'organisationName' => $organisation->name,
             ]))
+            ->when(
+                $this->invitation->offers_ownership,
+                fn (MailMessage $message) => $message->line(__('This invitation also asks you to accept Organisation Owner responsibility.')),
+            )
             ->line($this->existingUser
-                ? __('Log in and visit your dashboard to accept or decline this invitation.')
-                : __('Create your account with this invitation, then verify your email address to continue.'))
+                ? __('Log in with this invitation to accept it, or decline it from your dashboard.')
+                : __('Create your account with this invitation, then verify your email address to accept it.'))
             ->action(
                 $action,
                 route($route, ['invitation' => $this->token]),

--- a/app/Policies/OrganisationPolicy.php
+++ b/app/Policies/OrganisationPolicy.php
@@ -61,12 +61,13 @@ class OrganisationPolicy
      */
     public function leave(User $user, Organisation $organisation): bool
     {
-        if (! $user->belongsToOrganisation($organisation)) {
+        $membership = $user->organisationMembership($organisation);
+
+        if ($membership === null) {
             return false;
         }
 
-        return ! $user->ownsOrganisation($organisation)
-            || $organisation->owners()->whereKeyNot($user->id)->exists();
+        return ! $membership->is_owner || $organisation->hasOtherCapableOwner($membership);
     }
 
     /**

--- a/app/Policies/ProgramPolicy.php
+++ b/app/Policies/ProgramPolicy.php
@@ -14,7 +14,7 @@ class ProgramPolicy
      */
     public function viewAny(User $user, Organisation $organisation): bool
     {
-        return $user->organisationRole($organisation) === OrganisationRole::OrganisationAdministrator;
+        return $user->hasOrganisationRole($organisation, OrganisationRole::OrganisationAdministrator);
     }
 
     /**
@@ -22,10 +22,8 @@ class ProgramPolicy
      */
     public function view(User $user, Program $program): bool
     {
-        $role = $user->organisationRole($program->organisation);
-
-        return $role === OrganisationRole::OrganisationAdministrator
-            || ($role !== null && $user->hasProgramAccess($program));
+        return collect(OrganisationRole::cases())
+            ->contains(fn (OrganisationRole $role) => $user->hasOrganisationRole($program->organisation, $role, $program));
     }
 
     /**
@@ -41,10 +39,8 @@ class ProgramPolicy
      */
     public function update(User $user, Program $program): bool
     {
-        $role = $user->organisationRole($program->organisation);
-
-        return $role === OrganisationRole::OrganisationAdministrator
-            || ($role === OrganisationRole::ProgramManager && $user->hasProgramAccess($program));
+        return $user->hasOrganisationRole($program->organisation, OrganisationRole::OrganisationAdministrator)
+            || $user->hasOrganisationRole($program->organisation, OrganisationRole::ProgramManager, $program);
     }
 
     /**

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -138,7 +138,7 @@ class FortifyServiceProvider extends ServiceProvider
     /**
      * Get the pending organisation invitation context for auth pages.
      *
-     * @return array{code: string, email: string, organisationName: string}|null
+     * @return array{code: string, email: string, organisationName: string, offersOwnership: bool}|null
      */
     private function organisationInvitation(Request $request): ?array
     {
@@ -158,6 +158,7 @@ class FortifyServiceProvider extends ServiceProvider
             'code' => $invitationCode,
             'email' => $invitation->email,
             'organisationName' => $invitation->organisation->name,
+            'offersOwnership' => $invitation->offers_ownership,
         ];
     }
 }

--- a/database/factories/MembershipHoldFactory.php
+++ b/database/factories/MembershipHoldFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\MembershipHold;
+use App\Models\Organisation;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<MembershipHold>
+ */
+class MembershipHoldFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => Organisation::factory(),
+            'membership_id' => function (array $attributes): int {
+                $organisation = Organisation::query()->whereKey((int) $attributes['organisation_id'])->firstOrFail();
+
+                return $organisation->memberships()->create([
+                    'user_id' => User::factory()->create()->id,
+                ])->id;
+            },
+            'reason' => fake()->sentence(),
+            'starts_at' => now(),
+            'review_at' => now()->addWeek(),
+            'expires_at' => now()->addMonth(),
+            'issued_by' => User::factory(),
+        ];
+    }
+}

--- a/database/factories/OrganisationInvitationFactory.php
+++ b/database/factories/OrganisationInvitationFactory.php
@@ -6,6 +6,7 @@ use App\Enums\OrganisationRole;
 use App\Models\Organisation;
 use App\Models\OrganisationInvitation;
 use App\Models\User;
+use App\OrganisationContext;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
@@ -14,6 +15,20 @@ use Illuminate\Support\Str;
  */
 class OrganisationInvitationFactory extends Factory
 {
+    public function configure(): static
+    {
+        return $this->afterCreating(function (OrganisationInvitation $invitation): void {
+            app(OrganisationContext::class)->run($invitation->organisation, function () use ($invitation): void {
+                if ($invitation->roleAssignments()->doesntExist()) {
+                    $invitation->roleAssignments()->create([
+                        'organisation_id' => $invitation->organisation_id,
+                        'role' => $invitation->role,
+                    ]);
+                }
+            });
+        });
+    }
+
     /**
      * Define the model's default state.
      *
@@ -27,6 +42,7 @@ class OrganisationInvitationFactory extends Factory
             'token_hash' => hash('sha256', $token),
             'organisation_id' => Organisation::factory(),
             'email' => fake()->unique()->safeEmail(),
+            'new_person_name' => fake()->name(),
             'role' => OrganisationRole::CaseWorker,
             'invited_by' => User::factory(),
             'expires_at' => null,

--- a/database/factories/OrganisationInvitationRoleAssignmentFactory.php
+++ b/database/factories/OrganisationInvitationRoleAssignmentFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\OrganisationInvitation;
+use App\Models\OrganisationInvitationRoleAssignment;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<OrganisationInvitationRoleAssignment>
+ */
+class OrganisationInvitationRoleAssignmentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => Organisation::factory(),
+            'organisation_invitation_id' => function (array $attributes): int {
+                return OrganisationInvitation::factory()->create([
+                    'organisation_id' => $attributes['organisation_id'],
+                    'invited_by' => User::factory(),
+                ])->id;
+            },
+            'role' => OrganisationRole::EngagementOfficer,
+            'program_id' => null,
+        ];
+    }
+}

--- a/database/factories/PartyFactory.php
+++ b/database/factories/PartyFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\PartyKind;
+use App\Models\Organisation;
+use App\Models\Party;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Party>
+ */
+class PartyFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => Organisation::factory(),
+            'kind' => PartyKind::Person,
+            'display_name' => fake()->name(),
+        ];
+    }
+}

--- a/database/factories/RoleAssignmentFactory.php
+++ b/database/factories/RoleAssignmentFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\RoleAssignment;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<RoleAssignment>
+ */
+class RoleAssignmentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => Organisation::factory(),
+            'membership_id' => function (array $attributes): int {
+                $organisation = Organisation::query()->whereKey((int) $attributes['organisation_id'])->firstOrFail();
+
+                return $organisation->memberships()->create([
+                    'user_id' => User::factory()->create()->id,
+                ])->id;
+            },
+            'role' => OrganisationRole::CaseWorker,
+            'program_id' => null,
+            'ended_at' => null,
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -45,7 +45,8 @@ class UserFactory extends Factory
         return $this->afterCreating(function ($user) {
             $organisation = Organisation::factory()->active()->create();
 
-            $organisation->members()->attach($user, [
+            $organisation->memberships()->create([
+                'user_id' => $user->id,
                 'is_owner' => true,
             ]);
 

--- a/database/migrations/2026_08_30_190024_create_membership_parties_scoped_roles_and_holds.php
+++ b/database/migrations/2026_08_30_190024_create_membership_parties_scoped_roles_and_holds.php
@@ -1,0 +1,241 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('parties', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->string('kind');
+            $table->string('display_name');
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->unique(['organisation_id', 'id'], 'parties_organisation_id_id_unique');
+            $table->index(['organisation_id', 'kind', 'display_name']);
+        });
+
+        Schema::table('organisation_members', function (Blueprint $table) {
+            $table->foreignId('person_party_id')->nullable()->after('user_id');
+            $table->timestamp('accepted_at')->nullable()->after('is_owner');
+            $table->timestamp('ended_at')->nullable()->after('accepted_at');
+        });
+
+        DB::table('organisation_members')->update([
+            'accepted_at' => DB::raw('created_at'),
+        ]);
+
+        DB::table('organisation_members')
+            ->join('users', 'users.id', '=', 'organisation_members.user_id')
+            ->whereNull('organisation_members.person_party_id')
+            ->orderBy('organisation_members.id')
+            ->select([
+                'organisation_members.id as membership_id',
+                'organisation_members.organisation_id',
+                'organisation_members.created_at',
+                'organisation_members.updated_at',
+                'users.name',
+            ])
+            ->each(function (object $membership): void {
+                $partyId = DB::table('parties')->insertGetId([
+                    'organisation_id' => $membership->organisation_id,
+                    'kind' => 'person',
+                    'display_name' => $membership->name,
+                    'created_at' => $membership->created_at ?? now(),
+                    'updated_at' => $membership->updated_at ?? now(),
+                ]);
+
+                DB::table('organisation_members')
+                    ->where('id', $membership->membership_id)
+                    ->update(['person_party_id' => $partyId]);
+            });
+
+        Schema::table('organisation_members', function (Blueprint $table) {
+            $table->foreignId('person_party_id')->nullable(false)->change();
+            $table->timestamp('accepted_at')->nullable(false)->change();
+            $table->foreign(['organisation_id', 'person_party_id'], 'organisation_members_person_party_tenant_foreign')
+                ->references(['organisation_id', 'id'])->on('parties')->restrictOnDelete();
+            $table->index(['organisation_id', 'user_id', 'ended_at'], 'organisation_members_active_lookup');
+        });
+
+        Schema::table('organisation_members', function (Blueprint $table) {
+            $table->dropUnique(DB::getDriverName() === 'sqlite'
+                ? 'team_members_team_id_user_id_unique'
+                : 'organisation_members_organisation_id_user_id_unique');
+        });
+
+        $this->createActiveMembershipUniqueIndex();
+
+        Schema::create('role_assignments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('membership_id');
+            $table->string('role');
+            $table->foreignId('program_id')->nullable();
+            $table->timestamp('ended_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign(['organisation_id', 'membership_id'], 'role_assignments_membership_tenant_foreign')
+                ->references(['organisation_id', 'id'])->on('organisation_members')->cascadeOnDelete();
+            $table->foreign(['organisation_id', 'program_id'], 'role_assignments_program_tenant_foreign')
+                ->references(['organisation_id', 'id'])->on('programs')->restrictOnDelete();
+            $table->index(['organisation_id', 'membership_id', 'ended_at'], 'role_assignments_active_lookup');
+        });
+
+        DB::statement('CREATE UNIQUE INDEX role_assignments_one_active_organisation_scope ON role_assignments (organisation_id, membership_id, role) WHERE program_id IS NULL AND ended_at IS NULL');
+        DB::statement('CREATE UNIQUE INDEX role_assignments_one_active_program_scope ON role_assignments (organisation_id, membership_id, role, program_id) WHERE program_id IS NOT NULL AND ended_at IS NULL');
+
+        DB::table('organisation_members')
+            ->whereNotNull('role')
+            ->orderBy('id')
+            ->each(function (object $membership): void {
+                $programIds = DB::table('membership_program')
+                    ->where('membership_id', $membership->id)
+                    ->pluck('program_id');
+
+                if ($programIds->isEmpty()) {
+                    $programIds = collect([null]);
+                }
+
+                foreach ($programIds as $programId) {
+                    DB::table('role_assignments')->insert([
+                        'organisation_id' => $membership->organisation_id,
+                        'membership_id' => $membership->id,
+                        'role' => $membership->role,
+                        'program_id' => $programId,
+                        'created_at' => $membership->created_at ?? now(),
+                        'updated_at' => $membership->updated_at ?? now(),
+                    ]);
+                }
+            });
+
+        Schema::table('organisation_invitations', function (Blueprint $table) {
+            $table->foreignId('person_party_id')->nullable()->after('email');
+            $table->string('new_person_name')->nullable()->after('person_party_id');
+            $table->boolean('offers_ownership')->default(false)->after('role');
+            $table->unique(['organisation_id', 'id'], 'organisation_invitations_organisation_id_id_unique');
+            $table->foreign(['organisation_id', 'person_party_id'], 'organisation_invitations_person_party_tenant_foreign')
+                ->references(['organisation_id', 'id'])->on('parties')->restrictOnDelete();
+        });
+
+        DB::table('organisation_invitations')
+            ->whereNull('person_party_id')
+            ->update(['new_person_name' => DB::raw('email')]);
+
+        Schema::create('organisation_invitation_role_assignments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('organisation_invitation_id');
+            $table->string('role');
+            $table->foreignId('program_id')->nullable();
+            $table->timestamps();
+
+            $table->foreign(['organisation_id', 'organisation_invitation_id'], 'invitation_roles_invitation_tenant_foreign')
+                ->references(['organisation_id', 'id'])->on('organisation_invitations')->cascadeOnDelete();
+            $table->foreign(['organisation_id', 'program_id'], 'invitation_roles_program_tenant_foreign')
+                ->references(['organisation_id', 'id'])->on('programs')->restrictOnDelete();
+        });
+
+        DB::statement('CREATE UNIQUE INDEX invitation_roles_one_organisation_scope ON organisation_invitation_role_assignments (organisation_id, organisation_invitation_id, role) WHERE program_id IS NULL');
+        DB::statement('CREATE UNIQUE INDEX invitation_roles_one_program_scope ON organisation_invitation_role_assignments (organisation_id, organisation_invitation_id, role, program_id) WHERE program_id IS NOT NULL');
+
+        DB::table('organisation_invitations')
+            ->orderBy('id')
+            ->each(function (object $invitation): void {
+                DB::table('organisation_invitation_role_assignments')->insert([
+                    'organisation_id' => $invitation->organisation_id,
+                    'organisation_invitation_id' => $invitation->id,
+                    'role' => $invitation->role,
+                    'program_id' => null,
+                    'created_at' => $invitation->created_at ?? now(),
+                    'updated_at' => $invitation->updated_at ?? now(),
+                ]);
+            });
+
+        Schema::create('membership_holds', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('membership_id');
+            $table->text('reason');
+            $table->timestamp('starts_at');
+            $table->timestamp('review_at');
+            $table->timestamp('expires_at')->nullable();
+            $table->timestamp('released_at')->nullable();
+            $table->foreignId('issued_by')->constrained('users')->restrictOnDelete();
+            $table->foreignId('released_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->foreign(['organisation_id', 'membership_id'], 'membership_holds_membership_tenant_foreign')
+                ->references(['organisation_id', 'id'])->on('organisation_members')->cascadeOnDelete();
+            $table->index(['organisation_id', 'membership_id', 'released_at'], 'membership_holds_active_lookup');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('membership_holds');
+        Schema::dropIfExists('organisation_invitation_role_assignments');
+
+        Schema::table('organisation_invitations', function (Blueprint $table) {
+            $table->dropForeign(DB::getDriverName() === 'sqlite'
+                ? ['organisation_id', 'person_party_id']
+                : 'organisation_invitations_person_party_tenant_foreign');
+            $table->dropUnique('organisation_invitations_organisation_id_id_unique');
+            $table->dropColumn(['person_party_id', 'new_person_name', 'offers_ownership']);
+        });
+
+        Schema::dropIfExists('role_assignments');
+        $this->dropActiveMembershipUniqueIndex();
+
+        DB::statement(<<<'SQL'
+            DELETE FROM organisation_members
+            WHERE id NOT IN (
+                SELECT id
+                FROM (
+                    SELECT id,
+                        ROW_NUMBER() OVER (
+                            PARTITION BY organisation_id, user_id
+                            ORDER BY CASE WHEN ended_at IS NULL THEN 0 ELSE 1 END,
+                                accepted_at DESC,
+                                id DESC
+                        ) AS tenure_rank
+                    FROM organisation_members
+                ) AS ranked_memberships
+                WHERE tenure_rank = 1
+            )
+            SQL);
+
+        Schema::table('organisation_members', function (Blueprint $table) {
+            $table->dropForeign(DB::getDriverName() === 'sqlite'
+                ? ['organisation_id', 'person_party_id']
+                : 'organisation_members_person_party_tenant_foreign');
+            $table->dropIndex('organisation_members_active_lookup');
+            $table->dropColumn(['person_party_id', 'accepted_at', 'ended_at']);
+            $table->unique(['organisation_id', 'user_id'], 'organisation_members_organisation_id_user_id_unique');
+        });
+
+        Schema::dropIfExists('parties');
+    }
+
+    private function createActiveMembershipUniqueIndex(): void
+    {
+        DB::statement('CREATE UNIQUE INDEX organisation_members_one_active_tenure ON organisation_members (organisation_id, user_id) WHERE ended_at IS NULL');
+    }
+
+    private function dropActiveMembershipUniqueIndex(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS organisation_members_one_active_tenure');
+    }
+};

--- a/database/seeders/MembershipHoldSeeder.php
+++ b/database/seeders/MembershipHoldSeeder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Organisation;
+use App\OrganisationContext;
+use Illuminate\Database\Seeder;
+
+class MembershipHoldSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Organisation::query()->each(function (Organisation $organisation): void {
+            app(OrganisationContext::class)->run($organisation, function () use ($organisation): void {
+                $issuer = $organisation->memberships()->where('is_owner', true)->first();
+                $membership = $organisation->memberships()->where('is_owner', false)->first();
+
+                if ($issuer === null || $membership === null || $membership->holds()->exists()) {
+                    return;
+                }
+
+                $membership->holds()->create([
+                    'organisation_id' => $organisation->id,
+                    'reason' => 'Example completed membership review',
+                    'starts_at' => now()->subMonth(),
+                    'review_at' => now()->subWeeks(3),
+                    'expires_at' => now()->subWeeks(2),
+                    'released_at' => now()->subWeeks(2),
+                    'issued_by' => $issuer->user_id,
+                    'released_by' => $issuer->user_id,
+                ]);
+            });
+        });
+    }
+}

--- a/database/seeders/PartySeeder.php
+++ b/database/seeders/PartySeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\PartyKind;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\OrganisationContext;
+use Illuminate\Database\Seeder;
+
+class PartySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Organisation::query()->each(function (Organisation $organisation): void {
+            app(OrganisationContext::class)->run(
+                $organisation,
+                fn () => Party::factory()->count(5)->create([
+                    'organisation_id' => $organisation->id,
+                    'kind' => PartyKind::Person,
+                ]),
+            );
+        });
+    }
+}

--- a/database/seeders/RoleAssignmentSeeder.php
+++ b/database/seeders/RoleAssignmentSeeder.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\OrganisationContext;
+use Illuminate\Database\Seeder;
+
+class RoleAssignmentSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Organisation::query()->each(function (Organisation $organisation): void {
+            app(OrganisationContext::class)->run($organisation, function () use ($organisation): void {
+                $organisation->memberships()
+                    ->where('is_owner', false)
+                    ->get()
+                    ->each(function ($membership) use ($organisation): void {
+                        if ($membership->roleAssignments()->whereNull('ended_at')->doesntExist()) {
+                            $membership->roleAssignments()->create([
+                                'organisation_id' => $organisation->id,
+                                'role' => OrganisationRole::CaseWorker,
+                            ]);
+                        }
+                    });
+            });
+        });
+    }
+}

--- a/resources/js/components/invite-member-modal.tsx
+++ b/resources/js/components/invite-member-modal.tsx
@@ -1,4 +1,5 @@
 import { Form } from '@inertiajs/react';
+import { Plus, X } from 'lucide-react';
 import { useState } from 'react';
 import InputError from '@/components/input-error';
 import { Button } from '@/components/ui/button';
@@ -21,11 +22,20 @@ import {
     SelectValue,
 } from '@/components/ui/select';
 import { store as storeInvitation } from '@/routes/organisations/invitations';
-import type { RoleOption, Organisation } from '@/types';
+import { Checkbox } from '@/components/ui/checkbox';
+import type {
+    Organisation,
+    PersonPartyOption,
+    ProgramOption,
+    RoleOption,
+} from '@/types';
 
 type Props = {
     organisation: Organisation;
     availableRoles: RoleOption[];
+    programs: ProgramOption[];
+    personParties: PersonPartyOption[];
+    canOfferOwnership: boolean;
     open: boolean;
     onOpenChange: (open: boolean) => void;
 };
@@ -33,17 +43,23 @@ type Props = {
 export default function InviteMemberModal({
     organisation,
     availableRoles,
+    programs,
+    personParties,
+    canOfferOwnership,
     open,
     onOpenChange,
 }: Props) {
-    const [inviteRole, setInviteRole] =
-        useState<RoleOption['value']>('case_worker');
+    const [partyChoice, setPartyChoice] = useState('new');
+    const [assignments, setAssignments] = useState([
+        { role: 'case_worker', programId: '' },
+    ]);
 
     const handleOpenChange = (nextOpen: boolean) => {
         onOpenChange(nextOpen);
 
         if (!nextOpen) {
-            setInviteRole('case_worker');
+            setPartyChoice('new');
+            setAssignments([{ role: 'case_worker', programId: '' }]);
         }
     };
 
@@ -60,7 +76,7 @@ export default function InviteMemberModal({
                         <>
                             <DialogHeader>
                                 <DialogTitle>
-                                    Invite a organisation member
+                                    Invite an organisation member
                                 </DialogTitle>
                                 <DialogDescription>
                                     Send an invitation to join this
@@ -83,33 +99,185 @@ export default function InviteMemberModal({
                                 </div>
 
                                 <div className="grid gap-2">
-                                    <Label htmlFor="role">Role</Label>
+                                    <Label htmlFor="person_party_id">
+                                        Person Party
+                                    </Label>
                                     <Select
-                                        name="role"
-                                        data-test="invite-role"
-                                        value={inviteRole}
-                                        onValueChange={(value) =>
-                                            setInviteRole(
-                                                value as RoleOption['value'],
-                                            )
-                                        }
+                                        value={partyChoice}
+                                        onValueChange={setPartyChoice}
                                     >
                                         <SelectTrigger className="w-full">
-                                            <SelectValue placeholder="Select a role" />
+                                            <SelectValue />
                                         </SelectTrigger>
                                         <SelectContent>
-                                            {availableRoles.map((role) => (
+                                            <SelectItem value="new">
+                                                Create a new person Party
+                                            </SelectItem>
+                                            {personParties.map((party) => (
                                                 <SelectItem
-                                                    key={role.value}
-                                                    value={role.value}
+                                                    key={party.id}
+                                                    value={String(party.id)}
                                                 >
-                                                    {role.label}
+                                                    {party.display_name}
                                                 </SelectItem>
                                             ))}
                                         </SelectContent>
                                     </Select>
-                                    <InputError message={errors.role} />
+                                    {partyChoice === 'new' ? (
+                                        <Input
+                                            name="new_person_name"
+                                            placeholder="Person's full name"
+                                            required
+                                        />
+                                    ) : (
+                                        <input
+                                            type="hidden"
+                                            name="person_party_id"
+                                            value={partyChoice}
+                                        />
+                                    )}
+                                    <InputError
+                                        message={
+                                            errors.person_party_id ??
+                                            errors.new_person_name
+                                        }
+                                    />
                                 </div>
+
+                                <div className="grid gap-3">
+                                    <div className="flex items-center justify-between">
+                                        <Label>Initial role assignments</Label>
+                                        <Button
+                                            type="button"
+                                            variant="outline"
+                                            size="sm"
+                                            onClick={() =>
+                                                setAssignments((current) => [
+                                                    ...current,
+                                                    {
+                                                        role: 'case_worker',
+                                                        programId: '',
+                                                    },
+                                                ])
+                                            }
+                                        >
+                                            <Plus /> Add role
+                                        </Button>
+                                    </div>
+                                    {assignments.map((assignment, index) => (
+                                        <div
+                                            key={index}
+                                            className="grid grid-cols-[1fr_1fr_auto] gap-2"
+                                        >
+                                            <select
+                                                name={`role_assignments[${index}][role]`}
+                                                value={assignment.role}
+                                                onChange={(event) =>
+                                                    setAssignments((current) =>
+                                                        current.map(
+                                                            (
+                                                                item,
+                                                                itemIndex,
+                                                            ) =>
+                                                                itemIndex ===
+                                                                index
+                                                                    ? {
+                                                                          ...item,
+                                                                          role: event
+                                                                              .target
+                                                                              .value,
+                                                                      }
+                                                                    : item,
+                                                        ),
+                                                    )
+                                                }
+                                                className="border-input bg-background h-9 rounded-md border px-3 text-sm"
+                                            >
+                                                {availableRoles.map((role) => (
+                                                    <option
+                                                        key={role.value}
+                                                        value={role.value}
+                                                    >
+                                                        {role.label}
+                                                    </option>
+                                                ))}
+                                            </select>
+                                            <select
+                                                name={`role_assignments[${index}][program_id]`}
+                                                value={assignment.programId}
+                                                disabled={
+                                                    assignment.role ===
+                                                    'organisation_administrator'
+                                                }
+                                                onChange={(event) =>
+                                                    setAssignments((current) =>
+                                                        current.map(
+                                                            (
+                                                                item,
+                                                                itemIndex,
+                                                            ) =>
+                                                                itemIndex ===
+                                                                index
+                                                                    ? {
+                                                                          ...item,
+                                                                          programId:
+                                                                              event
+                                                                                  .target
+                                                                                  .value,
+                                                                      }
+                                                                    : item,
+                                                        ),
+                                                    )
+                                                }
+                                                className="border-input bg-background h-9 rounded-md border px-3 text-sm"
+                                            >
+                                                <option value="">
+                                                    Organisation-wide
+                                                </option>
+                                                {programs.map((program) => (
+                                                    <option
+                                                        key={program.id}
+                                                        value={program.id}
+                                                    >
+                                                        {program.name}
+                                                    </option>
+                                                ))}
+                                            </select>
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="icon"
+                                                disabled={
+                                                    assignments.length === 1
+                                                }
+                                                onClick={() =>
+                                                    setAssignments((current) =>
+                                                        current.filter(
+                                                            (_, itemIndex) =>
+                                                                itemIndex !==
+                                                                index,
+                                                        ),
+                                                    )
+                                                }
+                                            >
+                                                <X />
+                                            </Button>
+                                        </div>
+                                    ))}
+                                    <InputError
+                                        message={errors.role_assignments}
+                                    />
+                                </div>
+
+                                {canOfferOwnership ? (
+                                    <Label className="flex items-center gap-2 font-normal">
+                                        <Checkbox
+                                            name="offers_ownership"
+                                            value="1"
+                                        />
+                                        Offer Organisation Owner responsibility
+                                    </Label>
+                                ) : null}
                             </div>
 
                             <DialogFooter className="gap-2">

--- a/resources/js/components/organisation-invitation-alert.tsx
+++ b/resources/js/components/organisation-invitation-alert.tsx
@@ -20,6 +20,9 @@ export default function OrganisationInvitationAlert({
             <AlertDescription className="text-blue-900 dark:text-blue-100">
                 {action} to join the "{invitation.organisationName}"
                 organisation.
+                {invitation.offersOwnership
+                    ? ' By continuing, you also accept Organisation Owner responsibility.'
+                    : ''}
             </AlertDescription>
         </Alert>
     );

--- a/resources/js/components/pending-invitations-modal.tsx
+++ b/resources/js/components/pending-invitations-modal.tsx
@@ -67,8 +67,23 @@ export default function PendingInvitationsModal({
                                 </p>
                                 <p className="text-muted-foreground text-sm">
                                     {invitation.inviterName} invited you to join
-                                    this organisation.
+                                    this organisation as {invitation.personName}
+                                    .
                                 </p>
+                                <p className="text-muted-foreground text-sm">
+                                    {invitation.roleAssignments
+                                        .map(
+                                            (assignment) =>
+                                                `${assignment.roleLabel} (${assignment.scopeLabel})`,
+                                        )
+                                        .join(', ')}
+                                </p>
+                                {invitation.offersOwnership ? (
+                                    <p className="text-sm font-medium">
+                                        Accepting also accepts Organisation
+                                        Owner responsibility.
+                                    </p>
+                                ) : null}
                             </div>
 
                             <div className="mt-4 flex justify-end gap-2">

--- a/resources/js/pages/organisations/edit.tsx
+++ b/resources/js/pages/organisations/edit.tsx
@@ -1,5 +1,5 @@
 import { Form, Head, router } from '@inertiajs/react';
-import { ChevronDown, Mail, ShieldAlert, UserPlus, X } from 'lucide-react';
+import { Mail, Plus, ShieldAlert, UserPlus, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import CancelInvitationModal from '@/components/cancel-invitation-modal';
 import DeleteOrganisationModal from '@/components/delete-organisation-modal';
@@ -10,13 +10,6 @@ import RemoveMemberModal from '@/components/remove-member-modal';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Checkbox } from '@/components/ui/checkbox';
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import {
@@ -30,6 +23,10 @@ import { edit, index, update } from '@/routes/organisations';
 import { update as updateLifecycle } from '@/routes/organisations/lifecycle';
 import { update as updateMember } from '@/routes/organisations/members';
 import {
+    destroy as releaseMembershipHold,
+    store as createMembershipHold,
+} from '@/routes/organisations/members/holds';
+import {
     store as storeOwnershipTransfer,
     update as acceptOwnershipTransfer,
 } from '@/routes/organisations/ownership-transfers';
@@ -39,7 +36,9 @@ import type {
     OrganisationOwnerCandidate,
     OrganisationOwnershipTransfer,
     ProgramOption,
+    PersonPartyOption,
     RoleOption,
+    RoleAssignment,
     Organisation,
     OrganisationInvitation,
     OrganisationMember,
@@ -53,6 +52,7 @@ type Props = {
     permissions: OrganisationPermissions;
     availableRoles: RoleOption[];
     programs: ProgramOption[];
+    personParties: PersonPartyOption[];
     allowedTransitions: string[];
     ownerCandidates: OrganisationOwnerCandidate[];
     ownershipTransfer: OrganisationOwnershipTransfer | null;
@@ -66,6 +66,7 @@ export default function OrganisationEdit({
     permissions,
     availableRoles,
     programs,
+    personParties,
     allowedTransitions,
     ownerCandidates,
     ownershipTransfer,
@@ -95,32 +96,6 @@ export default function OrganisationEdit({
         status
             .replaceAll('_', ' ')
             .replace(/^./, (letter) => letter.toUpperCase());
-
-    const updateMemberRole = (member: OrganisationMember, newRole: string) => {
-        router.visit(updateMember([organisation.slug, member.id]), {
-            data: { role: newRole, program_ids: member.program_ids },
-            preserveScroll: true,
-        });
-    };
-
-    const updateMemberProgram = (
-        member: OrganisationMember,
-        programId: number,
-        checked: boolean,
-    ) => {
-        if (!member.role) {
-            return;
-        }
-
-        const programIds = checked
-            ? [...member.program_ids, programId]
-            : member.program_ids.filter((id) => id !== programId);
-
-        router.visit(updateMember([organisation.slug, member.id]), {
-            data: { role: member.role, program_ids: programIds },
-            preserveScroll: true,
-        });
-    };
 
     const confirmRemoveMember = (member: OrganisationMember) => {
         setMemberToRemove(member);
@@ -419,43 +394,6 @@ export default function OrganisationEdit({
                                             </Badge>
                                         ) : null}
 
-                                        {permissions.canUpdateMember ? (
-                                            <DropdownMenu>
-                                                <DropdownMenuTrigger asChild>
-                                                    <Button
-                                                        variant="outline"
-                                                        size="sm"
-                                                        data-test="member-role-trigger"
-                                                    >
-                                                        {member.role_label}
-                                                        <ChevronDown className="ml-2 h-4 w-4 opacity-50" />
-                                                    </Button>
-                                                </DropdownMenuTrigger>
-                                                <DropdownMenuContent>
-                                                    {availableRoles.map(
-                                                        (role) => (
-                                                            <DropdownMenuItem
-                                                                key={role.value}
-                                                                data-test="member-role-option"
-                                                                onSelect={() =>
-                                                                    updateMemberRole(
-                                                                        member,
-                                                                        role.value,
-                                                                    )
-                                                                }
-                                                            >
-                                                                {role.label}
-                                                            </DropdownMenuItem>
-                                                        ),
-                                                    )}
-                                                </DropdownMenuContent>
-                                            </DropdownMenu>
-                                        ) : (
-                                            <Badge variant="outline">
-                                                {member.role_label}
-                                            </Badge>
-                                        )}
-
                                         {!member.is_owner &&
                                         permissions.canRemoveMember ? (
                                             <TooltipProvider>
@@ -483,49 +421,24 @@ export default function OrganisationEdit({
                                     </div>
                                 </div>
 
-                                {programs.length > 0 ? (
-                                    <div className="border-t pt-4">
-                                        <p className="mb-3 text-sm font-medium">
-                                            Program access
-                                        </p>
-                                        <div className="flex flex-wrap gap-x-6 gap-y-3">
-                                            {programs.map((program) => (
-                                                <Label
-                                                    key={program.id}
-                                                    className="flex items-center gap-2 font-normal"
-                                                >
-                                                    <Checkbox
-                                                        data-test="member-program-checkbox"
-                                                        checked={member.program_ids.includes(
-                                                            program.id,
-                                                        )}
-                                                        disabled={
-                                                            !permissions.canUpdateMember ||
-                                                            !member.role
-                                                        }
-                                                        onCheckedChange={(
-                                                            checked,
-                                                        ) =>
-                                                            updateMemberProgram(
-                                                                member,
-                                                                program.id,
-                                                                checked ===
-                                                                    true,
-                                                            )
-                                                        }
-                                                    />
-                                                    {program.name}
-                                                </Label>
-                                            ))}
-                                        </div>
-                                        {!member.role ? (
-                                            <p className="text-muted-foreground mt-2 text-xs">
-                                                Assign an operational role
-                                                before granting program access.
-                                            </p>
-                                        ) : null}
-                                    </div>
-                                ) : null}
+                                <div className="border-t pt-4">
+                                    <p className="text-muted-foreground mb-3 text-xs">
+                                        Person Party:{' '}
+                                        {member.person_party.display_name}
+                                    </p>
+                                    <MemberRoleAssignments
+                                        organisation={organisation}
+                                        member={member}
+                                        availableRoles={availableRoles}
+                                        programs={programs}
+                                    />
+                                    {permissions.canUpdateMember ? (
+                                        <MembershipHoldControls
+                                            organisation={organisation}
+                                            member={member}
+                                        />
+                                    ) : null}
+                                </div>
                             </div>
                         ))}
                     </div>
@@ -555,7 +468,16 @@ export default function OrganisationEdit({
                                                 {invitation.email}
                                             </div>
                                             <div className="text-muted-foreground text-sm">
-                                                {invitation.role_label}
+                                                {invitation.person_name} ·{' '}
+                                                {invitation.role_assignments
+                                                    .map(
+                                                        (assignment) =>
+                                                            `${assignment.role_label} (${assignment.scope_label})`,
+                                                    )
+                                                    .join(', ')}
+                                                {invitation.offers_ownership
+                                                    ? ' · Owner responsibility offered'
+                                                    : ''}
                                             </div>
                                         </div>
                                     </div>
@@ -620,6 +542,9 @@ export default function OrganisationEdit({
                 <InviteMemberModal
                     organisation={organisation}
                     availableRoles={availableRoles}
+                    programs={programs}
+                    personParties={personParties}
+                    canOfferOwnership={permissions.canTransferOwnership}
                     open={inviteDialogOpen}
                     onOpenChange={setInviteDialogOpen}
                 />
@@ -647,6 +572,219 @@ export default function OrganisationEdit({
                 />
             ) : null}
         </>
+    );
+}
+
+function MemberRoleAssignments({
+    organisation,
+    member,
+    availableRoles,
+    programs,
+}: {
+    organisation: Organisation;
+    member: OrganisationMember;
+    availableRoles: RoleOption[];
+    programs: ProgramOption[];
+}) {
+    const [role, setRole] = useState<RoleOption['value']>('case_worker');
+    const [programId, setProgramId] = useState('');
+
+    const saveAssignments = (assignments: RoleAssignment[]) => {
+        router.visit(updateMember([organisation.slug, member.id]), {
+            data: {
+                role_assignments: assignments.map((assignment) => ({
+                    role: assignment.role,
+                    program_id: assignment.program_id,
+                })),
+            },
+            preserveScroll: true,
+        });
+    };
+
+    const addAssignment = () => {
+        const roleOption = availableRoles.find(
+            (option) => option.value === role,
+        );
+        const program = programs.find(
+            (option) => option.id === Number(programId),
+        );
+
+        saveAssignments([
+            ...member.role_assignments,
+            {
+                role,
+                role_label: roleOption?.label ?? role,
+                program_id: programId === '' ? null : Number(programId),
+                scope_label: program?.name ?? 'Organisation-wide',
+            },
+        ]);
+    };
+
+    return (
+        <div className="space-y-3">
+            <p className="text-sm font-medium">Operational roles</p>
+            <div className="flex flex-wrap gap-2">
+                {member.role_assignments.length === 0 ? (
+                    <span className="text-muted-foreground text-sm">
+                        No operational role
+                    </span>
+                ) : null}
+                {member.role_assignments.map((assignment) => (
+                    <Badge
+                        key={`${assignment.role}-${assignment.program_id ?? 'organisation'}`}
+                        variant="outline"
+                        className="gap-1"
+                    >
+                        {assignment.role_label} · {assignment.scope_label}
+                        {member.can_manage_roles ? (
+                            <button
+                                type="button"
+                                aria-label={`Remove ${assignment.role_label} at ${assignment.scope_label}`}
+                                onClick={() =>
+                                    saveAssignments(
+                                        member.role_assignments.filter(
+                                            (candidate) =>
+                                                candidate.id !== assignment.id,
+                                        ),
+                                    )
+                                }
+                            >
+                                <X className="size-3" />
+                            </button>
+                        ) : null}
+                    </Badge>
+                ))}
+            </div>
+
+            {member.can_manage_roles ? (
+                <div className="flex flex-wrap gap-2">
+                    <select
+                        value={role}
+                        onChange={(event) => {
+                            const nextRole = event.target
+                                .value as RoleOption['value'];
+                            setRole(nextRole);
+
+                            if (nextRole === 'organisation_administrator') {
+                                setProgramId('');
+                            }
+                        }}
+                        className="border-input bg-background h-9 rounded-md border px-3 text-sm"
+                    >
+                        {availableRoles.map((option) => (
+                            <option key={option.value} value={option.value}>
+                                {option.label}
+                            </option>
+                        ))}
+                    </select>
+                    <select
+                        value={programId}
+                        disabled={role === 'organisation_administrator'}
+                        onChange={(event) => setProgramId(event.target.value)}
+                        className="border-input bg-background h-9 rounded-md border px-3 text-sm"
+                    >
+                        <option value="">Organisation-wide</option>
+                        {programs.map((program) => (
+                            <option key={program.id} value={program.id}>
+                                {program.name}
+                            </option>
+                        ))}
+                    </select>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={addAssignment}
+                    >
+                        <Plus /> Add assignment
+                    </Button>
+                </div>
+            ) : null}
+        </div>
+    );
+}
+
+function MembershipHoldControls({
+    organisation,
+    member,
+}: {
+    organisation: Organisation;
+    member: OrganisationMember;
+}) {
+    if (!member.can_manage_hold) {
+        return null;
+    }
+
+    if (member.hold) {
+        return (
+            <div className="border-destructive/30 mt-4 flex items-center justify-between rounded-md border p-3">
+                <div>
+                    <p className="text-sm font-medium">Membership on hold</p>
+                    <p className="text-muted-foreground text-xs">
+                        {member.hold.reason} · Review{' '}
+                        {new Date(member.hold.review_at).toLocaleString()}
+                    </p>
+                </div>
+                <Form
+                    {...releaseMembershipHold.form([
+                        organisation.slug,
+                        member.id,
+                        member.hold.id,
+                    ])}
+                >
+                    {({ processing }) => (
+                        <Button
+                            type="submit"
+                            variant="outline"
+                            size="sm"
+                            disabled={processing}
+                        >
+                            Release hold
+                        </Button>
+                    )}
+                </Form>
+            </div>
+        );
+    }
+
+    const defaultReviewAt = new Date(Date.now() + 24 * 60 * 60 * 1000)
+        .toISOString()
+        .slice(0, 16);
+
+    return (
+        <Form
+            {...createMembershipHold.form([organisation.slug, member.id])}
+            className="mt-4 grid gap-2 rounded-md border p-3 sm:grid-cols-[1fr_auto_auto]"
+        >
+            {({ errors, processing }) => (
+                <>
+                    <div>
+                        <Input
+                            name="reason"
+                            placeholder="Reason for temporary hold"
+                            minLength={10}
+                            required
+                        />
+                        <InputError message={errors.reason} />
+                    </div>
+                    <div>
+                        <Input
+                            type="datetime-local"
+                            name="review_at"
+                            defaultValue={defaultReviewAt}
+                            required
+                        />
+                        <InputError message={errors.review_at} />
+                    </div>
+                    <Button
+                        type="submit"
+                        variant="outline"
+                        disabled={processing}
+                    >
+                        Place hold
+                    </Button>
+                </>
+            )}
+        </Form>
     );
 }
 

--- a/resources/js/types/organisations.ts
+++ b/resources/js/types/organisations.ts
@@ -22,17 +22,20 @@ export type OrganisationMember = {
     name: string;
     email: string;
     avatar?: string | null;
-    role: OrganisationRole | null;
-    role_label: string;
+    person_party: PersonPartyOption;
+    role_assignments: RoleAssignment[];
     is_owner: boolean;
-    program_ids: number[];
+    can_manage_roles: boolean;
+    can_manage_hold: boolean;
+    hold: MembershipHold | null;
 };
 
 export type OrganisationInvitation = {
     id: number;
     email: string;
-    role: OrganisationRole;
-    role_label: string;
+    person_name: string;
+    offers_ownership: boolean;
+    role_assignments: RoleAssignment[];
     created_at: string;
 };
 
@@ -40,11 +43,18 @@ export type OrganisationInvitationContext = {
     code: string;
     email: string;
     organisationName: string;
+    offersOwnership: boolean;
 };
 
 export type DashboardInvitation = {
     id: number;
     inviterName: string;
+    personName: string;
+    offersOwnership: boolean;
+    roleAssignments: Array<{
+        roleLabel: string;
+        scopeLabel: string;
+    }>;
     organisation: {
         name: string;
         slug: string;
@@ -95,4 +105,24 @@ export type RoleOption = {
 export type ProgramOption = {
     id: number;
     name: string;
+};
+
+export type PersonPartyOption = {
+    id: number;
+    display_name: string;
+};
+
+export type RoleAssignment = {
+    id?: number;
+    role: OrganisationRole;
+    role_label: string;
+    program_id: number | null;
+    scope_label: string;
+};
+
+export type MembershipHold = {
+    id: number;
+    reason: string;
+    review_at: string;
+    expires_at: string | null;
 };

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Auth\MfaChallengeController;
+use App\Http\Controllers\Organisations\MembershipHoldController;
 use App\Http\Controllers\Organisations\OrganisationController;
 use App\Http\Controllers\Organisations\OrganisationInvitationController;
 use App\Http\Controllers\Organisations\OrganisationLifecycleController;
@@ -76,6 +77,8 @@ Route::middleware(['auth', 'verified'])->group(function () {
 
             Route::patch('settings/organisations/{organisation}/members/{user}', [OrganisationMemberController::class, 'update'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.members.update');
             Route::delete('settings/organisations/{organisation}/members/{user}', [OrganisationMemberController::class, 'destroy'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.members.destroy');
+            Route::post('settings/organisations/{organisation}/members/{user}/holds', [MembershipHoldController::class, 'store'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.members.holds.store');
+            Route::delete('settings/organisations/{organisation}/members/{user}/holds/{hold}', [MembershipHoldController::class, 'destroy'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.members.holds.destroy');
 
             Route::post('settings/organisations/{organisation}/invitations', [OrganisationInvitationController::class, 'store'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.invitations.store');
             Route::delete('settings/organisations/{organisation}/invitations/{invitation}', [OrganisationInvitationController::class, 'destroy'])->middleware([EnsureOrganisationAccess::class.':administration', EnsureRecentPassword::class, EnsureRecentMfa::class])->name('organisations.invitations.destroy');

--- a/tests/Feature/Auth/AuthenticationTest.php
+++ b/tests/Feature/Auth/AuthenticationTest.php
@@ -32,6 +32,7 @@ class AuthenticationTest extends TestCase
         $invitation = OrganisationInvitation::factory()->forToken($token)->create([
             'organisation_id' => $organisation->id,
             'email' => 'invited@example.com',
+            'offers_ownership' => true,
             'invited_by' => $owner->id,
         ]);
 
@@ -41,7 +42,8 @@ class AuthenticationTest extends TestCase
         $response->assertInertia(fn (Assert $page) => $page
             ->component('auth/login')
             ->where('organisationInvitation.code', $token)
-            ->where('organisationInvitation.organisationName', 'Laravel Organisation'),
+            ->where('organisationInvitation.organisationName', 'Laravel Organisation')
+            ->where('organisationInvitation.offersOwnership', true),
         );
     }
 

--- a/tests/Feature/Auth/StaffAccessSecurityTest.php
+++ b/tests/Feature/Auth/StaffAccessSecurityTest.php
@@ -17,6 +17,10 @@ beforeEach(function () {
 test('issued invitations store only a hash and expire after 72 hours', function () {
     $inviter = User::factory()->create();
     $organisation = Organisation::factory()->create();
+    $organisation->memberships()->create([
+        'user_id' => $inviter->id,
+        'is_owner' => true,
+    ]);
 
     $issued = app(IssueOrganisationInvitation::class)->handle(
         $organisation,
@@ -80,6 +84,7 @@ test('sensitive organisation actions require a recent MFA confirmation', functio
         ->withSession(['auth.password_confirmed_at' => time()])
         ->post(route('organisations.invitations.store', $organisation), [
             'email' => 'invited@example.com',
+            'new_person_name' => 'Invited Person',
             'role' => OrganisationRole::CaseWorker->value,
         ])
         ->assertRedirect(route('mfa.confirm'));
@@ -202,6 +207,7 @@ test('password confirmation after a mutation returns to its safe form page', fun
         ->from($formUrl)
         ->post(route('organisations.invitations.store', $organisation), [
             'email' => 'invited@example.com',
+            'new_person_name' => 'Invited Person',
             'role' => OrganisationRole::CaseWorker->value,
         ])
         ->assertRedirect(route('password.confirm'));
@@ -224,6 +230,7 @@ test('MFA confirmation after a mutation returns to its safe form page', function
         ->from($formUrl)
         ->post(route('organisations.invitations.store', $organisation), [
             'email' => 'invited@example.com',
+            'new_person_name' => 'Invited Person',
             'role' => OrganisationRole::CaseWorker->value,
         ])
         ->assertRedirect(route('mfa.confirm'));

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -57,6 +57,8 @@ class DashboardTest extends TestCase
         $invitation = OrganisationInvitation::factory()->create([
             'organisation_id' => $organisation->id,
             'email' => 'invited@example.com',
+            'new_person_name' => 'Invited Person',
+            'offers_ownership' => true,
             'invited_by' => $owner->id,
         ]);
 
@@ -70,6 +72,10 @@ class DashboardTest extends TestCase
             ->has('pendingInvitations', 1)
             ->where('pendingInvitations.0.id', $invitation->id)
             ->where('pendingInvitations.0.inviterName', 'Taylor Otwell')
+            ->where('pendingInvitations.0.personName', 'Invited Person')
+            ->where('pendingInvitations.0.offersOwnership', true)
+            ->where('pendingInvitations.0.roleAssignments.0.roleLabel', 'Case worker')
+            ->where('pendingInvitations.0.roleAssignments.0.scopeLabel', 'Organisation-wide')
             ->where('pendingInvitations.0.organisation.name', 'Laravel Organisation')
             ->where('pendingInvitations.0.organisation.slug', $organisation->slug)
             ->missing('pendingInvitations.0.organisationName'),

--- a/tests/Feature/OrganisationMembershipAccessTest.php
+++ b/tests/Feature/OrganisationMembershipAccessTest.php
@@ -1,0 +1,334 @@
+<?php
+
+use App\Actions\Organisations\AcceptOrganisationInvitation;
+use App\Actions\Organisations\IssueOrganisationInvitation;
+use App\Enums\OrganisationRole;
+use App\Enums\PartyKind;
+use App\Http\Middleware\EnsureRecentMfa;
+use App\Http\Middleware\EnsureRecentPassword;
+use App\Http\Middleware\EnsureStaffSecurityRequirements;
+use App\Http\Middleware\ProtectSensitiveFortifyRoutes;
+use App\Models\Membership;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\Program;
+use App\Models\User;
+use App\OrganisationContext;
+use App\Policies\ProgramPolicy;
+use Illuminate\Validation\ValidationException;
+
+beforeEach(function () {
+    $this->withoutMiddleware([
+        EnsureStaffSecurityRequirements::class,
+        EnsureRecentMfa::class,
+        EnsureRecentPassword::class,
+        ProtectSensitiveFortifyRoutes::class,
+    ]);
+});
+
+function createMembership(Organisation $organisation, User $user, ?OrganisationRole $role = null, bool $isOwner = false): Membership
+{
+    $organisation->members()->attach($user, [
+        'role' => $role?->value,
+        'is_owner' => $isOwner,
+    ]);
+
+    return $organisation->memberships()->where('user_id', $user->id)->firstOrFail();
+}
+
+test('verified invitation acceptance links the explicit Party and creates independently scoped roles', function () {
+    $owner = User::factory()->create();
+    $invitedUser = User::factory()->unverified()->create(['email' => 'sam@example.test']);
+    $organisation = Organisation::factory()->active()->create();
+    createMembership($organisation, $owner, isOwner: true);
+
+    [$programA, $programB, $party] = app(OrganisationContext::class)->run($organisation, function () use ($organisation) {
+        return [
+            Program::factory()->create(['organisation_id' => $organisation->id]),
+            Program::factory()->create(['organisation_id' => $organisation->id]),
+            Party::factory()->create([
+                'organisation_id' => $organisation->id,
+                'kind' => PartyKind::Person,
+                'display_name' => 'Sam Person',
+            ]),
+        ];
+    });
+
+    $issued = app(IssueOrganisationInvitation::class)->handle(
+        $organisation,
+        $owner,
+        $invitedUser->email,
+        $party->id,
+        null,
+        [
+            ['role' => OrganisationRole::ProgramManager->value, 'program_id' => $programA->id],
+            ['role' => OrganisationRole::CaseWorker->value, 'program_id' => $programB->id],
+        ],
+    );
+
+    expect(fn () => app(AcceptOrganisationInvitation::class)->handle($invitedUser, $issued->invitation))
+        ->toThrow(ValidationException::class)
+        ->and($organisation->memberships()->where('user_id', $invitedUser->id)->exists())->toBeFalse();
+
+    $invitedUser->markEmailAsVerified();
+    app(AcceptOrganisationInvitation::class)->handle($invitedUser, $issued->invitation);
+
+    $membership = $organisation->memberships()->where('user_id', $invitedUser->id)->firstOrFail();
+    $assignments = app(OrganisationContext::class)->run(
+        $organisation,
+        fn () => $membership->roleAssignments()->whereNull('ended_at')->get(),
+    );
+
+    expect($membership->person_party_id)->toBe($party->id)
+        ->and($assignments)->toHaveCount(2)
+        ->and($assignments->pluck('program_id')->all())->toEqualCanonicalizing([$programA->id, $programB->id]);
+});
+
+test('email matching never selects an existing person Party', function () {
+    $owner = User::factory()->create();
+    $invitedUser = User::factory()->create(['email' => 'person@example.test']);
+    $organisation = Organisation::factory()->active()->create();
+    createMembership($organisation, $owner, isOwner: true);
+
+    $existingParty = app(OrganisationContext::class)->run(
+        $organisation,
+        fn () => Party::factory()->create([
+            'organisation_id' => $organisation->id,
+            'kind' => PartyKind::Person,
+            'display_name' => $invitedUser->email,
+        ]),
+    );
+
+    $issued = app(IssueOrganisationInvitation::class)->handle(
+        $organisation,
+        $owner,
+        $invitedUser->email,
+        null,
+        'Different Person',
+        [['role' => OrganisationRole::CaseWorker->value, 'program_id' => null]],
+    );
+    app(AcceptOrganisationInvitation::class)->handle($invitedUser, $issued->invitation);
+
+    $membership = $organisation->memberships()->where('user_id', $invitedUser->id)->firstOrFail();
+
+    expect($membership->person_party_id)->not->toBe($existingParty->id);
+});
+
+test('Owner responsibility is separate and accepted only through an Owner-issued invitation', function () {
+    $owner = User::factory()->create();
+    $administrator = User::factory()->create();
+    $invitedUser = User::factory()->create(['email' => 'new-owner@example.test']);
+    $organisation = Organisation::factory()->active()->create();
+    createMembership($organisation, $owner, isOwner: true);
+    createMembership($organisation, $administrator, OrganisationRole::OrganisationAdministrator);
+
+    expect(fn () => app(IssueOrganisationInvitation::class)->handle(
+        $organisation,
+        $administrator,
+        $invitedUser->email,
+        null,
+        'New Owner',
+        [['role' => OrganisationRole::ExecutiveViewer->value, 'program_id' => null]],
+        true,
+    ))->toThrow(ValidationException::class);
+
+    $issued = app(IssueOrganisationInvitation::class)->handle(
+        $organisation,
+        $owner,
+        $invitedUser->email,
+        null,
+        'New Owner',
+        [['role' => OrganisationRole::ExecutiveViewer->value, 'program_id' => null]],
+        true,
+    );
+    app(AcceptOrganisationInvitation::class)->handle($invitedUser, $issued->invitation);
+
+    expect($invitedUser->fresh()->ownsOrganisation($organisation))->toBeTrue()
+        ->and($invitedUser->hasOrganisationRole($organisation, OrganisationRole::ExecutiveViewer))->toBeTrue();
+});
+
+test('rejoining creates a new tenure and retains the ended Membership', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create(['email' => 'returning@example.test']);
+    $organisation = Organisation::factory()->active()->create();
+    createMembership($organisation, $owner, isOwner: true);
+    $endedMembership = createMembership($organisation, $member, OrganisationRole::CaseWorker);
+
+    app(OrganisationContext::class)->run($organisation, fn () => $endedMembership->end());
+    $partyId = $endedMembership->person_party_id;
+    $issued = app(IssueOrganisationInvitation::class)->handle(
+        $organisation,
+        $owner,
+        $member->email,
+        $partyId,
+        null,
+        [['role' => OrganisationRole::EngagementOfficer->value, 'program_id' => null]],
+    );
+    app(AcceptOrganisationInvitation::class)->handle($member, $issued->invitation);
+
+    $history = $organisation->membershipHistory()->where('user_id', $member->id)->orderBy('id')->get();
+
+    expect($history)->toHaveCount(2)
+        ->and($history->first()->ended_at)->not->toBeNull()
+        ->and($history->last()->id)->not->toBe($endedMembership->id)
+        ->and($history->last()->person_party_id)->toBe($partyId);
+});
+
+test('an ended tenure cannot be nominated for Organisation ownership', function () {
+    $owner = User::factory()->create();
+    $formerMember = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    createMembership($organisation, $owner, isOwner: true);
+    $membership = createMembership($organisation, $formerMember, OrganisationRole::CaseWorker);
+    app(OrganisationContext::class)->run($organisation, fn () => $membership->end());
+
+    $this->actingAs($owner)
+        ->post(route('organisations.ownership-transfers.store', $organisation), [
+            'nominee_user_id' => $formerMember->id,
+        ])
+        ->assertSessionHasErrors('nominee_user_id');
+});
+
+test('different roles contribute only within their independent scopes', function () {
+    $owner = User::factory()->create();
+    $member = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    createMembership($organisation, $owner, isOwner: true);
+    $membership = createMembership($organisation, $member);
+
+    [$managedProgram, $caseProgram, $otherProgram] = app(OrganisationContext::class)->run(
+        $organisation,
+        fn () => [
+            Program::factory()->create(['organisation_id' => $organisation->id]),
+            Program::factory()->create(['organisation_id' => $organisation->id]),
+            Program::factory()->create(['organisation_id' => $organisation->id]),
+        ],
+    );
+
+    app(OrganisationContext::class)->run($organisation, function () use ($membership, $organisation, $managedProgram, $caseProgram): void {
+        $membership->roleAssignments()->createMany([
+            ['organisation_id' => $organisation->id, 'role' => OrganisationRole::ProgramManager, 'program_id' => $managedProgram->id],
+            ['organisation_id' => $organisation->id, 'role' => OrganisationRole::CaseWorker, 'program_id' => $caseProgram->id],
+        ]);
+    });
+
+    app(OrganisationContext::class)->run($organisation, function () use ($owner, $member, $managedProgram, $caseProgram, $otherProgram): void {
+        $policy = app(ProgramPolicy::class);
+
+        expect($policy->update($member, $managedProgram))->toBeTrue()
+            ->and($policy->view($member, $caseProgram))->toBeTrue()
+            ->and($policy->update($member, $caseProgram))->toBeFalse()
+            ->and($policy->view($member, $otherProgram))->toBeFalse()
+            ->and($policy->view($owner, $managedProgram))->toBeFalse();
+    });
+});
+
+test('Organisation Administrators cannot self-escalate or appoint another administrator', function () {
+    $owner = User::factory()->create();
+    $administrator = User::factory()->create();
+    $member = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    createMembership($organisation, $owner, isOwner: true);
+    createMembership($organisation, $administrator, OrganisationRole::OrganisationAdministrator);
+    createMembership($organisation, $member, OrganisationRole::CaseWorker);
+
+    $this->actingAs($administrator)
+        ->patch(route('organisations.members.update', [$organisation, $administrator]), [
+            'role_assignments' => [['role' => OrganisationRole::ProgramManager->value, 'program_id' => null]],
+        ])
+        ->assertSessionHasErrors('role_assignments');
+
+    $this->actingAs($administrator)
+        ->patch(route('organisations.members.update', [$organisation, $member]), [
+            'role_assignments' => [['role' => OrganisationRole::OrganisationAdministrator->value, 'program_id' => null]],
+        ])
+        ->assertSessionHasErrors('role_assignments');
+});
+
+test('duplicate role and scope proposals are rejected before an invitation is created', function () {
+    $owner = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    createMembership($organisation, $owner, isOwner: true);
+
+    $this->actingAs($owner)
+        ->post(route('organisations.invitations.store', $organisation), [
+            'email' => 'duplicate@example.test',
+            'new_person_name' => 'Duplicate Example',
+            'role_assignments' => [
+                ['role' => OrganisationRole::CaseWorker->value, 'program_id' => null],
+                ['role' => OrganisationRole::CaseWorker->value, 'program_id' => null],
+            ],
+        ])
+        ->assertSessionHasErrors('role_assignments');
+
+    $this->assertDatabaseMissing('organisation_invitations', ['email' => 'duplicate@example.test']);
+});
+
+test('a Membership Hold pauses only that Membership and preserves capable owner continuity', function () {
+    $owner = User::factory()->create();
+    $secondOwner = User::factory()->create();
+    $member = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    createMembership($organisation, $owner, isOwner: true);
+    createMembership($organisation, $secondOwner, isOwner: true);
+    createMembership($organisation, $member, OrganisationRole::OrganisationAdministrator);
+
+    $this->actingAs($owner)
+        ->post(route('organisations.members.holds.store', [$organisation, $member]), [
+            'reason' => 'Temporary safeguarding review',
+            'review_at' => now()->addDay()->toISOString(),
+        ])
+        ->assertRedirect();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($member, $organisation): void {
+        expect($member->fresh()->hasOrganisationRole($organisation, OrganisationRole::OrganisationAdministrator))->toBeFalse();
+    });
+
+    $hold = app(OrganisationContext::class)->run(
+        $organisation,
+        fn () => $organisation->memberships()->where('user_id', $member->id)->firstOrFail()->holds()->firstOrFail(),
+    );
+    $this->actingAs($owner)
+        ->delete(route('organisations.members.holds.destroy', [$organisation, $member, $hold]))
+        ->assertRedirect();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($member, $organisation): void {
+        expect($member->fresh()->hasOrganisationRole($organisation, OrganisationRole::OrganisationAdministrator))->toBeTrue();
+    });
+
+    $this->actingAs($owner)
+        ->post(route('organisations.members.holds.store', [$organisation, $secondOwner]), [
+            'reason' => 'Temporary governance review',
+            'review_at' => now()->addDay()->toISOString(),
+        ])
+        ->assertRedirect();
+
+    $this->actingAs($owner)
+        ->post(route('organisations.members.holds.store', [$organisation, $owner]), [
+            'reason' => 'Would remove final capable owner',
+            'review_at' => now()->addDay()->toISOString(),
+        ])
+        ->assertForbidden();
+});
+
+test('an invitation cannot select a person Party from another Organisation', function () {
+    $owner = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    $otherOrganisation = Organisation::factory()->active()->create();
+    createMembership($organisation, $owner, isOwner: true);
+    $foreignParty = app(OrganisationContext::class)->run(
+        $otherOrganisation,
+        fn () => Party::factory()->create([
+            'organisation_id' => $otherOrganisation->id,
+            'kind' => PartyKind::Person,
+        ]),
+    );
+
+    $this->actingAs($owner)
+        ->post(route('organisations.invitations.store', $organisation), [
+            'email' => 'invitee@example.test',
+            'person_party_id' => $foreignParty->id,
+            'role_assignments' => [['role' => OrganisationRole::CaseWorker->value, 'program_id' => null]],
+        ])
+        ->assertSessionHasErrors('person_party_id');
+});

--- a/tests/Feature/Organisations/OrganisationInvitationTest.php
+++ b/tests/Feature/Organisations/OrganisationInvitationTest.php
@@ -45,6 +45,7 @@ class OrganisationInvitationTest extends TestCase
             ->actingAs($owner)
             ->post(route('organisations.invitations.store', $organisation), [
                 'email' => 'invited@example.com',
+                'new_person_name' => 'Invited Person',
                 'role' => OrganisationRole::CaseWorker->value,
             ]);
 
@@ -113,6 +114,7 @@ class OrganisationInvitationTest extends TestCase
             ->actingAs($admin)
             ->post(route('organisations.invitations.store', $organisation), [
                 'email' => 'invited@example.com',
+                'new_person_name' => 'Invited Person',
                 'role' => OrganisationRole::CaseWorker->value,
             ]);
 
@@ -134,6 +136,7 @@ class OrganisationInvitationTest extends TestCase
             ->actingAs($admin)
             ->post(route('organisations.invitations.store', $organisation), [
                 'email' => 'invited@example.com',
+                'new_person_name' => 'Invited Person',
                 'role' => 'owner',
             ]);
 
@@ -161,6 +164,7 @@ class OrganisationInvitationTest extends TestCase
             ->actingAs($owner)
             ->post(route('organisations.invitations.store', $organisation), [
                 'email' => 'member@example.com',
+                'new_person_name' => 'Existing Member',
                 'role' => OrganisationRole::CaseWorker->value,
             ]);
 
@@ -185,6 +189,7 @@ class OrganisationInvitationTest extends TestCase
             ->actingAs($owner)
             ->post(route('organisations.invitations.store', $organisation), [
                 'email' => 'invited@example.com',
+                'new_person_name' => 'Invited Person',
                 'role' => OrganisationRole::CaseWorker->value,
             ]);
 
@@ -208,6 +213,7 @@ class OrganisationInvitationTest extends TestCase
             ->actingAs($owner)
             ->post(route('organisations.invitations.store', $organisation), [
                 'email' => 'invited@example.com',
+                'new_person_name' => 'Invited Person',
                 'role' => OrganisationRole::CaseWorker->value,
             ]);
 
@@ -249,6 +255,7 @@ class OrganisationInvitationTest extends TestCase
             ->actingAs($member)
             ->post(route('organisations.invitations.store', $organisation), [
                 'email' => 'invited@example.com',
+                'new_person_name' => 'Invited Person',
                 'role' => OrganisationRole::CaseWorker->value,
             ]);
 


### PR DESCRIPTION
Closes #38

## Summary
- link every accepted Organisation Membership tenure to an explicit Organisation-owned person Party and retain ended tenures
- replace the single effective role with independently scoped Role Assignments while keeping ownership separate from operational access
- add reasoned, audited Membership Holds with capable-owner safeguards and administrator self-escalation controls
- update invitation, member-management, and dashboard UI for Party selection, multiple scopes, and explicit Owner responsibility

## Verification
- `vendor/bin/pint --dirty --format agent`
- `composer types:check`
- `npm run check`
- `npm run types:check`
- `npm test`
- `npm run build`
- `php artisan test --compact` (204 tests, 791 assertions)
- fresh migration and rollback against temporary SQLite database
- reviewed complete diff against `origin/main` and fixed findings