### PR TITLE
Encrypt classified Party contacts with tenant-bound matching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,14 @@ APP_RELEASE=development
 APP_SOURCE_REPOSITORY=https://github.com/datashaman/community-kind
 ORGANISATION_SELF_SERVICE_PROVISIONING=false
 
+# Supply independent, versioned key rings through the environment or secret store.
+# Values are JSON objects whose keys are versions and whose values are base64: keys.
+CLASSIFIED_DATA_KEY_CURRENT=
+CLASSIFIED_DATA_KEYS=
+CONTACT_INDEX_KEY_CURRENT=
+CONTACT_INDEX_KEY_PREVIOUS=
+CONTACT_INDEX_KEYS=
+
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en
 APP_FAKER_LOCALE=en_US

--- a/app/Actions/Parties/FindPartiesByContact.php
+++ b/app/Actions/Parties/FindPartiesByContact.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Actions\Parties;
+
+use App\Cryptography\ContactBlindIndexer;
+use App\Enums\PartyContactType;
+use App\Models\Party;
+use App\Models\PartyContactPoint;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+
+class FindPartiesByContact
+{
+    public function __construct(
+        private readonly OrganisationContext $organisationContext,
+        private readonly ContactBlindIndexer $blindIndexer,
+    ) {}
+
+    /** @return Collection<int, Party> */
+    public function handle(PartyContactType $type, #[\SensitiveParameter] string $value): Collection
+    {
+        $organisation = $this->organisationContext->organisation();
+        $indexes = $this->blindIndexer->indexesForQuery($organisation->uuid, $type, $value);
+
+        $partyIds = PartyContactPoint::query()
+            ->where('type', $type)
+            ->where(function (Builder $query) use ($indexes): void {
+                foreach ($indexes as $version => $blindIndex) {
+                    $query->orWhere(function (Builder $query) use ($version, $blindIndex): void {
+                        $query->where('current_index_key_version', $version)
+                            ->where('current_blind_index', $blindIndex);
+                    })->orWhere(function (Builder $query) use ($version, $blindIndex): void {
+                        $query->where('previous_index_key_version', $version)
+                            ->where('previous_blind_index', $blindIndex);
+                    });
+                }
+            })
+            ->pluck('party_id')
+            ->unique();
+
+        return Party::query()
+            ->whereKey($partyIds)
+            ->orderBy('display_name')
+            ->orderBy('id')
+            ->get();
+    }
+}

--- a/app/Actions/Parties/RebuildPartyContactBlindIndexes.php
+++ b/app/Actions/Parties/RebuildPartyContactBlindIndexes.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Actions\Parties;
+
+use App\Cryptography\ContactBlindIndexer;
+use App\Models\Organisation;
+use App\Models\PartyContactPoint;
+use App\Models\PlatformSecurityEvent;
+use App\OrganisationContext;
+
+class RebuildPartyContactBlindIndexes
+{
+    public function __construct(
+        private readonly OrganisationContext $organisationContext,
+        private readonly ContactBlindIndexer $blindIndexer,
+    ) {}
+
+    public function handle(Organisation $organisation): int
+    {
+        $this->organisationContext->ensureOwns($organisation->id);
+        $currentVersion = $this->blindIndexer->currentVersion();
+        $previousVersion = $this->blindIndexer->previousVersion();
+        $rebuilt = 0;
+
+        PartyContactPoint::query()->lazyById()->each(function (PartyContactPoint $contactPoint) use (
+            $organisation,
+            $currentVersion,
+            $previousVersion,
+            &$rebuilt,
+        ): void {
+            $indexes = $this->blindIndexer->indexesForWrite(
+                $organisation->uuid,
+                $contactPoint->type,
+                $contactPoint->encrypted_value->reveal(),
+            );
+            $attributes = [
+                'current_index_key_version' => $currentVersion,
+                'current_blind_index' => $indexes[$currentVersion],
+                'previous_index_key_version' => $previousVersion,
+                'previous_blind_index' => $previousVersion === null ? null : $indexes[$previousVersion],
+            ];
+
+            $contactPoint->forceFill($attributes);
+
+            if (! $contactPoint->isDirty(array_keys($attributes))) {
+                return;
+            }
+
+            $contactPoint->save();
+            $rebuilt++;
+        });
+
+        PlatformSecurityEvent::query()->create([
+            'type' => 'party_contact_index_key_rebuilt',
+            'metadata' => [
+                'organisation_uuid' => $organisation->uuid,
+                'record_count' => $rebuilt,
+                'current_version' => $currentVersion,
+                'previous_version' => $previousVersion,
+            ],
+            'occurred_at' => now(),
+        ]);
+
+        return $rebuilt;
+    }
+}

--- a/app/Actions/Parties/RotatePartyContactDataEncryption.php
+++ b/app/Actions/Parties/RotatePartyContactDataEncryption.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Actions\Parties;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Models\Organisation;
+use App\Models\PartyContactPoint;
+use App\Models\PlatformSecurityEvent;
+use App\OrganisationContext;
+
+class RotatePartyContactDataEncryption
+{
+    public function __construct(
+        private readonly OrganisationContext $organisationContext,
+        private readonly ClassifiedDataEncrypter $encrypter,
+    ) {}
+
+    public function handle(Organisation $organisation): int
+    {
+        $this->organisationContext->ensureOwns($organisation->id);
+        $currentVersion = $this->encrypter->currentVersion();
+        $rotated = 0;
+        $previousVersions = [];
+
+        PartyContactPoint::query()
+            ->where('data_key_version', '!=', $currentVersion)
+            ->lazyById()
+            ->each(function (PartyContactPoint $contactPoint) use (
+                $currentVersion,
+                &$rotated,
+                &$previousVersions,
+            ): void {
+                $previousVersions[] = $contactPoint->data_key_version;
+                $value = $contactPoint->encrypted_value;
+                $contactPoint->encrypted_value = new ClassifiedValue($value->reveal());
+                $contactPoint->forceFill(['data_key_version' => $currentVersion]);
+                $contactPoint->save();
+                $rotated++;
+            });
+
+        PlatformSecurityEvent::query()->create([
+            'type' => 'party_contact_data_key_rotated',
+            'metadata' => [
+                'organisation_uuid' => $organisation->uuid,
+                'record_count' => $rotated,
+                'from_versions' => array_values(array_unique($previousVersions)),
+                'to_version' => $currentVersion,
+            ],
+            'occurred_at' => now(),
+        ]);
+
+        return $rotated;
+    }
+}

--- a/app/Actions/Parties/StorePartyContact.php
+++ b/app/Actions/Parties/StorePartyContact.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Actions\Parties;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Cryptography\ContactBlindIndexer;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\PartyContactType;
+use App\Models\Party;
+use App\Models\PartyContactPoint;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+
+class StorePartyContact
+{
+    public function __construct(
+        private readonly OrganisationContext $organisationContext,
+        private readonly ClassifiedDataEncrypter $encrypter,
+        private readonly ContactBlindIndexer $blindIndexer,
+    ) {}
+
+    public function handle(
+        Party $party,
+        PartyContactType $type,
+        #[\SensitiveParameter] string $value,
+    ): PartyContactPoint {
+        $this->organisationContext->ensureOwns($party->organisation_id);
+        $organisation = $this->organisationContext->organisation();
+        $indexes = $this->blindIndexer->indexesForWrite($organisation->uuid, $type, $value);
+        $currentVersion = $this->blindIndexer->currentVersion();
+        $previousVersion = $this->blindIndexer->previousVersion();
+
+        return DB::transaction(function () use (
+            $party,
+            $type,
+            $value,
+            $indexes,
+            $currentVersion,
+            $previousVersion,
+        ): PartyContactPoint {
+            $contactPoint = new PartyContactPoint;
+            $contactPoint->id = $contactPoint->newUniqueId();
+            $contactPoint->organisation_id = $party->organisation_id;
+            $contactPoint->party_id = $party->id;
+            $contactPoint->type = $type;
+            $contactPoint->encrypted_value = new ClassifiedValue($value);
+            $contactPoint->forceFill([
+                'data_key_version' => $this->encrypter->currentVersion(),
+                'current_index_key_version' => $currentVersion,
+                'current_blind_index' => $indexes[$currentVersion],
+                'previous_index_key_version' => $previousVersion,
+                'previous_blind_index' => $previousVersion === null ? null : $indexes[$previousVersion],
+            ]);
+            $contactPoint->save();
+
+            return $contactPoint;
+        });
+    }
+}

--- a/app/Casts/ClassifiedValueCast.php
+++ b/app/Casts/ClassifiedValueCast.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Casts;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Exceptions\ClassifiedDataUnavailable;
+use App\OrganisationContext;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+/** @implements CastsAttributes<ClassifiedValue, mixed> */
+class ClassifiedValueCast implements CastsAttributes
+{
+    public bool $withoutObjectCaching = true;
+
+    public function __construct(private readonly string $fieldPrefix) {}
+
+    public function get(Model $model, string $key, mixed $value, array $attributes): ?ClassifiedValue
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (! is_string($value)) {
+            throw new ClassifiedDataUnavailable;
+        }
+
+        [$organisationUuid, $recordUuid, $field] = $this->context($model, $attributes);
+
+        return app(ClassifiedDataEncrypter::class)->decrypt(
+            $value,
+            $organisationUuid,
+            $recordUuid,
+            $field,
+        );
+    }
+
+    public function set(Model $model, string $key, mixed $value, array $attributes): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $classifiedValue = is_string($value) ? new ClassifiedValue($value) : $value;
+
+        if (! $classifiedValue instanceof ClassifiedValue) {
+            throw new ClassifiedDataUnavailable;
+        }
+
+        [$organisationUuid, $recordUuid, $field] = $this->context($model, $attributes);
+
+        return app(ClassifiedDataEncrypter::class)->encrypt(
+            $classifiedValue,
+            $organisationUuid,
+            $recordUuid,
+            $field,
+        );
+    }
+
+    /** @param array<string, mixed> $attributes
+     * @return array{string, string, string}
+     */
+    private function context(Model $model, array $attributes): array
+    {
+        $organisationId = $attributes['organisation_id'] ?? null;
+        $recordUuid = $attributes['id'] ?? null;
+        $type = $attributes['type'] ?? null;
+
+        if (! is_numeric($organisationId) || ! is_string($recordUuid) || ! is_string($type)) {
+            throw new ClassifiedDataUnavailable;
+        }
+
+        $organisationContext = app(OrganisationContext::class);
+        $organisationContext->ensureOwns((int) $organisationId);
+
+        return [
+            $organisationContext->organisation()->uuid,
+            $recordUuid,
+            "{$this->fieldPrefix}.{$type}",
+        ];
+    }
+}

--- a/app/Cryptography/ClassifiedDataEncrypter.php
+++ b/app/Cryptography/ClassifiedDataEncrypter.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Cryptography;
+
+use App\Data\Values\ClassifiedValue;
+use App\Exceptions\ClassifiedDataUnavailable;
+use Illuminate\Encryption\Encrypter;
+use Throwable;
+
+class ClassifiedDataEncrypter
+{
+    public function __construct(private readonly VersionedKeyRing $keyRing) {}
+
+    public function currentVersion(): string
+    {
+        return $this->keyRing->currentVersion();
+    }
+
+    public function encrypt(
+        #[\SensitiveParameter] ClassifiedValue $value,
+        string $organisationUuid,
+        string $recordUuid,
+        string $field,
+    ): string {
+        try {
+            $version = $this->currentVersion();
+            $plaintext = json_encode([
+                'context' => $this->context($organisationUuid, $recordUuid, $field, $version),
+                'value' => $value->reveal(),
+            ], JSON_THROW_ON_ERROR);
+            $payload = $this->encrypter($version)->encryptString($plaintext);
+
+            return json_encode(['version' => $version, 'payload' => $payload], JSON_THROW_ON_ERROR);
+        } catch (ClassifiedDataUnavailable $exception) {
+            throw $exception;
+        } catch (Throwable $exception) {
+            throw new ClassifiedDataUnavailable($exception);
+        }
+    }
+
+    public function decrypt(
+        #[\SensitiveParameter] string $envelope,
+        string $organisationUuid,
+        string $recordUuid,
+        string $field,
+    ): ClassifiedValue {
+        try {
+            $encoded = json_decode($envelope, true, flags: JSON_THROW_ON_ERROR);
+
+            if (! is_array($encoded) || ! is_string($encoded['version'] ?? null) || ! is_string($encoded['payload'] ?? null)) {
+                throw new ClassifiedDataUnavailable;
+            }
+
+            $version = $encoded['version'];
+            $decrypted = $this->encrypter($version)->decryptString($encoded['payload']);
+            $plaintext = json_decode($decrypted, true, flags: JSON_THROW_ON_ERROR);
+            $expectedContext = $this->context($organisationUuid, $recordUuid, $field, $version);
+
+            if (! is_array($plaintext)
+                || ($plaintext['context'] ?? null) !== $expectedContext
+                || ! is_string($plaintext['value'] ?? null)) {
+                throw new ClassifiedDataUnavailable;
+            }
+
+            return new ClassifiedValue($plaintext['value']);
+        } catch (ClassifiedDataUnavailable $exception) {
+            throw $exception;
+        } catch (Throwable $exception) {
+            throw new ClassifiedDataUnavailable($exception);
+        }
+    }
+
+    /** @return array{organisation: string, record: string, field: string, key_version: string} */
+    private function context(string $organisationUuid, string $recordUuid, string $field, string $version): array
+    {
+        return [
+            'organisation' => $organisationUuid,
+            'record' => $recordUuid,
+            'field' => $field,
+            'key_version' => $version,
+        ];
+    }
+
+    private function encrypter(string $version): Encrypter
+    {
+        return new Encrypter($this->keyRing->key($version), 'aes-256-gcm');
+    }
+}

--- a/app/Cryptography/ContactBlindIndexer.php
+++ b/app/Cryptography/ContactBlindIndexer.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Cryptography;
+
+use App\Enums\PartyContactType;
+use App\Exceptions\ClassifiedDataUnavailable;
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+class ContactBlindIndexer
+{
+    public function __construct(private readonly VersionedKeyRing $keyRing) {}
+
+    public function currentVersion(): string
+    {
+        return $this->keyRing->currentVersion();
+    }
+
+    public function previousVersion(): ?string
+    {
+        return $this->keyRing->previousVersion();
+    }
+
+    /** @return array<string, string> */
+    public function indexesForWrite(string $organisationUuid, PartyContactType $type, #[\SensitiveParameter] string $value): array
+    {
+        $normalized = $this->normalize($type, $value);
+        $indexes = [];
+
+        foreach ($this->keyRing->writeVersions() as $version) {
+            $indexes[$version] = $this->digest($version, $organisationUuid, $type, $normalized);
+        }
+
+        return $indexes;
+    }
+
+    /** @return array<string, string> */
+    public function indexesForQuery(string $organisationUuid, PartyContactType $type, #[\SensitiveParameter] string $value): array
+    {
+        return $this->indexesForWrite($organisationUuid, $type, $value);
+    }
+
+    private function normalize(PartyContactType $type, #[\SensitiveParameter] string $value): string
+    {
+        return match ($type) {
+            PartyContactType::Email => $this->normalizeEmail($value),
+            PartyContactType::Telephone => $this->normalizeTelephone($value),
+        };
+    }
+
+    private function normalizeEmail(#[\SensitiveParameter] string $value): string
+    {
+        $normalized = Str::lower(trim($value));
+
+        if (filter_var($normalized, FILTER_VALIDATE_EMAIL) === false) {
+            throw new InvalidArgumentException('A valid email contact is required.');
+        }
+
+        return $normalized;
+    }
+
+    private function normalizeTelephone(#[\SensitiveParameter] string $value): string
+    {
+        $normalized = preg_replace('/[^0-9+]/', '', trim($value));
+
+        if (! is_string($normalized)) {
+            throw new ClassifiedDataUnavailable;
+        }
+
+        if (str_starts_with($normalized, '00')) {
+            $normalized = '+'.substr($normalized, 2);
+        }
+
+        if (preg_match('/\A\+?[0-9]{7,15}\z/', $normalized) !== 1) {
+            throw new InvalidArgumentException('A valid telephone contact is required.');
+        }
+
+        return $normalized;
+    }
+
+    private function digest(
+        string $version,
+        string $organisationUuid,
+        PartyContactType $type,
+        #[\SensitiveParameter] string $normalized,
+    ): string {
+        return hash_hmac(
+            'sha256',
+            implode('|', [$organisationUuid, $type->value, $normalized]),
+            $this->keyRing->key($version),
+        );
+    }
+}

--- a/app/Cryptography/VersionedKeyRing.php
+++ b/app/Cryptography/VersionedKeyRing.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Cryptography;
+
+use App\Exceptions\ClassifiedDataUnavailable;
+
+class VersionedKeyRing
+{
+    public function __construct(private readonly string $configurationKey) {}
+
+    public function currentVersion(): string
+    {
+        return $this->requiredVersion('current_version');
+    }
+
+    public function previousVersion(): ?string
+    {
+        $version = config("{$this->configurationKey}.previous_version");
+
+        if ($version === null || $version === '') {
+            return null;
+        }
+
+        $version = $this->validateVersion($version);
+
+        if ($version === $this->currentVersion()) {
+            throw new ClassifiedDataUnavailable;
+        }
+
+        return $version;
+    }
+
+    /** @return list<string> */
+    public function writeVersions(): array
+    {
+        $versions = [$this->currentVersion()];
+        $previousVersion = $this->previousVersion();
+
+        if ($previousVersion !== null) {
+            $versions[] = $previousVersion;
+        }
+
+        return $versions;
+    }
+
+    public function key(string $version): string
+    {
+        $version = $this->validateVersion($version);
+        $keys = config("{$this->configurationKey}.keys");
+
+        if (! is_array($keys) || ! isset($keys[$version]) || ! is_string($keys[$version])) {
+            throw new ClassifiedDataUnavailable;
+        }
+
+        $encodedKey = $keys[$version];
+
+        if (! str_starts_with($encodedKey, 'base64:')) {
+            throw new ClassifiedDataUnavailable;
+        }
+
+        $key = base64_decode(substr($encodedKey, 7), true);
+
+        if (! is_string($key) || mb_strlen($key, '8bit') !== 32) {
+            throw new ClassifiedDataUnavailable;
+        }
+
+        return $key;
+    }
+
+    private function requiredVersion(string $name): string
+    {
+        $version = config("{$this->configurationKey}.{$name}");
+
+        return $this->validateVersion($version);
+    }
+
+    private function validateVersion(mixed $version): string
+    {
+        if (! is_string($version) || preg_match('/\A[a-zA-Z0-9][a-zA-Z0-9._-]{0,63}\z/', $version) !== 1) {
+            throw new ClassifiedDataUnavailable;
+        }
+
+        return $version;
+    }
+}

--- a/app/Data/Values/ClassifiedValue.php
+++ b/app/Data/Values/ClassifiedValue.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Data\Values;
+
+class ClassifiedValue
+{
+    public function __construct(#[\SensitiveParameter] private readonly string $value) {}
+
+    public function reveal(): string
+    {
+        return $this->value;
+    }
+}

--- a/app/Enums/PartyContactType.php
+++ b/app/Enums/PartyContactType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum PartyContactType: string
+{
+    case Email = 'email';
+    case Telephone = 'telephone';
+}

--- a/app/Exceptions/ClassifiedDataUnavailable.php
+++ b/app/Exceptions/ClassifiedDataUnavailable.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Exceptions;
+
+use Illuminate\Contracts\Debug\ShouldntReport;
+use RuntimeException;
+use Throwable;
+
+class ClassifiedDataUnavailable extends RuntimeException implements ShouldntReport
+{
+    public function __construct(?Throwable $previous = null)
+    {
+        parent::__construct('Classified data is unavailable.', previous: $previous);
+    }
+}

--- a/app/Jobs/RebuildPartyContactBlindIndexes.php
+++ b/app/Jobs/RebuildPartyContactBlindIndexes.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Actions\Organisations\ResolveOrganisationAccess;
+use App\Actions\Parties\RebuildPartyContactBlindIndexes as RebuildPartyContactBlindIndexesAction;
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Models\Organisation;
+use App\OrganisationContext;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use LogicException;
+
+class RebuildPartyContactBlindIndexes implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 1;
+
+    public int $organisationId;
+
+    public int $accessVersion;
+
+    public function __construct(Organisation $organisation)
+    {
+        $currentOrganisation = Organisation::query()->findOrFail($organisation->id);
+        $this->organisationId = $currentOrganisation->id;
+        $this->accessVersion = $currentOrganisation->access_version;
+        $this->onQueue('bulk');
+    }
+
+    public function handle(
+        OrganisationContext $organisationContext,
+        ResolveOrganisationAccess $resolveOrganisationAccess,
+        RebuildPartyContactBlindIndexesAction $rebuild,
+    ): void {
+        $organisation = Organisation::query()->find($this->organisationId);
+
+        if ($organisation === null || $organisation->access_version !== $this->accessVersion) {
+            throw new LogicException('The queued Organisation context is stale or unavailable.');
+        }
+
+        if ($resolveOrganisationAccess->handle($organisation, OrganisationAccessScope::Jobs) !== OrganisationAccessLevel::Full) {
+            throw new LogicException('The Organisation context cannot run tenant jobs.');
+        }
+
+        $organisationContext->run($organisation, fn () => $rebuild->handle($organisation));
+    }
+}

--- a/app/Jobs/RotatePartyContactDataEncryption.php
+++ b/app/Jobs/RotatePartyContactDataEncryption.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Actions\Organisations\ResolveOrganisationAccess;
+use App\Actions\Parties\RotatePartyContactDataEncryption as RotatePartyContactDataEncryptionAction;
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Models\Organisation;
+use App\OrganisationContext;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use LogicException;
+
+class RotatePartyContactDataEncryption implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 1;
+
+    public int $organisationId;
+
+    public int $accessVersion;
+
+    public function __construct(Organisation $organisation)
+    {
+        $currentOrganisation = Organisation::query()->findOrFail($organisation->id);
+        $this->organisationId = $currentOrganisation->id;
+        $this->accessVersion = $currentOrganisation->access_version;
+        $this->onQueue('bulk');
+    }
+
+    public function handle(
+        OrganisationContext $organisationContext,
+        ResolveOrganisationAccess $resolveOrganisationAccess,
+        RotatePartyContactDataEncryptionAction $rotate,
+    ): void {
+        $organisation = Organisation::query()->find($this->organisationId);
+
+        if ($organisation === null || $organisation->access_version !== $this->accessVersion) {
+            throw new LogicException('The queued Organisation context is stale or unavailable.');
+        }
+
+        if ($resolveOrganisationAccess->handle($organisation, OrganisationAccessScope::Jobs) !== OrganisationAccessLevel::Full) {
+            throw new LogicException('The Organisation context cannot run tenant jobs.');
+        }
+
+        $organisationContext->run($organisation, fn () => $rotate->handle($organisation));
+    }
+}

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -8,6 +8,7 @@ use App\OrganisationContext;
 use Database\Factories\OrganisationFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -18,6 +19,7 @@ use Illuminate\Support\Carbon;
 
 /**
  * @property int $id
+ * @property string $uuid
  * @property string $name
  * @property string $slug
  * @property OrganisationStatus $status
@@ -36,7 +38,13 @@ use Illuminate\Support\Carbon;
 class Organisation extends Model
 {
     /** @use HasFactory<OrganisationFactory> */
-    use GeneratesUniqueOrganisationSlugs, HasFactory, SoftDeletes;
+    use GeneratesUniqueOrganisationSlugs, HasFactory, HasUuids, SoftDeletes;
+
+    /** @return list<string> */
+    public function uniqueIds(): array
+    {
+        return ['uuid'];
+    }
 
     /** @var array<string, mixed> */
     protected $attributes = [
@@ -142,6 +150,12 @@ class Organisation extends Model
     public function parties(): HasMany
     {
         return $this->hasMany(Party::class);
+    }
+
+    /** @return HasMany<PartyContactPoint, $this> */
+    public function partyContactPoints(): HasMany
+    {
+        return $this->hasMany(PartyContactPoint::class);
     }
 
     /** @return HasMany<OrganisationAccessHold, $this> */

--- a/app/Models/Party.php
+++ b/app/Models/Party.php
@@ -7,6 +7,7 @@ use App\Enums\PartyKind;
 use Database\Factories\PartyFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -15,17 +16,25 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
  * @property int $id
+ * @property string $uuid
  * @property int $organisation_id
  * @property PartyKind $kind
  * @property string $display_name
  * @property-read Organisation $organisation
  * @property-read Collection<int, Membership> $memberships
+ * @property-read Collection<int, PartyContactPoint> $contactPoints
  */
 #[Fillable(['organisation_id', 'kind', 'display_name'])]
 class Party extends Model
 {
     /** @use HasFactory<PartyFactory> */
-    use BelongsToOrganisation, HasFactory, SoftDeletes;
+    use BelongsToOrganisation, HasFactory, HasUuids, SoftDeletes;
+
+    /** @return list<string> */
+    public function uniqueIds(): array
+    {
+        return ['uuid'];
+    }
 
     /** @return BelongsTo<Organisation, $this> */
     public function organisation(): BelongsTo
@@ -37,6 +46,12 @@ class Party extends Model
     public function memberships(): HasMany
     {
         return $this->hasMany(Membership::class, 'person_party_id');
+    }
+
+    /** @return HasMany<PartyContactPoint, $this> */
+    public function contactPoints(): HasMany
+    {
+        return $this->hasMany(PartyContactPoint::class);
     }
 
     /** @return array<string, string> */

--- a/app/Models/PartyContactPoint.php
+++ b/app/Models/PartyContactPoint.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\ClassifiedValueCast;
+use App\Concerns\BelongsToOrganisation;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\PartyContactType;
+use Database\Factories\PartyContactPointFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property int $party_id
+ * @property PartyContactType $type
+ * @property ClassifiedValue $encrypted_value
+ * @property string $data_key_version
+ * @property string $current_index_key_version
+ * @property string $current_blind_index
+ * @property string|null $previous_index_key_version
+ * @property string|null $previous_blind_index
+ * @property-read Organisation $organisation
+ * @property-read Party $party
+ */
+#[Fillable(['party_id', 'type', 'encrypted_value'])]
+class PartyContactPoint extends Model
+{
+    /** @use HasFactory<PartyContactPointFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected $hidden = [
+        'encrypted_value',
+        'current_blind_index',
+        'previous_blind_index',
+    ];
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return BelongsTo<Party, $this> */
+    public function party(): BelongsTo
+    {
+        return $this->belongsTo(Party::class)->withTrashed();
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'type' => PartyContactType::class,
+            'encrypted_value' => ClassifiedValueCast::class.':party_contact',
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace App\Providers;
 
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Cryptography\ContactBlindIndexer;
+use App\Cryptography\VersionedKeyRing;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
@@ -16,7 +19,14 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->bind(
+            ClassifiedDataEncrypter::class,
+            fn () => new ClassifiedDataEncrypter(new VersionedKeyRing('classified_data.encryption')),
+        );
+        $this->app->bind(
+            ContactBlindIndexer::class,
+            fn () => new ContactBlindIndexer(new VersionedKeyRing('classified_data.contact_index')),
+        );
     }
 
     /**

--- a/config/classified_data.php
+++ b/config/classified_data.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'encryption' => [
+        'current_version' => env('CLASSIFIED_DATA_KEY_CURRENT'),
+        'keys' => json_decode((string) env('CLASSIFIED_DATA_KEYS', '{}'), true) ?: [],
+    ],
+
+    'contact_index' => [
+        'current_version' => env('CONTACT_INDEX_KEY_CURRENT'),
+        'previous_version' => env('CONTACT_INDEX_KEY_PREVIOUS'),
+        'keys' => json_decode((string) env('CONTACT_INDEX_KEYS', '{}'), true) ?: [],
+    ],
+];

--- a/database/factories/PartyContactPointFactory.php
+++ b/database/factories/PartyContactPointFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Cryptography\ContactBlindIndexer;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\PartyContactType;
+use App\Models\Party;
+use App\Models\PartyContactPoint;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PartyContactPoint>
+ */
+class PartyContactPointFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $organisation = app(OrganisationContext::class)->organisation();
+        $type = PartyContactType::Email;
+        $value = fake()->safeEmail();
+        $blindIndexer = app(ContactBlindIndexer::class);
+        $indexes = $blindIndexer->indexesForWrite($organisation->uuid, $type, $value);
+        $currentVersion = $blindIndexer->currentVersion();
+        $previousVersion = $blindIndexer->previousVersion();
+        $contactPoint = new PartyContactPoint;
+
+        return [
+            'id' => $contactPoint->newUniqueId(),
+            'organisation_id' => $organisation->id,
+            'party_id' => Party::factory()->state(['organisation_id' => $organisation->id]),
+            'type' => $type,
+            'encrypted_value' => new ClassifiedValue($value),
+            'data_key_version' => app(ClassifiedDataEncrypter::class)->currentVersion(),
+            'current_index_key_version' => $currentVersion,
+            'current_blind_index' => $indexes[$currentVersion],
+            'previous_index_key_version' => $previousVersion,
+            'previous_blind_index' => $previousVersion === null ? null : $indexes[$previousVersion],
+        ];
+    }
+}

--- a/database/migrations/2026_08_31_021947_add_uuids_and_create_party_contact_points_table.php
+++ b/database/migrations/2026_08_31_021947_add_uuids_and_create_party_contact_points_table.php
@@ -1,0 +1,140 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('organisations', function (Blueprint $table) {
+            $table->uuid('uuid')->nullable();
+        });
+
+        DB::table('organisations')->orderBy('id')->eachById(function (object $organisation): void {
+            DB::table('organisations')->where('id', $organisation->id)->update(['uuid' => (string) Str::uuid7()]);
+        });
+
+        Schema::table('organisations', function (Blueprint $table) {
+            $table->uuid('uuid')->nullable(false)->change();
+            $table->unique('uuid');
+        });
+
+        Schema::table('parties', function (Blueprint $table) {
+            $table->uuid('uuid')->nullable();
+        });
+
+        DB::table('parties')->orderBy('id')->eachById(function (object $party): void {
+            DB::table('parties')->where('id', $party->id)->update(['uuid' => (string) Str::uuid7()]);
+        });
+
+        Schema::table('parties', function (Blueprint $table) {
+            $table->uuid('uuid')->nullable(false)->change();
+            $table->unique('uuid');
+        });
+
+        Schema::create('party_contact_points', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id');
+            $table->foreignId('party_id');
+            $table->string('type', 32);
+            $table->text('encrypted_value');
+            $table->string('data_key_version', 64);
+            $table->string('current_index_key_version', 64);
+            $table->char('current_blind_index', 64);
+            $table->string('previous_index_key_version', 64)->nullable();
+            $table->char('previous_blind_index', 64)->nullable();
+            $table->timestamps();
+
+            $table->foreign(['organisation_id', 'party_id'])
+                ->references(['organisation_id', 'id'])->on('parties')->restrictOnDelete();
+            $table->index(
+                ['organisation_id', 'type', 'current_index_key_version', 'current_blind_index'],
+                'party_contacts_current_lookup_index',
+            );
+            $table->index(
+                ['organisation_id', 'type', 'previous_index_key_version', 'previous_blind_index'],
+                'party_contacts_previous_lookup_index',
+            );
+        });
+
+        $this->preventContactOwnershipChanges();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        $this->allowContactOwnershipChanges();
+        Schema::dropIfExists('party_contact_points');
+
+        Schema::table('parties', function (Blueprint $table) {
+            $table->dropUnique(['uuid']);
+            $table->dropColumn('uuid');
+        });
+
+        Schema::table('organisations', function (Blueprint $table) {
+            $table->dropUnique(['uuid']);
+            $table->dropColumn('uuid');
+        });
+    }
+
+    private function preventContactOwnershipChanges(): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                CREATE OR REPLACE FUNCTION prevent_party_contact_organisation_change() RETURNS trigger AS $$
+                BEGIN
+                    IF NEW.organisation_id IS DISTINCT FROM OLD.organisation_id THEN
+                        RAISE EXCEPTION 'Party contact Organisation ownership is immutable.';
+                    END IF;
+
+                    RETURN NEW;
+                END;
+                $$ LANGUAGE plpgsql;
+
+                CREATE TRIGGER party_contact_points_organisation_id_immutable
+                    BEFORE UPDATE OF organisation_id ON party_contact_points
+                    FOR EACH ROW
+                    EXECUTE FUNCTION prevent_party_contact_organisation_change();
+                SQL);
+
+            return;
+        }
+
+        if (DB::getDriverName() === 'sqlite') {
+            DB::unprepared(<<<'SQL'
+                CREATE TRIGGER party_contact_points_organisation_id_immutable
+                    BEFORE UPDATE OF organisation_id ON party_contact_points
+                    FOR EACH ROW
+                    WHEN NEW.organisation_id != OLD.organisation_id
+                BEGIN
+                    SELECT RAISE(ABORT, 'Party contact Organisation ownership is immutable.');
+                END;
+                SQL);
+        }
+    }
+
+    private function allowContactOwnershipChanges(): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                DROP TRIGGER IF EXISTS party_contact_points_organisation_id_immutable ON party_contact_points;
+                DROP FUNCTION IF EXISTS prevent_party_contact_organisation_change();
+                SQL);
+
+            return;
+        }
+
+        if (DB::getDriverName() === 'sqlite') {
+            DB::unprepared('DROP TRIGGER IF EXISTS party_contact_points_organisation_id_immutable');
+        }
+    }
+};

--- a/tests/Feature/ClassifiedPartyContactEncryptionTest.php
+++ b/tests/Feature/ClassifiedPartyContactEncryptionTest.php
@@ -1,0 +1,407 @@
+<?php
+
+use App\Actions\Parties\FindPartiesByContact;
+use App\Actions\Parties\RebuildPartyContactBlindIndexes;
+use App\Actions\Parties\RotatePartyContactDataEncryption;
+use App\Actions\Parties\StorePartyContact;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\PartyContactType;
+use App\Exceptions\ClassifiedDataUnavailable;
+use App\Jobs\RebuildPartyContactBlindIndexes as RebuildPartyContactBlindIndexesJob;
+use App\Jobs\RotatePartyContactDataEncryption as RotatePartyContactDataEncryptionJob;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\PartyContactPoint;
+use App\Models\PlatformSecurityEvent;
+use App\OrganisationContext;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+beforeEach(function () {
+    configurePartyContactKeys(
+        dataCurrent: 'data-v1',
+        dataKeys: ['data-v1' => testPartyContactKey()],
+        indexCurrent: 'index-v1',
+        indexKeys: ['index-v1' => testPartyContactKey()],
+    );
+});
+
+it('stores randomized classified ciphertext while leaving Party names searchable', function () {
+    $organisation = Organisation::factory()->active()->create();
+
+    [$firstContact, $secondContact, $party] = app(OrganisationContext::class)->run(
+        $organisation,
+        function () {
+            $firstParty = partyForCurrentOrganisation(['display_name' => 'Ada Example']);
+            $secondParty = partyForCurrentOrganisation(['display_name' => 'Bea Example']);
+            $store = app(StorePartyContact::class);
+
+            return [
+                $store->handle($firstParty, PartyContactType::Email, 'ada@example.test'),
+                $store->handle($secondParty, PartyContactType::Email, 'ada@example.test'),
+                Party::query()->where('display_name', 'Ada Example')->firstOrFail(),
+            ];
+        },
+    );
+
+    $firstCiphertext = DB::table('party_contact_points')->where('id', $firstContact->id)->value('encrypted_value');
+    $secondCiphertext = DB::table('party_contact_points')->where('id', $secondContact->id)->value('encrypted_value');
+
+    expect($firstCiphertext)
+        ->toBeString()
+        ->not->toContain('ada@example.test')
+        ->not->toBe($secondCiphertext);
+    expect($party->display_name)->toBe('Ada Example');
+    config(['app.key' => 'base64:'.base64_encode(random_bytes(32))]);
+    app(OrganisationContext::class)->run($organisation, function () use ($firstContact): void {
+        expect($firstContact->encrypted_value)
+            ->toBeInstanceOf(ClassifiedValue::class)
+            ->and($firstContact->encrypted_value->reveal())->toBe('ada@example.test');
+    });
+});
+
+it('fails closed when ciphertext is swapped across records, Organisations, or fields', function () {
+    $firstOrganisation = Organisation::factory()->active()->create();
+    $secondOrganisation = Organisation::factory()->active()->create();
+
+    [$firstEmail, $firstTelephone] = app(OrganisationContext::class)->run($firstOrganisation, function () {
+        $party = partyForCurrentOrganisation();
+        $store = app(StorePartyContact::class);
+
+        return [
+            $store->handle($party, PartyContactType::Email, 'first@example.test'),
+            $store->handle($party, PartyContactType::Telephone, '+27 82 555 0101'),
+        ];
+    });
+    $secondEmail = app(OrganisationContext::class)->run($secondOrganisation, function () {
+        $party = partyForCurrentOrganisation();
+
+        return app(StorePartyContact::class)->handle($party, PartyContactType::Email, 'second@example.test');
+    });
+    $firstCiphertext = DB::table('party_contact_points')->where('id', $firstEmail->id)->value('encrypted_value');
+
+    DB::table('party_contact_points')->where('id', $firstTelephone->id)->update(['encrypted_value' => $firstCiphertext]);
+    DB::table('party_contact_points')->where('id', $secondEmail->id)->update(['encrypted_value' => $firstCiphertext]);
+
+    app(OrganisationContext::class)->run(
+        $firstOrganisation,
+        fn () => expect(fn () => PartyContactPoint::query()->findOrFail($firstTelephone->id)->encrypted_value)
+            ->toThrow(ClassifiedDataUnavailable::class, 'Classified data is unavailable.'),
+    );
+    app(OrganisationContext::class)->run(
+        $secondOrganisation,
+        fn () => expect(fn () => PartyContactPoint::query()->findOrFail($secondEmail->id)->encrypted_value)
+            ->toThrow(ClassifiedDataUnavailable::class, 'Classified data is unavailable.'),
+    );
+
+    DB::table('party_contact_points')->where('id', $firstEmail->id)->update(['type' => PartyContactType::Telephone->value]);
+
+    app(OrganisationContext::class)->run(
+        $firstOrganisation,
+        fn () => expect(fn () => PartyContactPoint::query()->findOrFail($firstEmail->id)->encrypted_value)
+            ->toThrow(ClassifiedDataUnavailable::class, 'Classified data is unavailable.'),
+    );
+});
+
+it('returns only exact tenant-local email and telephone matches', function () {
+    $firstOrganisation = Organisation::factory()->active()->create();
+    $secondOrganisation = Organisation::factory()->active()->create();
+
+    $firstParty = app(OrganisationContext::class)->run($firstOrganisation, function () {
+        $party = partyForCurrentOrganisation();
+        $store = app(StorePartyContact::class);
+        $store->handle($party, PartyContactType::Email, 'Person@Example.Test');
+        $store->handle($party, PartyContactType::Telephone, '+27 (82) 555-0101');
+
+        return $party;
+    });
+    app(OrganisationContext::class)->run($secondOrganisation, function () {
+        $party = partyForCurrentOrganisation();
+        app(StorePartyContact::class)->handle($party, PartyContactType::Email, 'person@example.test');
+    });
+
+    app(OrganisationContext::class)->run($firstOrganisation, function () use ($firstParty): void {
+        $find = app(FindPartiesByContact::class);
+
+        expect($find->handle(PartyContactType::Email, ' person@example.test ')->modelKeys())
+            ->toBe([$firstParty->id]);
+        expect($find->handle(PartyContactType::Telephone, '0027 82 555 0101')->modelKeys())
+            ->toBe([$firstParty->id]);
+        expect($find->handle(PartyContactType::Email, 'other@example.test'))->toBeEmpty();
+        expect($find->handle(PartyContactType::Email, 'person@example.tests'))->toBeEmpty();
+        expect($find->handle(PartyContactType::Telephone, '8255501'))->toBeEmpty();
+    });
+});
+
+it('produces different blind indexes for identical contacts in different Organisations', function () {
+    $firstOrganisation = Organisation::factory()->active()->create();
+    $secondOrganisation = Organisation::factory()->active()->create();
+
+    $firstContact = app(OrganisationContext::class)->run($firstOrganisation, function () {
+        $party = partyForCurrentOrganisation();
+
+        return app(StorePartyContact::class)->handle($party, PartyContactType::Email, 'shared@example.test');
+    });
+    $secondContact = app(OrganisationContext::class)->run($secondOrganisation, function () {
+        $party = partyForCurrentOrganisation();
+
+        return app(StorePartyContact::class)->handle($party, PartyContactType::Email, 'shared@example.test');
+    });
+
+    expect($firstContact->getRawOriginal('current_blind_index'))
+        ->not->toBe($secondContact->getRawOriginal('current_blind_index'));
+});
+
+it('rejects cross-Organisation Party associations and keeps contact rows tenant scoped', function () {
+    $firstOrganisation = Organisation::factory()->active()->create();
+    $secondOrganisation = Organisation::factory()->active()->create();
+
+    $firstContact = app(OrganisationContext::class)->run($firstOrganisation, function () {
+        $party = partyForCurrentOrganisation();
+
+        return app(StorePartyContact::class)->handle($party, PartyContactType::Email, 'first@example.test');
+    });
+    $secondParty = app(OrganisationContext::class)->run(
+        $secondOrganisation,
+        fn () => partyForCurrentOrganisation(),
+    );
+    $rawContact = DB::table('party_contact_points')->where('id', $firstContact->id)->first();
+
+    expect(fn () => DB::transaction(fn () => DB::table('party_contact_points')->insert([
+        'id' => (string) Str::uuid7(),
+        'organisation_id' => $firstOrganisation->id,
+        'party_id' => $secondParty->id,
+        'type' => $rawContact->type,
+        'encrypted_value' => $rawContact->encrypted_value,
+        'data_key_version' => $rawContact->data_key_version,
+        'current_index_key_version' => $rawContact->current_index_key_version,
+        'current_blind_index' => $rawContact->current_blind_index,
+        'previous_index_key_version' => null,
+        'previous_blind_index' => null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ])))->toThrow(QueryException::class);
+    expect(fn () => DB::transaction(fn () => DB::table('party_contact_points')
+        ->where('id', $firstContact->id)
+        ->update([
+            'organisation_id' => $secondOrganisation->id,
+            'party_id' => $secondParty->id,
+        ])))->toThrow(QueryException::class);
+
+    app(OrganisationContext::class)->run($secondOrganisation, function () use ($firstContact): void {
+        expect(PartyContactPoint::query()->find($firstContact->id))->toBeNull();
+    });
+    expect(fn () => PartyContactPoint::query()->find($firstContact->id))->toThrow(LogicException::class);
+});
+
+it('dual-reads and dual-writes while contact indexes rotate', function () {
+    $organisation = Organisation::factory()->active()->create();
+
+    $oldParty = app(OrganisationContext::class)->run($organisation, function () {
+        $party = partyForCurrentOrganisation(['display_name' => 'Old Index']);
+        app(StorePartyContact::class)->handle($party, PartyContactType::Email, 'shared@example.test');
+
+        return $party;
+    });
+    $indexV1Key = config('classified_data.contact_index.keys.index-v1');
+    configurePartyContactKeys(
+        dataCurrent: 'data-v1',
+        dataKeys: config('classified_data.encryption.keys'),
+        indexCurrent: 'index-v2',
+        indexKeys: ['index-v1' => $indexV1Key, 'index-v2' => testPartyContactKey()],
+        indexPrevious: 'index-v1',
+    );
+
+    $newParty = app(OrganisationContext::class)->run($organisation, function () {
+        $party = partyForCurrentOrganisation(['display_name' => 'New Index']);
+        $contact = app(StorePartyContact::class)->handle($party, PartyContactType::Email, 'shared@example.test');
+
+        expect($contact->current_index_key_version)->toBe('index-v2');
+        expect($contact->previous_index_key_version)->toBe('index-v1');
+
+        return $party;
+    });
+    $oldCiphertext = DB::table('party_contact_points')
+        ->where('party_id', $oldParty->id)
+        ->value('encrypted_value');
+
+    app(OrganisationContext::class)->run($organisation, function () use ($organisation, $oldParty, $newParty): void {
+        expect(app(FindPartiesByContact::class)
+            ->handle(PartyContactType::Email, 'shared@example.test')->modelKeys())
+            ->toBe([$newParty->id, $oldParty->id]);
+        expect(app(RebuildPartyContactBlindIndexes::class)->handle($organisation))->toBe(1);
+        expect(app(RebuildPartyContactBlindIndexes::class)->handle($organisation))->toBe(0);
+    });
+    expect(DB::table('party_contact_points')->where('party_id', $oldParty->id)->value('encrypted_value'))
+        ->toBe($oldCiphertext);
+
+    configurePartyContactKeys(
+        dataCurrent: 'data-v1',
+        dataKeys: config('classified_data.encryption.keys'),
+        indexCurrent: 'index-v2',
+        indexKeys: ['index-v2' => config('classified_data.contact_index.keys.index-v2')],
+    );
+
+    app(OrganisationContext::class)->run($organisation, function () use ($oldParty, $newParty): void {
+        expect(app(FindPartiesByContact::class)
+            ->handle(PartyContactType::Email, 'shared@example.test')->modelKeys())
+            ->toBe([$newParty->id, $oldParty->id]);
+    });
+});
+
+it('re-encrypts old data keys idempotently and retains recovery access while the old key is present', function () {
+    $organisation = Organisation::factory()->active()->create();
+
+    $contact = app(OrganisationContext::class)->run($organisation, function () {
+        $party = partyForCurrentOrganisation();
+
+        return app(StorePartyContact::class)->handle($party, PartyContactType::Email, 'restore@example.test');
+    });
+    $oldCiphertext = DB::table('party_contact_points')->where('id', $contact->id)->value('encrypted_value');
+    $dataV1Key = config('classified_data.encryption.keys.data-v1');
+    configurePartyContactKeys(
+        dataCurrent: 'data-v2',
+        dataKeys: ['data-v1' => $dataV1Key, 'data-v2' => testPartyContactKey()],
+        indexCurrent: 'index-v1',
+        indexKeys: config('classified_data.contact_index.keys'),
+    );
+
+    app(OrganisationContext::class)->run($organisation, function () use ($organisation, $contact, $oldCiphertext): void {
+        expect(PartyContactPoint::query()->findOrFail($contact->id)->encrypted_value->reveal())
+            ->toBe('restore@example.test');
+        expect(app(RotatePartyContactDataEncryption::class)->handle($organisation))->toBe(1);
+        expect(app(RotatePartyContactDataEncryption::class)->handle($organisation))->toBe(0);
+
+        $rotated = PartyContactPoint::query()->findOrFail($contact->id);
+
+        expect($rotated->data_key_version)->toBe('data-v2');
+        expect($rotated->encrypted_value->reveal())->toBe('restore@example.test');
+        expect($rotated->getRawOriginal('encrypted_value'))->not->toBe($oldCiphertext);
+    });
+});
+
+it('fails closed with missing or incorrect recovery keys without reporting classified content', function () {
+    $organisation = Organisation::factory()->active()->create();
+
+    $contact = app(OrganisationContext::class)->run($organisation, function () {
+        $party = partyForCurrentOrganisation();
+
+        return app(StorePartyContact::class)->handle($party, PartyContactType::Email, 'never-log@example.test');
+    });
+    $ciphertext = DB::table('party_contact_points')->where('id', $contact->id)->value('encrypted_value');
+    configurePartyContactKeys(
+        dataCurrent: 'data-v1',
+        dataKeys: [],
+        indexCurrent: 'index-v1',
+        indexKeys: config('classified_data.contact_index.keys'),
+    );
+    Log::spy();
+
+    app(OrganisationContext::class)->run(
+        $organisation,
+        fn () => expect(fn () => PartyContactPoint::query()->findOrFail($contact->id)->encrypted_value)
+            ->toThrow(ClassifiedDataUnavailable::class, 'Classified data is unavailable.'),
+    );
+    configurePartyContactKeys(
+        dataCurrent: 'data-v1',
+        dataKeys: ['data-v1' => testPartyContactKey()],
+        indexCurrent: 'index-v1',
+        indexKeys: config('classified_data.contact_index.keys'),
+    );
+    app(OrganisationContext::class)->run(
+        $organisation,
+        fn () => expect(fn () => PartyContactPoint::query()->findOrFail($contact->id)->encrypted_value)
+            ->toThrow(ClassifiedDataUnavailable::class, 'Classified data is unavailable.'),
+    );
+
+    foreach (['emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug', 'log'] as $level) {
+        Log::shouldNotHaveReceived($level);
+    }
+    expect((new ClassifiedDataUnavailable)->getMessage())
+        ->not->toContain('never-log@example.test')
+        ->not->toContain($ciphertext);
+});
+
+it('keeps classified values and blind indexes out of serialization, queues, search, and security telemetry', function () {
+    $organisation = Organisation::factory()->active()->create();
+
+    $contact = app(OrganisationContext::class)->run($organisation, function () {
+        $party = partyForCurrentOrganisation();
+
+        return app(StorePartyContact::class)->handle($party, PartyContactType::Email, 'private@example.test');
+    });
+    $ciphertext = $contact->getRawOriginal('encrypted_value');
+    $blindIndex = $contact->getRawOriginal('current_blind_index');
+    expect(json_encode($contact->toArray(), JSON_THROW_ON_ERROR))
+        ->not->toContain('private@example.test')
+        ->not->toContain($ciphertext)
+        ->not->toContain($blindIndex);
+    $queuePayload = serialize([
+        new RotatePartyContactDataEncryptionJob($organisation),
+        new RebuildPartyContactBlindIndexesJob($organisation),
+    ]);
+    expect($queuePayload)
+        ->not->toContain('private@example.test')
+        ->not->toContain($ciphertext)
+        ->not->toContain($blindIndex);
+    expect(method_exists($contact, 'searchable'))->toBeFalse();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($organisation): void {
+        app(RebuildPartyContactBlindIndexes::class)->handle($organisation);
+    });
+    $telemetry = PlatformSecurityEvent::query()
+        ->where('type', 'party_contact_index_key_rebuilt')
+        ->latest('occurred_at')
+        ->firstOrFail()
+        ->metadata;
+
+    expect(json_encode($telemetry, JSON_THROW_ON_ERROR))
+        ->not->toContain('private@example.test')
+        ->not->toContain($ciphertext)
+        ->not->toContain($blindIndex);
+    expect(array_keys($telemetry))->toBe([
+        'organisation_uuid',
+        'record_count',
+        'current_version',
+        'previous_version',
+    ]);
+});
+
+/** @param array<string, string> $dataKeys
+ * @param  array<string, string>  $indexKeys
+ */
+function configurePartyContactKeys(
+    string $dataCurrent,
+    array $dataKeys,
+    string $indexCurrent,
+    array $indexKeys,
+    ?string $indexPrevious = null,
+): void {
+    config([
+        'classified_data.encryption' => [
+            'current_version' => $dataCurrent,
+            'keys' => $dataKeys,
+        ],
+        'classified_data.contact_index' => [
+            'current_version' => $indexCurrent,
+            'previous_version' => $indexPrevious,
+            'keys' => $indexKeys,
+        ],
+    ]);
+}
+
+function testPartyContactKey(): string
+{
+    return 'base64:'.base64_encode(random_bytes(32));
+}
+
+/** @param array<string, mixed> $attributes */
+function partyForCurrentOrganisation(array $attributes = []): Party
+{
+    return Party::factory()->create([
+        'organisation_id' => app(OrganisationContext::class)->id(),
+        ...$attributes,
+    ]);
+}


### PR DESCRIPTION
Closes #7

## Summary
- add independent versioned application-data and contact-index key rings
- store Party email and telephone contacts as context-bound randomized ciphertext
- support exact Organisation-local blind-index matching and dual-version rotation
- add idempotent data/index rotation jobs with content-free security telemetry
- add Organisation and Party UUIDs for authenticated encryption context

## Verification
- `vendor/bin/pint --dirty --format agent`
- `composer types:check`
- `npm run types:check`
- `npm run check`
- `npm test`
- `npm run build`
- `composer audit --locked`
- `php artisan test --compact` (213 tests, 852 assertions)
- populated PostgreSQL migration
- fresh SQLite migration and rollback

## Review
Reviewed the complete diff against `origin/main` and fixed all findings before commit, including cast-side-effect re-encryption, database-level Organisation ownership immutability, and direct tenant-integrity coverage.