### PR TITLE
Add tamper-resistant audits and incident containment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,10 @@ APP_URL=http://localhost
 APP_RELEASE=development
 APP_SOURCE_REPOSITORY=https://github.com/datashaman/community-kind
 ORGANISATION_SELF_SERVICE_PROVISIONING=false
+# Hosted deployments should set this to the least-privileged application role, distinct from the migration role.
+AUDIT_RUNTIME_DATABASE_ROLE=
+SECURITY_CONTACT=https://github.com/datashaman/community-kind/security/advisories/new
+SECURITY_TXT_EXPIRES=2027-08-30T00:00:00Z
 
 # Supply independent, versioned key rings through the environment or secret store.
 # Values are JSON objects whose keys are versions and whose values are base64: keys.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,13 +3,20 @@
 CommunityKind is at the synthetic-data specification-build stage and must not
 be used with real client, supporter, payment, credential, or incident data.
 
-Do not report suspected vulnerabilities in a public issue. Until the monitored
-security intake required before an internet-accessible deployment is published,
-contact the repository owner privately through GitHub. Do not include real
-personal data, tenant content, credentials, or active exploit material in an
-initial report.
+Do not report suspected vulnerabilities in a public issue. Use the private
+[GitHub security advisory](https://github.com/datashaman/community-kind/security/advisories/new)
+channel identified by each hosted surface's `/.well-known/security.txt` file.
+Do not include real personal data, tenant content, credentials, live malware,
+or active exploit material in an initial report. Use opaque references and ask
+for a secure evidence-transfer route if further detail is necessary.
+
+Reports should identify the affected release or host, explain the security
+impact, and give minimal reproduction steps using synthetic data. Do not perform
+destructive testing, persistence, denial of service, privacy-invasive testing,
+or access to another Organisation. We aim to acknowledge reports within two
+business days and coordinate remediation and disclosure in good faith. This
+policy does not create a bug bounty, safe-harbour promise, or authorization to
+test systems you do not own.
 
 There is currently no production service, supported release series, availability
-commitment, or claim of regulatory compliance. A coordinated disclosure policy
-and RFC 9116 `security.txt` will be activated before hosted surfaces become
-internet-accessible.
+commitment, or claim of regulatory compliance.

--- a/app/Actions/Auditing/RecordTenantAuditEvent.php
+++ b/app/Actions/Auditing/RecordTenantAuditEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Actions\Auditing;
+
+use App\Data\Auditing\VersionedAuditPayload;
+use App\Enums\TenantAuditEventType;
+use App\Models\Organisation;
+use App\Models\TenantAuditEvent;
+use App\Models\User;
+
+class RecordTenantAuditEvent
+{
+    /** @param array<string, mixed> $payload */
+    public function handle(
+        Organisation $organisation,
+        TenantAuditEventType $type,
+        string $subjectType,
+        string $subjectId,
+        array $payload,
+        ?User $actor = null,
+    ): TenantAuditEvent {
+        return TenantAuditEvent::query()->create([
+            'organisation_id' => $organisation->id,
+            'actor_user_id' => $actor?->id,
+            'type' => $type,
+            'schema_version' => VersionedAuditPayload::CURRENT_VERSION,
+            'subject_type' => $subjectType,
+            'subject_id' => $subjectId,
+            'payload' => $payload,
+            'occurred_at' => now(),
+        ]);
+    }
+}

--- a/app/Actions/Parties/RebuildPartyContactBlindIndexes.php
+++ b/app/Actions/Parties/RebuildPartyContactBlindIndexes.php
@@ -2,10 +2,11 @@
 
 namespace App\Actions\Parties;
 
+use App\Actions\Security\RecordPlatformSecurityEvent;
 use App\Cryptography\ContactBlindIndexer;
+use App\Enums\PlatformSecurityEventType;
 use App\Models\Organisation;
 use App\Models\PartyContactPoint;
-use App\Models\PlatformSecurityEvent;
 use App\OrganisationContext;
 
 class RebuildPartyContactBlindIndexes
@@ -13,6 +14,7 @@ class RebuildPartyContactBlindIndexes
     public function __construct(
         private readonly OrganisationContext $organisationContext,
         private readonly ContactBlindIndexer $blindIndexer,
+        private readonly RecordPlatformSecurityEvent $recordPlatformSecurityEvent,
     ) {}
 
     public function handle(Organisation $organisation): int
@@ -50,16 +52,15 @@ class RebuildPartyContactBlindIndexes
             $rebuilt++;
         });
 
-        PlatformSecurityEvent::query()->create([
-            'type' => 'party_contact_index_key_rebuilt',
-            'metadata' => [
+        $this->recordPlatformSecurityEvent->handle(
+            PlatformSecurityEventType::PartyContactIndexKeyRebuilt,
+            [
                 'organisation_uuid' => $organisation->uuid,
                 'record_count' => $rebuilt,
                 'current_version' => $currentVersion,
                 'previous_version' => $previousVersion,
             ],
-            'occurred_at' => now(),
-        ]);
+        );
 
         return $rebuilt;
     }

--- a/app/Actions/Parties/RotatePartyContactDataEncryption.php
+++ b/app/Actions/Parties/RotatePartyContactDataEncryption.php
@@ -2,11 +2,12 @@
 
 namespace App\Actions\Parties;
 
+use App\Actions\Security\RecordPlatformSecurityEvent;
 use App\Cryptography\ClassifiedDataEncrypter;
 use App\Data\Values\ClassifiedValue;
+use App\Enums\PlatformSecurityEventType;
 use App\Models\Organisation;
 use App\Models\PartyContactPoint;
-use App\Models\PlatformSecurityEvent;
 use App\OrganisationContext;
 
 class RotatePartyContactDataEncryption
@@ -14,6 +15,7 @@ class RotatePartyContactDataEncryption
     public function __construct(
         private readonly OrganisationContext $organisationContext,
         private readonly ClassifiedDataEncrypter $encrypter,
+        private readonly RecordPlatformSecurityEvent $recordPlatformSecurityEvent,
     ) {}
 
     public function handle(Organisation $organisation): int
@@ -39,16 +41,15 @@ class RotatePartyContactDataEncryption
                 $rotated++;
             });
 
-        PlatformSecurityEvent::query()->create([
-            'type' => 'party_contact_data_key_rotated',
-            'metadata' => [
+        $this->recordPlatformSecurityEvent->handle(
+            PlatformSecurityEventType::PartyContactDataKeyRotated,
+            [
                 'organisation_uuid' => $organisation->uuid,
                 'record_count' => $rotated,
                 'from_versions' => array_values(array_unique($previousVersions)),
                 'to_version' => $currentVersion,
             ],
-            'occurred_at' => now(),
-        ]);
+        );
 
         return $rotated;
     }

--- a/app/Actions/Programs/UpdateProgram.php
+++ b/app/Actions/Programs/UpdateProgram.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Actions\Programs;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Enums\TenantAuditEventType;
+use App\Models\Program;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class UpdateProgram
+{
+    public function __construct(private RecordTenantAuditEvent $recordTenantAuditEvent) {}
+
+    /** @param array{name: string, slug: string} $attributes */
+    public function handle(Program $program, array $attributes, User $actor): Program
+    {
+        return DB::transaction(function () use ($program, $attributes, $actor): Program {
+            $program->fill($attributes);
+            $changedFields = array_keys($program->getDirty());
+            $program->save();
+
+            $this->recordTenantAuditEvent->handle(
+                $program->organisation,
+                TenantAuditEventType::ProgramUpdated,
+                'program',
+                (string) $program->id,
+                [
+                    'program_id' => $program->id,
+                    'changed_fields' => $changedFields,
+                ],
+                $actor,
+            );
+
+            return $program;
+        });
+    }
+}

--- a/app/Actions/Security/ApplyIncidentContainment.php
+++ b/app/Actions/Security/ApplyIncidentContainment.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace App\Actions\Security;
+
+use App\Actions\Organisations\PlaceOrganisationAccessHold;
+use App\Enums\IncidentReasonCode;
+use App\Enums\InstallationCapability;
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Enums\PlatformSecurityEventType;
+use App\Enums\SecurityIncidentClassification;
+use App\Enums\SecurityIncidentEntryType;
+use App\Enums\SecurityIncidentStatus;
+use App\Models\InstallationControl;
+use App\Models\Organisation;
+use App\Models\OrganisationAccessHold;
+use App\Models\SecurityIncident;
+use App\Models\SecurityIncidentOrganisation;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class ApplyIncidentContainment
+{
+    public function __construct(
+        private RevokeUserAccess $revokeUserAccess,
+        private PlaceOrganisationAccessHold $placeOrganisationAccessHold,
+        private RecordPlatformSecurityEvent $recordPlatformSecurityEvent,
+        private RecordSecurityIncidentEntry $recordSecurityIncidentEntry,
+    ) {}
+
+    /**
+     * @param  list<User>  $users
+     * @param  list<Organisation>  $organisations
+     * @param  list<InstallationCapability>  $capabilities
+     * @param  list<string>  $credentialReferences
+     */
+    public function handle(
+        SecurityIncident $incident,
+        User $actor,
+        IncidentReasonCode $reasonCode,
+        array $users = [],
+        array $organisations = [],
+        array $capabilities = [],
+        array $credentialReferences = [],
+        OrganisationAccessScope $holdScope = OrganisationAccessScope::All,
+        OrganisationAccessLevel $holdLevel = OrganisationAccessLevel::Denied,
+        ?Carbon $reviewAt = null,
+        ?Carbon $expiresAt = null,
+    ): SecurityIncident {
+        return DB::transaction(function () use ($incident, $actor, $reasonCode, $users, $organisations, $capabilities, $credentialReferences, $holdScope, $holdLevel, $reviewAt, $expiresAt): SecurityIncident {
+            $incident = SecurityIncident::query()->lockForUpdate()->findOrFail($incident->id);
+
+            if ($incident->classification !== SecurityIncidentClassification::Incident || ! $incident->status->allowsContainment()) {
+                throw new LogicException('Only an open incident can authorize containment.');
+            }
+
+            foreach ($users as $user) {
+                $counts = $this->revokeUserAccess->handle($user, $actor);
+                $this->recordPlatformSecurityEvent->handle(
+                    PlatformSecurityEventType::UserAccessRevoked,
+                    ['incident_uuid' => $incident->id, 'user_id' => $user->id, ...$counts],
+                    actor: $actor,
+                    subject: $user,
+                    incidentUuid: $incident->id,
+                );
+            }
+
+            foreach ($organisations as $organisation) {
+                $existingHold = OrganisationAccessHold::query()
+                    ->where('incident_uuid', $incident->id)
+                    ->where('organisation_id', $organisation->id)
+                    ->where('scope', $holdScope)
+                    ->whereNull('released_at')
+                    ->where(fn ($query) => $query->whereNull('expires_at')->orWhere('expires_at', '>', now()))
+                    ->first();
+
+                if ($existingHold !== null && $existingHold->access_level->rank() >= $holdLevel->rank()) {
+                    continue;
+                }
+
+                $hold = $this->placeOrganisationAccessHold->handle(
+                    $organisation,
+                    $actor->email,
+                    $reasonCode->value,
+                    $holdScope,
+                    $holdLevel,
+                    $reviewAt ?? Carbon::now()->addDay(),
+                    $expiresAt ?? Carbon::now()->addDays(3),
+                    $actor,
+                    $incident->id,
+                );
+                SecurityIncidentOrganisation::query()->updateOrCreate(
+                    ['incident_uuid' => $incident->id, 'organisation_id' => $organisation->id],
+                    ['impact_status' => 'investigating'],
+                );
+                $this->recordPlatformSecurityEvent->handle(
+                    PlatformSecurityEventType::OrganisationAccessHoldApplied,
+                    [
+                        'incident_uuid' => $incident->id,
+                        'organisation_uuid' => $organisation->uuid,
+                        'hold_id' => $hold->id,
+                        'scope' => $holdScope->value,
+                        'access_level' => $holdLevel->value,
+                        'reason_code' => $reasonCode->value,
+                    ],
+                    actor: $actor,
+                    incidentUuid: $incident->id,
+                );
+            }
+
+            foreach ($capabilities as $capability) {
+                $control = InstallationControl::query()->firstOrCreate(
+                    [
+                        'incident_uuid' => $incident->id,
+                        'capability' => $capability,
+                        'released_at' => null,
+                    ],
+                    [
+                        'reason_code' => $reasonCode->value,
+                        'activated_by_user_id' => $actor->id,
+                        'activated_at' => now(),
+                    ],
+                );
+
+                if (! $control->wasRecentlyCreated) {
+                    continue;
+                }
+
+                $this->recordPlatformSecurityEvent->handle(
+                    PlatformSecurityEventType::InstallationControlApplied,
+                    [
+                        'incident_uuid' => $incident->id,
+                        'control_id' => $control->id,
+                        'capability' => $capability->value,
+                        'reason_code' => $reasonCode->value,
+                    ],
+                    actor: $actor,
+                    incidentUuid: $incident->id,
+                );
+            }
+
+            foreach ($credentialReferences as $credentialReference) {
+                $this->recordPlatformSecurityEvent->handle(
+                    PlatformSecurityEventType::CredentialRotationCoordinated,
+                    [
+                        'incident_uuid' => $incident->id,
+                        'credential_reference' => $credentialReference,
+                    ],
+                    actor: $actor,
+                    incidentUuid: $incident->id,
+                );
+            }
+
+            $fromStatus = $incident->status;
+            $incident->update([
+                'status' => SecurityIncidentStatus::Contained,
+                'confirmed_at' => $incident->confirmed_at ?? now(),
+                'first_awareness_at' => $incident->first_awareness_at ?? now(),
+                'commander_user_id' => $incident->commander_user_id ?? $actor->id,
+            ]);
+            $this->recordSecurityIncidentEntry->handle(
+                $incident,
+                SecurityIncidentEntryType::Action,
+                'Containment controls applied.',
+                $actor,
+                status: 'completed',
+            );
+            if ($fromStatus !== SecurityIncidentStatus::Contained) {
+                $this->recordPlatformSecurityEvent->handle(
+                    PlatformSecurityEventType::IncidentStatusChanged,
+                    [
+                        'incident_uuid' => $incident->id,
+                        'from_status' => $fromStatus->value,
+                        'to_status' => SecurityIncidentStatus::Contained->value,
+                    ],
+                    actor: $actor,
+                    incidentUuid: $incident->id,
+                );
+            }
+
+            return $incident;
+        });
+    }
+}

--- a/app/Actions/Security/RecordPlatformSecurityEvent.php
+++ b/app/Actions/Security/RecordPlatformSecurityEvent.php
@@ -2,6 +2,8 @@
 
 namespace App\Actions\Security;
 
+use App\Data\Auditing\VersionedAuditPayload;
+use App\Enums\PlatformSecurityEventType;
 use App\Models\PlatformSecurityEvent;
 use App\Models\User;
 
@@ -10,12 +12,19 @@ class RecordPlatformSecurityEvent
     /**
      * @param  array<string, mixed>  $metadata
      */
-    public function handle(string $type, User $actor, User $subject, array $metadata = []): PlatformSecurityEvent
-    {
+    public function handle(
+        PlatformSecurityEventType $type,
+        array $metadata,
+        ?User $actor = null,
+        ?User $subject = null,
+        ?string $incidentUuid = null,
+    ): PlatformSecurityEvent {
         return PlatformSecurityEvent::create([
             'type' => $type,
-            'actor_user_id' => $actor->id,
-            'subject_user_id' => $subject->id,
+            'schema_version' => VersionedAuditPayload::CURRENT_VERSION,
+            'incident_uuid' => $incidentUuid,
+            'actor_user_id' => $actor?->id,
+            'subject_user_id' => $subject?->id,
             'metadata' => $metadata,
             'occurred_at' => now(),
         ]);

--- a/app/Actions/Security/RecordSecurityIncidentEntry.php
+++ b/app/Actions/Security/RecordSecurityIncidentEntry.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Actions\Security;
+
+use App\Enums\SecurityIncidentEntryType;
+use App\Models\SecurityIncident;
+use App\Models\SecurityIncidentEntry;
+use App\Models\User;
+use Carbon\CarbonInterface;
+use InvalidArgumentException;
+
+class RecordSecurityIncidentEntry
+{
+    public function handle(
+        SecurityIncident $incident,
+        SecurityIncidentEntryType $type,
+        string $summary,
+        ?User $actor = null,
+        ?string $reference = null,
+        ?string $status = null,
+        ?CarbonInterface $dueAt = null,
+    ): SecurityIncidentEntry {
+        if ($summary === '' || ($type === SecurityIncidentEntryType::EvidenceReference && $reference === null)) {
+            throw new InvalidArgumentException('Incident entries require a summary and evidence entries require an opaque reference.');
+        }
+
+        return $incident->entries()->create([
+            'actor_user_id' => $actor?->id,
+            'type' => $type,
+            'summary' => $summary,
+            'reference' => $reference,
+            'status' => $status,
+            'due_at' => $dueAt,
+            'occurred_at' => now(),
+        ]);
+    }
+}

--- a/app/Actions/Security/RecoverIncidentContainment.php
+++ b/app/Actions/Security/RecoverIncidentContainment.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Actions\Security;
+
+use App\Actions\Organisations\ReleaseOrganisationAccessHold;
+use App\Enums\IncidentReasonCode;
+use App\Enums\PlatformSecurityEventType;
+use App\Enums\SecurityIncidentEntryType;
+use App\Enums\SecurityIncidentStatus;
+use App\Models\InstallationControl;
+use App\Models\OrganisationAccessHold;
+use App\Models\SecurityIncident;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class RecoverIncidentContainment
+{
+    public function __construct(
+        private ReleaseOrganisationAccessHold $releaseOrganisationAccessHold,
+        private RecordPlatformSecurityEvent $recordPlatformSecurityEvent,
+        private RecordSecurityIncidentEntry $recordSecurityIncidentEntry,
+    ) {}
+
+    public function handle(SecurityIncident $incident, User $actor, IncidentReasonCode $reasonCode): SecurityIncident
+    {
+        return DB::transaction(function () use ($incident, $actor, $reasonCode): SecurityIncident {
+            $incident = SecurityIncident::query()->lockForUpdate()->findOrFail($incident->id);
+
+            if ($incident->status !== SecurityIncidentStatus::Contained) {
+                throw new LogicException('Containment can only be recovered from a contained incident.');
+            }
+
+            OrganisationAccessHold::query()
+                ->with('organisation')
+                ->where('incident_uuid', $incident->id)
+                ->whereNull('released_at')
+                ->each(function (OrganisationAccessHold $hold) use ($incident, $actor, $reasonCode): void {
+                    $this->releaseOrganisationAccessHold->handle($hold, $actor->email, $reasonCode->value, $actor);
+                    $this->recordPlatformSecurityEvent->handle(
+                        PlatformSecurityEventType::OrganisationAccessHoldReleased,
+                        [
+                            'incident_uuid' => $incident->id,
+                            'organisation_uuid' => $hold->organisation->uuid,
+                            'hold_id' => $hold->id,
+                            'reason_code' => $reasonCode->value,
+                        ],
+                        actor: $actor,
+                        incidentUuid: $incident->id,
+                    );
+                });
+
+            InstallationControl::query()
+                ->where('incident_uuid', $incident->id)
+                ->whereNull('released_at')
+                ->each(function (InstallationControl $control) use ($incident, $actor, $reasonCode): void {
+                    $control->update([
+                        'released_by_user_id' => $actor->id,
+                        'released_at' => now(),
+                        'release_reason_code' => $reasonCode->value,
+                    ]);
+                    $this->recordPlatformSecurityEvent->handle(
+                        PlatformSecurityEventType::InstallationControlReleased,
+                        [
+                            'incident_uuid' => $incident->id,
+                            'control_id' => $control->id,
+                            'capability' => $control->capability->value,
+                            'reason_code' => $reasonCode->value,
+                        ],
+                        actor: $actor,
+                        incidentUuid: $incident->id,
+                    );
+                });
+
+            $incident->update(['status' => SecurityIncidentStatus::Recovering]);
+            $this->recordSecurityIncidentEntry->handle(
+                $incident,
+                SecurityIncidentEntryType::RecoveryGate,
+                'Containment rollback completed; verification is required before closure.',
+                $actor,
+                status: 'passed',
+            );
+            $this->recordPlatformSecurityEvent->handle(
+                PlatformSecurityEventType::IncidentStatusChanged,
+                [
+                    'incident_uuid' => $incident->id,
+                    'from_status' => SecurityIncidentStatus::Contained->value,
+                    'to_status' => SecurityIncidentStatus::Recovering->value,
+                ],
+                actor: $actor,
+                incidentUuid: $incident->id,
+            );
+
+            return $incident;
+        });
+    }
+}

--- a/app/Actions/Security/ReportSecurityIncident.php
+++ b/app/Actions/Security/ReportSecurityIncident.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Actions\Security;
+
+use App\Enums\PlatformSecurityEventType;
+use App\Enums\SecurityIncidentClassification;
+use App\Enums\SecurityIncidentSeverity;
+use App\Enums\SecurityIncidentStatus;
+use App\Models\SecurityIncident;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class ReportSecurityIncident
+{
+    public function __construct(private RecordPlatformSecurityEvent $recordPlatformSecurityEvent) {}
+
+    public function handle(
+        SecurityIncidentClassification $classification,
+        SecurityIncidentSeverity $severity,
+        string $detectionSource,
+        string $summary,
+        ?User $actor = null,
+    ): SecurityIncident {
+        return DB::transaction(function () use ($classification, $severity, $detectionSource, $summary, $actor): SecurityIncident {
+            $incident = SecurityIncident::query()->create([
+                'classification' => $classification,
+                'severity' => $severity,
+                'status' => SecurityIncidentStatus::Reported,
+                'detection_source' => $detectionSource,
+                'summary' => $summary,
+                'detected_at' => now(),
+            ]);
+
+            $this->recordPlatformSecurityEvent->handle(
+                PlatformSecurityEventType::IncidentReported,
+                [
+                    'incident_uuid' => $incident->id,
+                    'classification' => $classification->value,
+                    'severity' => $severity->value,
+                    'detection_source' => $detectionSource,
+                ],
+                actor: $actor,
+                incidentUuid: $incident->id,
+            );
+
+            return $incident;
+        });
+    }
+}

--- a/app/Actions/Security/RevokeUserAccess.php
+++ b/app/Actions/Security/RevokeUserAccess.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Actions\Security;
+
+use App\Models\OrganisationInvitation;
+use App\Models\User;
+use Illuminate\Database\ConnectionInterface;
+
+class RevokeUserAccess
+{
+    public function __construct(private ConnectionInterface $database) {}
+
+    /** @return array{session_count: int, invitation_count: int, password_reset_revoked: bool} */
+    public function handle(User $user, ?User $actor = null): array
+    {
+        $sessionCount = $this->database
+            ->table((string) config('session.table', 'sessions'))
+            ->where('user_id', $user->getAuthIdentifier())
+            ->delete();
+        $passwordResetRevoked = $this->database
+            ->table('password_reset_tokens')
+            ->where('email', $user->email)
+            ->delete() > 0;
+        $invitationCount = OrganisationInvitation::query()
+            ->whereRaw('LOWER(email) = ?', [mb_strtolower($user->email)])
+            ->whereNull('accepted_at')
+            ->whereNull('revoked_at')
+            ->update([
+                'revoked_at' => now(),
+                'revoked_by' => $actor?->id,
+            ]);
+
+        $user->forceFill(['remember_token' => null])->save();
+
+        return [
+            'session_count' => $sessionCount,
+            'invitation_count' => $invitationCount,
+            'password_reset_revoked' => $passwordResetRevoked,
+        ];
+    }
+}

--- a/app/Console/Commands/ContainSecurityIncident.php
+++ b/app/Console/Commands/ContainSecurityIncident.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Security\ApplyIncidentContainment;
+use App\Enums\IncidentReasonCode;
+use App\Enums\InstallationCapability;
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Models\Organisation;
+use App\Models\SecurityIncident;
+use App\Models\User;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Throwable;
+
+#[Signature('security:incident:contain
+    {incident : Incident UUID}
+    {--confirm= : Repeat the incident UUID to authorize the operation}
+    {--actor-user= : Installation Operator User ID}
+    {--reason-code= : Allowlisted containment reason code}
+    {--revoke-user=* : User IDs whose installation-wide access must be revoked}
+    {--hold-organisation=* : Organisation UUIDs to hold}
+    {--hold-scope=all : Organisation Access Hold scope}
+    {--hold-level=denied : Organisation Access Hold level}
+    {--pause=* : Installation capabilities to pause: queues, outbox, uploads, or forms}
+    {--freeze-writes : Apply an Installation-wide write freeze}
+    {--credential=* : Opaque credential references requiring coordinated rotation}')]
+#[Description('Apply reason-coded, audited containment for a registered security incident')]
+class ContainSecurityIncident extends Command
+{
+    public function handle(ApplyIncidentContainment $applyIncidentContainment): int
+    {
+        $incidentId = (string) $this->argument('incident');
+
+        if ($this->option('confirm') !== $incidentId) {
+            $this->error('Containment requires --confirm to exactly repeat the incident UUID.');
+
+            return self::FAILURE;
+        }
+
+        $reasonCode = IncidentReasonCode::tryFrom((string) $this->option('reason-code'));
+        $holdScope = OrganisationAccessScope::tryFrom((string) $this->option('hold-scope'));
+        $holdLevel = OrganisationAccessLevel::tryFrom((string) $this->option('hold-level'));
+
+        if ($reasonCode === null || $holdScope === null || $holdLevel === null) {
+            $this->error('The reason code, hold scope, or hold level is not allowlisted.');
+
+            return self::INVALID;
+        }
+
+        $capabilityValues = $this->stringListOption('pause');
+        if ($this->option('freeze-writes')) {
+            $capabilityValues[] = InstallationCapability::Writes->value;
+        }
+        $capabilities = [];
+        foreach (array_unique($capabilityValues) as $value) {
+            $capability = InstallationCapability::tryFrom($value);
+            if ($capability === null) {
+                $this->error('One or more paused capabilities are not allowlisted.');
+
+                return self::INVALID;
+            }
+
+            $capabilities[] = $capability;
+        }
+
+        $credentialReferences = $this->stringListOption('credential');
+        foreach ($credentialReferences as $reference) {
+            if (preg_match('/^[a-zA-Z0-9._:-]+$/', $reference) === 1) {
+                continue;
+            }
+
+            $this->error('Credential options must be opaque references, not secrets or free text.');
+
+            return self::INVALID;
+        }
+
+        $revokedUserIds = $this->stringListOption('revoke-user');
+        $heldOrganisationUuids = $this->stringListOption('hold-organisation');
+
+        if ($capabilities === [] && $credentialReferences === [] && $revokedUserIds === [] && $heldOrganisationUuids === []) {
+            $this->error('Select at least one containment action.');
+
+            return self::INVALID;
+        }
+
+        $revokedUserIds = array_values(array_unique($revokedUserIds));
+        $heldOrganisationUuids = array_values(array_unique($heldOrganisationUuids));
+        $users = array_values(User::query()->whereKey($revokedUserIds)->get()->all());
+        $organisations = array_values(Organisation::query()->whereIn('uuid', $heldOrganisationUuids)->get()->all());
+
+        if (count($users) !== count($revokedUserIds) || count($organisations) !== count($heldOrganisationUuids)) {
+            $this->error('Every requested User and Organisation target must exist before containment begins.');
+
+            return self::INVALID;
+        }
+
+        try {
+            $applyIncidentContainment->handle(
+                SecurityIncident::query()->findOrFail($incidentId),
+                User::query()->findOrFail((int) $this->option('actor-user')),
+                $reasonCode,
+                $users,
+                $organisations,
+                $capabilities,
+                $credentialReferences,
+                $holdScope,
+                $holdLevel,
+            );
+        } catch (Throwable $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->info("Containment applied for incident {$incidentId}.");
+
+        return self::SUCCESS;
+    }
+
+    /** @return list<string> */
+    private function stringListOption(string $name): array
+    {
+        $values = $this->option($name);
+
+        if (! is_array($values)) {
+            return [];
+        }
+
+        $strings = [];
+        foreach ($values as $value) {
+            if (is_string($value) || is_int($value)) {
+                $strings[] = (string) $value;
+            }
+        }
+
+        return $strings;
+    }
+}

--- a/app/Console/Commands/RecoverSecurityIncident.php
+++ b/app/Console/Commands/RecoverSecurityIncident.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Security\RecoverIncidentContainment;
+use App\Enums\IncidentReasonCode;
+use App\Models\SecurityIncident;
+use App\Models\User;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Throwable;
+
+#[Signature('security:incident:recover
+    {incident : Incident UUID}
+    {--confirm= : Repeat the incident UUID to authorize the operation}
+    {--actor-user= : Installation Operator User ID}
+    {--reason-code= : Allowlisted recovery reason code}')]
+#[Description('Release incident-scoped containment and enter verified recovery')]
+class RecoverSecurityIncident extends Command
+{
+    public function handle(RecoverIncidentContainment $recoverIncidentContainment): int
+    {
+        $incidentId = (string) $this->argument('incident');
+
+        if ($this->option('confirm') !== $incidentId) {
+            $this->error('Recovery requires --confirm to exactly repeat the incident UUID.');
+
+            return self::FAILURE;
+        }
+
+        $reasonCode = IncidentReasonCode::tryFrom((string) $this->option('reason-code'));
+        if ($reasonCode === null) {
+            $this->error('The recovery reason code is not allowlisted.');
+
+            return self::INVALID;
+        }
+
+        try {
+            $recoverIncidentContainment->handle(
+                SecurityIncident::query()->findOrFail($incidentId),
+                User::query()->findOrFail((int) $this->option('actor-user')),
+                $reasonCode,
+            );
+        } catch (Throwable $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->info("Containment released for incident {$incidentId}; recovery verification is required.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Data/Auditing/VersionedAuditPayload.php
+++ b/app/Data/Auditing/VersionedAuditPayload.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Data\Auditing;
+
+use InvalidArgumentException;
+
+final class VersionedAuditPayload
+{
+    public const int CURRENT_VERSION = 1;
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  array<string, string>  $schema
+     */
+    public static function validate(array $payload, array $schema): void
+    {
+        if (count($payload) !== count($schema)
+            || array_diff_key($payload, $schema) !== []
+            || array_diff_key($schema, $payload) !== []) {
+            throw new InvalidArgumentException('Audit payload keys must exactly match the versioned allowlist.');
+        }
+
+        foreach ($schema as $key => $type) {
+            if (! self::matches($payload[$key], $type)) {
+                throw new InvalidArgumentException("Audit payload field [{$key}] does not match its allowlisted type.");
+            }
+        }
+    }
+
+    private static function matches(mixed $value, string $type): bool
+    {
+        return match ($type) {
+            'string' => is_string($value) && $value !== '',
+            'nullable_string' => $value === null || (is_string($value) && $value !== ''),
+            'integer' => is_int($value),
+            'boolean' => is_bool($value),
+            'string_list' => is_array($value)
+                && array_is_list($value)
+                && collect($value)->every(fn (mixed $item): bool => is_string($item) && $item !== ''),
+            default => false,
+        };
+    }
+}

--- a/app/Enums/IncidentReasonCode.php
+++ b/app/Enums/IncidentReasonCode.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Enums;
+
+enum IncidentReasonCode: string
+{
+    case SuspectedCrossTenantAccess = 'suspected_cross_tenant_access';
+    case PrivilegedAccountCompromise = 'privileged_account_compromise';
+    case KeyDisclosure = 'key_disclosure';
+    case MaliciousFileRelease = 'malicious_file_release';
+    case AuditIntegrityFailure = 'audit_integrity_failure';
+    case SyntheticExercise = 'synthetic_exercise';
+}

--- a/app/Enums/InstallationCapability.php
+++ b/app/Enums/InstallationCapability.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum InstallationCapability: string
+{
+    case Writes = 'writes';
+    case Queues = 'queues';
+    case Outbox = 'outbox';
+    case Uploads = 'uploads';
+    case Forms = 'forms';
+}

--- a/app/Enums/PlatformSecurityEventType.php
+++ b/app/Enums/PlatformSecurityEventType.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Enums;
+
+enum PlatformSecurityEventType: string
+{
+    case OtherBrowserSessionsRevoked = 'other_browser_sessions_revoked';
+    case PartyContactIndexKeyRebuilt = 'party_contact_index_key_rebuilt';
+    case PartyContactDataKeyRotated = 'party_contact_data_key_rotated';
+    case IncidentReported = 'incident_reported';
+    case IncidentStatusChanged = 'incident_status_changed';
+    case UserAccessRevoked = 'user_access_revoked';
+    case OrganisationAccessHoldApplied = 'organisation_access_hold_applied';
+    case OrganisationAccessHoldReleased = 'organisation_access_hold_released';
+    case InstallationControlApplied = 'installation_control_applied';
+    case InstallationControlReleased = 'installation_control_released';
+    case CredentialRotationCoordinated = 'credential_rotation_coordinated';
+
+    /** @return array<string, string> */
+    public function payloadSchema(): array
+    {
+        return match ($this) {
+            self::OtherBrowserSessionsRevoked => ['revoked_count' => 'integer'],
+            self::PartyContactIndexKeyRebuilt => [
+                'organisation_uuid' => 'string',
+                'record_count' => 'integer',
+                'current_version' => 'string',
+                'previous_version' => 'nullable_string',
+            ],
+            self::PartyContactDataKeyRotated => [
+                'organisation_uuid' => 'string',
+                'record_count' => 'integer',
+                'from_versions' => 'string_list',
+                'to_version' => 'string',
+            ],
+            self::IncidentReported => [
+                'incident_uuid' => 'string',
+                'classification' => 'string',
+                'severity' => 'string',
+                'detection_source' => 'string',
+            ],
+            self::IncidentStatusChanged => [
+                'incident_uuid' => 'string',
+                'from_status' => 'string',
+                'to_status' => 'string',
+            ],
+            self::UserAccessRevoked => [
+                'incident_uuid' => 'string',
+                'user_id' => 'integer',
+                'session_count' => 'integer',
+                'invitation_count' => 'integer',
+                'password_reset_revoked' => 'boolean',
+            ],
+            self::OrganisationAccessHoldApplied => [
+                'incident_uuid' => 'string',
+                'organisation_uuid' => 'string',
+                'hold_id' => 'string',
+                'scope' => 'string',
+                'access_level' => 'string',
+                'reason_code' => 'string',
+            ],
+            self::OrganisationAccessHoldReleased => [
+                'incident_uuid' => 'string',
+                'organisation_uuid' => 'string',
+                'hold_id' => 'string',
+                'reason_code' => 'string',
+            ],
+            self::InstallationControlApplied => [
+                'incident_uuid' => 'string',
+                'control_id' => 'string',
+                'capability' => 'string',
+                'reason_code' => 'string',
+            ],
+            self::InstallationControlReleased => [
+                'incident_uuid' => 'string',
+                'control_id' => 'string',
+                'capability' => 'string',
+                'reason_code' => 'string',
+            ],
+            self::CredentialRotationCoordinated => [
+                'incident_uuid' => 'string',
+                'credential_reference' => 'string',
+            ],
+        };
+    }
+}

--- a/app/Enums/SecurityIncidentClassification.php
+++ b/app/Enums/SecurityIncidentClassification.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum SecurityIncidentClassification: string
+{
+    case Alert = 'alert';
+    case Incident = 'incident';
+}

--- a/app/Enums/SecurityIncidentEntryType.php
+++ b/app/Enums/SecurityIncidentEntryType.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Enums;
+
+enum SecurityIncidentEntryType: string
+{
+    case Decision = 'decision';
+    case Action = 'action';
+    case EvidenceReference = 'evidence_reference';
+    case RecoveryGate = 'recovery_gate';
+    case CorrectiveAction = 'corrective_action';
+    case StatusChange = 'status_change';
+}

--- a/app/Enums/SecurityIncidentSeverity.php
+++ b/app/Enums/SecurityIncidentSeverity.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum SecurityIncidentSeverity: string
+{
+    case S1Critical = 's1_critical';
+    case S2High = 's2_high';
+    case S3Medium = 's3_medium';
+    case S4Low = 's4_low';
+}

--- a/app/Enums/SecurityIncidentStatus.php
+++ b/app/Enums/SecurityIncidentStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Enums;
+
+enum SecurityIncidentStatus: string
+{
+    case Reported = 'reported';
+    case Triaging = 'triaging';
+    case Confirmed = 'confirmed';
+    case Contained = 'contained';
+    case Eradicated = 'eradicated';
+    case Recovering = 'recovering';
+    case Monitoring = 'monitoring';
+    case Closed = 'closed';
+    case FalsePositive = 'false_positive';
+    case Reopened = 'reopened';
+
+    public function allowsContainment(): bool
+    {
+        return ! in_array($this, [self::Closed, self::FalsePositive], true);
+    }
+}

--- a/app/Enums/TenantAuditEventType.php
+++ b/app/Enums/TenantAuditEventType.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Enums;
+
+enum TenantAuditEventType: string
+{
+    case ProgramUpdated = 'program_updated';
+
+    /** @return array<string, string> */
+    public function payloadSchema(): array
+    {
+        return match ($this) {
+            self::ProgramUpdated => [
+                'program_id' => 'integer',
+                'changed_fields' => 'string_list',
+            ],
+        };
+    }
+}

--- a/app/Http/Controllers/Organisations/ProgramController.php
+++ b/app/Http/Controllers/Organisations/ProgramController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Organisations;
 use App\Actions\Programs\BuildProgramReport;
 use App\Actions\Programs\ExportPrograms;
 use App\Actions\Programs\SearchPrograms;
+use App\Actions\Programs\UpdateProgram;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Organisations\UpdateProgramRequest;
 use App\Models\Organisation;
@@ -25,11 +26,14 @@ class ProgramController extends Controller
         return response()->json($program->only(['id', 'organisation_id', 'name', 'slug']));
     }
 
-    public function update(UpdateProgramRequest $request, Organisation $organisation, string $program): JsonResponse
+    public function update(UpdateProgramRequest $request, Organisation $organisation, string $program, UpdateProgram $updateProgram): JsonResponse
     {
         $program = $this->findProgram($program);
         Gate::authorize('update', $program);
-        $program->update($request->validated());
+        $program = $updateProgram->handle($program, [
+            'name' => $request->string('name')->toString(),
+            'slug' => $request->string('slug')->toString(),
+        ], $request->user());
 
         return response()->json($program->only(['id', 'organisation_id', 'name', 'slug']));
     }

--- a/app/Http/Controllers/Settings/OtherBrowserSessionController.php
+++ b/app/Http/Controllers/Settings/OtherBrowserSessionController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Settings;
 
 use App\Actions\Security\RecordPlatformSecurityEvent;
 use App\Actions\Security\RevokeOtherBrowserSessions;
+use App\Enums\PlatformSecurityEventType;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Settings\RevokeOtherBrowserSessionsRequest;
 use Illuminate\Http\RedirectResponse;
@@ -22,10 +23,10 @@ class OtherBrowserSessionController extends Controller
             $revokedCount = $revokeOtherBrowserSessions->handle($user, $request->session()->getId());
 
             $recordPlatformSecurityEvent->handle(
-                type: 'other_browser_sessions_revoked',
+                type: PlatformSecurityEventType::OtherBrowserSessionsRevoked,
+                metadata: ['revoked_count' => $revokedCount],
                 actor: $user,
                 subject: $user,
-                metadata: ['revoked_count' => $revokedCount],
             );
         });
 

--- a/app/Http/Middleware/EnsureInstallationAccess.php
+++ b/app/Http/Middleware/EnsureInstallationAccess.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Enums\InstallationCapability;
+use App\Models\InstallationControl;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureInstallationAccess
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next, ?string $capability = null): Response
+    {
+        $routeName = $request->route()?->getName();
+
+        if (! $request->isMethodSafe()
+            && ! $this->isSecurityWrite($routeName)
+            && InstallationControl::isPaused(InstallationCapability::Writes)) {
+            abort(Response::HTTP_SERVICE_UNAVAILABLE, 'Installation writes are temporarily unavailable.');
+        }
+
+        if ($capability === InstallationCapability::Forms->value
+            && ! $request->isMethodSafe()
+            && InstallationControl::isPaused(InstallationCapability::Forms)) {
+            abort(Response::HTTP_SERVICE_UNAVAILABLE, 'Forms are temporarily unavailable.');
+        }
+
+        if ($request->allFiles() !== [] && InstallationControl::isPaused(InstallationCapability::Uploads)) {
+            abort(Response::HTTP_SERVICE_UNAVAILABLE, 'Uploads are temporarily unavailable.');
+        }
+
+        return $next($request);
+    }
+
+    private function isSecurityWrite(?string $routeName): bool
+    {
+        if ($routeName === null) {
+            return false;
+        }
+
+        return $routeName === 'logout'
+            || $routeName === 'security.other-browser-sessions.destroy'
+            || $routeName === 'user-password.update'
+            || str_starts_with($routeName, 'login.')
+            || str_starts_with($routeName, 'password.')
+            || str_starts_with($routeName, 'two-factor.')
+            || str_starts_with($routeName, 'mfa.');
+    }
+}

--- a/app/Jobs/RebuildPartyContactBlindIndexes.php
+++ b/app/Jobs/RebuildPartyContactBlindIndexes.php
@@ -8,6 +8,7 @@ use App\Enums\OrganisationAccessLevel;
 use App\Enums\OrganisationAccessScope;
 use App\Models\Organisation;
 use App\OrganisationContext;
+use App\Queue\Middleware\PauseForInstallationControl;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use LogicException;
@@ -46,5 +47,11 @@ class RebuildPartyContactBlindIndexes implements ShouldQueue
         }
 
         $organisationContext->run($organisation, fn () => $rebuild->handle($organisation));
+    }
+
+    /** @return list<object> */
+    public function middleware(): array
+    {
+        return [new PauseForInstallationControl];
     }
 }

--- a/app/Jobs/RebuildProgramSearchDocument.php
+++ b/app/Jobs/RebuildProgramSearchDocument.php
@@ -10,6 +10,7 @@ use App\Enums\OrganisationLifecycleEventType;
 use App\Models\Organisation;
 use App\Models\Program;
 use App\OrganisationContext;
+use App\Queue\Middleware\PauseForInstallationControl;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use LogicException;
@@ -68,4 +69,10 @@ class RebuildProgramSearchDocument implements ShouldQueue
     public int $accessVersion;
 
     public int $programId;
+
+    /** @return list<object> */
+    public function middleware(): array
+    {
+        return [new PauseForInstallationControl];
+    }
 }

--- a/app/Jobs/RotatePartyContactDataEncryption.php
+++ b/app/Jobs/RotatePartyContactDataEncryption.php
@@ -8,6 +8,7 @@ use App\Enums\OrganisationAccessLevel;
 use App\Enums\OrganisationAccessScope;
 use App\Models\Organisation;
 use App\OrganisationContext;
+use App\Queue\Middleware\PauseForInstallationControl;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use LogicException;
@@ -46,5 +47,11 @@ class RotatePartyContactDataEncryption implements ShouldQueue
         }
 
         $organisationContext->run($organisation, fn () => $rotate->handle($organisation));
+    }
+
+    /** @return list<object> */
+    public function middleware(): array
+    {
+        return [new PauseForInstallationControl];
     }
 }

--- a/app/Models/InstallationControl.php
+++ b/app/Models/InstallationControl.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\InstallationCapability;
+use Database\Factories\InstallationControlFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property InstallationCapability $capability
+ */
+#[Fillable(['incident_uuid', 'capability', 'reason_code', 'activated_by_user_id', 'activated_at', 'released_by_user_id', 'released_at', 'release_reason_code'])]
+class InstallationControl extends Model
+{
+    /** @use HasFactory<InstallationControlFactory> */
+    use HasFactory, HasUlids;
+
+    public static function isPaused(InstallationCapability $capability): bool
+    {
+        return static::query()
+            ->where('capability', $capability)
+            ->whereNull('released_at')
+            ->exists();
+    }
+
+    /** @return BelongsTo<SecurityIncident, $this> */
+    public function incident(): BelongsTo
+    {
+        return $this->belongsTo(SecurityIncident::class, 'incident_uuid');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'capability' => InstallationCapability::class,
+            'activated_at' => 'datetime',
+            'released_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -170,6 +170,12 @@ class Organisation extends Model
         return $this->hasMany(OrganisationLifecycleEvent::class);
     }
 
+    /** @return HasMany<TenantAuditEvent, $this> */
+    public function auditEvents(): HasMany
+    {
+        return $this->hasMany(TenantAuditEvent::class);
+    }
+
     /** @return HasMany<OrganisationOwnershipTransfer, $this> */
     public function ownershipTransfers(): HasMany
     {

--- a/app/Models/PlatformSecurityEvent.php
+++ b/app/Models/PlatformSecurityEvent.php
@@ -2,16 +2,19 @@
 
 namespace App\Models;
 
+use App\Data\Auditing\VersionedAuditPayload;
+use App\Enums\PlatformSecurityEventType;
 use Database\Factories\PlatformSecurityEventFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
+use LogicException;
 
 /**
  * @property string $id
- * @property string $type
+ * @property PlatformSecurityEventType $type
  * @property int|null $actor_user_id
  * @property int|null $subject_user_id
  * @property array<string, mixed> $metadata
@@ -24,6 +27,8 @@ class PlatformSecurityEvent extends Model
 
     protected $fillable = [
         'type',
+        'schema_version',
+        'incident_uuid',
         'actor_user_id',
         'subject_user_id',
         'metadata',
@@ -31,6 +36,19 @@ class PlatformSecurityEvent extends Model
     ];
 
     public $timestamps = false;
+
+    protected static function booted(): void
+    {
+        static::creating(function (PlatformSecurityEvent $event): void {
+            if ($event->schema_version !== VersionedAuditPayload::CURRENT_VERSION) {
+                throw new LogicException('Unsupported platform security event schema version.');
+            }
+
+            VersionedAuditPayload::validate($event->metadata, $event->type->payloadSchema());
+        });
+        static::updating(fn () => throw new LogicException('Platform security events are append-only.'));
+        static::deleting(fn () => throw new LogicException('Platform security events are append-only.'));
+    }
 
     /**
      * @return BelongsTo<User, $this>
@@ -54,6 +72,8 @@ class PlatformSecurityEvent extends Model
     protected function casts(): array
     {
         return [
+            'type' => PlatformSecurityEventType::class,
+            'schema_version' => 'integer',
             'metadata' => 'array',
             'occurred_at' => 'datetime',
         ];

--- a/app/Models/SecurityIncident.php
+++ b/app/Models/SecurityIncident.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\SecurityIncidentClassification;
+use App\Enums\SecurityIncidentSeverity;
+use App\Enums\SecurityIncidentStatus;
+use Database\Factories\SecurityIncidentFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property string $id
+ * @property SecurityIncidentClassification $classification
+ * @property SecurityIncidentSeverity $severity
+ * @property SecurityIncidentStatus $status
+ * @property int|null $commander_user_id
+ */
+#[Fillable(['classification', 'severity', 'status', 'detection_source', 'summary', 'detected_at', 'first_awareness_at', 'confirmed_at', 'closed_at', 'commander_user_id'])]
+class SecurityIncident extends Model
+{
+    /** @use HasFactory<SecurityIncidentFactory> */
+    use HasFactory, HasUuids;
+
+    /** @return BelongsTo<User, $this> */
+    public function commander(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'commander_user_id');
+    }
+
+    /** @return HasMany<SecurityIncidentEntry, $this> */
+    public function entries(): HasMany
+    {
+        return $this->hasMany(SecurityIncidentEntry::class, 'incident_uuid');
+    }
+
+    /** @return HasMany<SecurityIncidentOrganisation, $this> */
+    public function organisationImpacts(): HasMany
+    {
+        return $this->hasMany(SecurityIncidentOrganisation::class, 'incident_uuid');
+    }
+
+    /** @return HasMany<InstallationControl, $this> */
+    public function installationControls(): HasMany
+    {
+        return $this->hasMany(InstallationControl::class, 'incident_uuid');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'classification' => SecurityIncidentClassification::class,
+            'severity' => SecurityIncidentSeverity::class,
+            'status' => SecurityIncidentStatus::class,
+            'detected_at' => 'datetime',
+            'first_awareness_at' => 'datetime',
+            'confirmed_at' => 'datetime',
+            'closed_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/SecurityIncidentEntry.php
+++ b/app/Models/SecurityIncidentEntry.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\SecurityIncidentEntryType;
+use Database\Factories\SecurityIncidentEntryFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use LogicException;
+
+#[Fillable(['incident_uuid', 'actor_user_id', 'type', 'summary', 'reference', 'status', 'due_at', 'occurred_at'])]
+class SecurityIncidentEntry extends Model
+{
+    /** @use HasFactory<SecurityIncidentEntryFactory> */
+    use HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Security incident entries are append-only.'));
+        static::deleting(fn () => throw new LogicException('Security incident entries are append-only.'));
+    }
+
+    /** @return BelongsTo<SecurityIncident, $this> */
+    public function incident(): BelongsTo
+    {
+        return $this->belongsTo(SecurityIncident::class, 'incident_uuid');
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function actor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'actor_user_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'type' => SecurityIncidentEntryType::class,
+            'due_at' => 'datetime',
+            'occurred_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/SecurityIncidentOrganisation.php
+++ b/app/Models/SecurityIncidentOrganisation.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable(['incident_uuid', 'organisation_id', 'impact_status', 'impact_summary', 'approved_communication'])]
+class SecurityIncidentOrganisation extends Model
+{
+    /** @return BelongsTo<SecurityIncident, $this> */
+    public function incident(): BelongsTo
+    {
+        return $this->belongsTo(SecurityIncident::class, 'incident_uuid');
+    }
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+}

--- a/app/Models/TenantAuditEvent.php
+++ b/app/Models/TenantAuditEvent.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Data\Auditing\VersionedAuditPayload;
+use App\Enums\TenantAuditEventType;
+use Database\Factories\TenantAuditEventFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use LogicException;
+
+/**
+ * @property TenantAuditEventType $type
+ * @property int $schema_version
+ * @property array<string, mixed> $payload
+ */
+#[Fillable(['organisation_id', 'actor_user_id', 'type', 'schema_version', 'subject_type', 'subject_id', 'payload', 'occurred_at'])]
+class TenantAuditEvent extends Model
+{
+    /** @use HasFactory<TenantAuditEventFactory> */
+    use BelongsToOrganisation, HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    protected static function booted(): void
+    {
+        static::creating(function (TenantAuditEvent $event): void {
+            if ($event->schema_version !== VersionedAuditPayload::CURRENT_VERSION) {
+                throw new LogicException('Unsupported tenant audit schema version.');
+            }
+
+            VersionedAuditPayload::validate($event->payload, $event->type->payloadSchema());
+        });
+        static::updating(fn () => throw new LogicException('Tenant audit events are append-only.'));
+        static::deleting(fn () => throw new LogicException('Tenant audit events are append-only.'));
+    }
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function actor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'actor_user_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'type' => TenantAuditEventType::class,
+            'schema_version' => 'integer',
+            'payload' => 'array',
+            'occurred_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Queue/Middleware/PauseForInstallationControl.php
+++ b/app/Queue/Middleware/PauseForInstallationControl.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Queue\Middleware;
+
+use App\Enums\InstallationCapability;
+use App\Models\InstallationControl;
+use Closure;
+
+class PauseForInstallationControl
+{
+    public function handle(object $job, Closure $next): void
+    {
+        if (InstallationControl::isPaused(InstallationCapability::Queues)) {
+            if (method_exists($job, 'release')) {
+                $job->release(60);
+            }
+
+            return;
+        }
+
+        $next($job);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\EnforceAbsoluteSessionLifetime;
+use App\Http\Middleware\EnsureInstallationAccess;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\ProtectSensitiveFortifyRoutes;
@@ -21,6 +22,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
 
         $middleware->web(append: [
+            EnsureInstallationAccess::class,
             EnforceAbsoluteSessionLifetime::class,
             ProtectSensitiveFortifyRoutes::class,
             HandleAppearance::class,

--- a/config/audit.php
+++ b/config/audit.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'runtime_database_role' => env('AUDIT_RUNTIME_DATABASE_ROLE'),
+];

--- a/config/security.php
+++ b/config/security.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'vulnerability_contact' => env(
+        'SECURITY_CONTACT',
+        'https://github.com/datashaman/community-kind/security/advisories/new',
+    ),
+    'security_txt_expires' => env('SECURITY_TXT_EXPIRES', '2027-08-30T00:00:00Z'),
+];

--- a/database/factories/InstallationControlFactory.php
+++ b/database/factories/InstallationControlFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\IncidentReasonCode;
+use App\Enums\InstallationCapability;
+use App\Models\InstallationControl;
+use App\Models\SecurityIncident;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<InstallationControl>
+ */
+class InstallationControlFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'incident_uuid' => SecurityIncident::factory(),
+            'capability' => InstallationCapability::Writes,
+            'reason_code' => IncidentReasonCode::SyntheticExercise->value,
+            'activated_at' => now(),
+        ];
+    }
+}

--- a/database/factories/PlatformSecurityEventFactory.php
+++ b/database/factories/PlatformSecurityEventFactory.php
@@ -2,6 +2,8 @@
 
 namespace Database\Factories;
 
+use App\Data\Auditing\VersionedAuditPayload;
+use App\Enums\PlatformSecurityEventType;
 use App\Models\PlatformSecurityEvent;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
@@ -19,10 +21,11 @@ class PlatformSecurityEventFactory extends Factory
     public function definition(): array
     {
         return [
-            'type' => fake()->randomElement(['other_browser_sessions_revoked']),
+            'type' => PlatformSecurityEventType::OtherBrowserSessionsRevoked,
+            'schema_version' => VersionedAuditPayload::CURRENT_VERSION,
             'actor_user_id' => User::factory(),
             'subject_user_id' => User::factory(),
-            'metadata' => [],
+            'metadata' => ['revoked_count' => 1],
             'occurred_at' => now(),
         ];
     }

--- a/database/factories/SecurityIncidentEntryFactory.php
+++ b/database/factories/SecurityIncidentEntryFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\SecurityIncidentEntryType;
+use App\Models\SecurityIncident;
+use App\Models\SecurityIncidentEntry;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SecurityIncidentEntry>
+ */
+class SecurityIncidentEntryFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'incident_uuid' => SecurityIncident::factory(),
+            'type' => SecurityIncidentEntryType::Action,
+            'summary' => 'Synthetic response action.',
+            'status' => 'completed',
+            'occurred_at' => now(),
+        ];
+    }
+}

--- a/database/factories/SecurityIncidentFactory.php
+++ b/database/factories/SecurityIncidentFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\SecurityIncidentClassification;
+use App\Enums\SecurityIncidentSeverity;
+use App\Enums\SecurityIncidentStatus;
+use App\Models\SecurityIncident;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SecurityIncident>
+ */
+class SecurityIncidentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'classification' => SecurityIncidentClassification::Incident,
+            'severity' => SecurityIncidentSeverity::S3Medium,
+            'status' => SecurityIncidentStatus::Reported,
+            'detection_source' => 'synthetic_test',
+            'summary' => 'Synthetic incident for testing.',
+            'detected_at' => now(),
+        ];
+    }
+}

--- a/database/factories/TenantAuditEventFactory.php
+++ b/database/factories/TenantAuditEventFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Data\Auditing\VersionedAuditPayload;
+use App\Enums\TenantAuditEventType;
+use App\Models\Organisation;
+use App\Models\TenantAuditEvent;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<TenantAuditEvent>
+ */
+class TenantAuditEventFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => Organisation::factory(),
+            'actor_user_id' => User::factory(),
+            'type' => TenantAuditEventType::ProgramUpdated,
+            'schema_version' => VersionedAuditPayload::CURRENT_VERSION,
+            'subject_type' => 'program',
+            'subject_id' => (string) fake()->numberBetween(1, 1000),
+            'payload' => [
+                'program_id' => fake()->numberBetween(1, 1000),
+                'changed_fields' => ['name'],
+            ],
+            'occurred_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/2026_08_31_025233_create_tenant_audit_events_table.php
+++ b/database/migrations/2026_08_31_025233_create_tenant_audit_events_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tenant_audit_events', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->unsignedBigInteger('actor_user_id')->nullable()->index();
+            $table->string('type');
+            $table->unsignedSmallInteger('schema_version');
+            $table->string('subject_type');
+            $table->string('subject_id');
+            $table->json('payload');
+            $table->timestamp('occurred_at');
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['organisation_id', 'occurred_at', 'id']);
+            $table->index(['organisation_id', 'subject_type', 'subject_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tenant_audit_events');
+    }
+};

--- a/database/migrations/2026_08_31_025234_create_security_incidents_table.php
+++ b/database/migrations/2026_08_31_025234_create_security_incidents_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('security_incidents', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('classification');
+            $table->string('severity');
+            $table->string('status');
+            $table->string('detection_source');
+            $table->text('summary');
+            $table->timestamp('detected_at');
+            $table->timestamp('first_awareness_at')->nullable();
+            $table->timestamp('confirmed_at')->nullable();
+            $table->timestamp('closed_at')->nullable();
+            $table->foreignId('commander_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->index(['status', 'severity', 'detected_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('security_incidents');
+    }
+};

--- a/database/migrations/2026_08_31_025235_create_security_incident_entries_table.php
+++ b/database/migrations/2026_08_31_025235_create_security_incident_entries_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('security_incident_entries', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignUuid('incident_uuid')->constrained('security_incidents')->cascadeOnDelete();
+            $table->unsignedBigInteger('actor_user_id')->nullable()->index();
+            $table->string('type');
+            $table->text('summary');
+            $table->string('reference')->nullable();
+            $table->string('status')->nullable();
+            $table->timestamp('due_at')->nullable();
+            $table->timestamp('occurred_at');
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['incident_uuid', 'occurred_at', 'id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('security_incident_entries');
+    }
+};

--- a/database/migrations/2026_08_31_025236_create_security_incident_organisations_table.php
+++ b/database/migrations/2026_08_31_025236_create_security_incident_organisations_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('security_incident_organisations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignUuid('incident_uuid')->constrained('security_incidents')->cascadeOnDelete();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->string('impact_status');
+            $table->text('impact_summary')->nullable();
+            $table->text('approved_communication')->nullable();
+            $table->timestamps();
+
+            $table->unique(['incident_uuid', 'organisation_id']);
+            $table->index(['organisation_id', 'impact_status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('security_incident_organisations');
+    }
+};

--- a/database/migrations/2026_08_31_025237_create_installation_controls_table.php
+++ b/database/migrations/2026_08_31_025237_create_installation_controls_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('installation_controls', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignUuid('incident_uuid')->constrained('security_incidents')->cascadeOnDelete();
+            $table->string('capability');
+            $table->string('reason_code');
+            $table->foreignId('activated_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('activated_at');
+            $table->foreignId('released_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('released_at')->nullable();
+            $table->string('release_reason_code')->nullable();
+            $table->timestamps();
+
+            $table->index(['capability', 'released_at']);
+            $table->index(['incident_uuid', 'released_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('installation_controls');
+    }
+};

--- a/database/migrations/2026_08_31_025249_add_schema_version_and_incident_to_platform_security_events.php
+++ b/database/migrations/2026_08_31_025249_add_schema_version_and_incident_to_platform_security_events.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('platform_security_events', function (Blueprint $table) {
+            $table->dropForeign(['actor_user_id']);
+            $table->dropForeign(['subject_user_id']);
+            $table->unsignedSmallInteger('schema_version')->default(1)->after('type');
+            $table->uuid('incident_uuid')->nullable()->after('schema_version');
+            $table->foreign('incident_uuid')->references('id')->on('security_incidents')->nullOnDelete();
+            $table->index(['incident_uuid', 'occurred_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('platform_security_events', function (Blueprint $table) {
+            $table->dropForeign(['incident_uuid']);
+            $table->dropIndex(['incident_uuid', 'occurred_at']);
+            $table->dropColumn(['schema_version', 'incident_uuid']);
+            $table->foreign('actor_user_id')->references('id')->on('users')->nullOnDelete();
+            $table->foreign('subject_user_id')->references('id')->on('users')->nullOnDelete();
+        });
+    }
+};

--- a/database/migrations/2026_08_31_025250_enforce_append_only_audit_streams.php
+++ b/database/migrations/2026_08_31_025250_enforce_append_only_audit_streams.php
@@ -1,0 +1,73 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                CREATE OR REPLACE FUNCTION prevent_append_only_mutation() RETURNS trigger
+                LANGUAGE plpgsql AS $$
+                BEGIN
+                    RAISE EXCEPTION 'append-only table';
+                END;
+                $$
+            SQL);
+        }
+
+        foreach (['tenant_audit_events', 'platform_security_events', 'security_incident_entries'] as $table) {
+            if (DB::getDriverName() === 'pgsql') {
+                DB::unprepared("CREATE TRIGGER {$table}_append_only BEFORE UPDATE OR DELETE OR TRUNCATE ON {$table} FOR EACH STATEMENT EXECUTE FUNCTION prevent_append_only_mutation() ");
+            } elseif (DB::getDriverName() === 'sqlite') {
+                DB::unprepared("CREATE TRIGGER {$table}_append_only_update BEFORE UPDATE ON {$table} BEGIN SELECT RAISE(ABORT, 'append-only table'); END");
+                DB::unprepared("CREATE TRIGGER {$table}_append_only_delete BEFORE DELETE ON {$table} BEGIN SELECT RAISE(ABORT, 'append-only table'); END");
+            }
+        }
+
+        if (DB::getDriverName() === 'pgsql') {
+            $runtimeRole = config('audit.runtime_database_role');
+
+            if (is_string($runtimeRole) && preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $runtimeRole) === 1) {
+                foreach (['tenant_audit_events', 'platform_security_events', 'security_incident_entries'] as $table) {
+                    DB::connection()->getPdo()->exec("REVOKE UPDATE, DELETE, TRUNCATE ON {$table} FROM {$runtimeRole}");
+                    DB::connection()->getPdo()->exec("GRANT SELECT, INSERT ON {$table} TO {$runtimeRole}");
+                }
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            $runtimeRole = config('audit.runtime_database_role');
+
+            if (is_string($runtimeRole) && preg_match('/^[a-zA-Z_][a-zA-Z0-9_]*$/', $runtimeRole) === 1) {
+                foreach (['tenant_audit_events', 'platform_security_events', 'security_incident_entries'] as $table) {
+                    DB::connection()->getPdo()->exec("GRANT UPDATE, DELETE, TRUNCATE ON {$table} TO {$runtimeRole}");
+                }
+            }
+        }
+
+        foreach (['tenant_audit_events', 'platform_security_events', 'security_incident_entries'] as $table) {
+            if (DB::getDriverName() === 'pgsql') {
+                DB::unprepared("DROP TRIGGER IF EXISTS {$table}_append_only ON {$table}");
+            } elseif (DB::getDriverName() === 'sqlite') {
+                DB::unprepared("DROP TRIGGER IF EXISTS {$table}_append_only_update");
+                DB::unprepared("DROP TRIGGER IF EXISTS {$table}_append_only_delete");
+            }
+        }
+
+        if (DB::getDriverName() === 'pgsql') {
+            DB::unprepared('DROP FUNCTION IF EXISTS prevent_append_only_mutation()');
+        }
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,12 +8,38 @@ use App\Http\Middleware\EnsureStaffSecurityRequirements;
 use App\Http\Middleware\UseOrganisationContext;
 use App\Models\Organisation;
 use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
 use Illuminate\Http\Response;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 
 Route::inertia('/', 'welcome')->name('home');
 Route::model('current_organisation', Organisation::class);
+
+Route::get('/.well-known/security.txt', function (Request $request): Response {
+    $host = $request->getSchemeAndHttpHost();
+    $contents = implode("\n", [
+        'Contact: '.config('security.vulnerability_contact'),
+        'Expires: '.config('security.security_txt_expires'),
+        'Canonical: '.$host.'/.well-known/security.txt',
+        'Policy: '.$host.'/security-policy',
+        '',
+    ]);
+
+    return response($contents, headers: [
+        'Content-Type' => 'text/plain; charset=UTF-8',
+        'Cache-Control' => 'public, max-age=3600',
+        'X-Content-Type-Options' => 'nosniff',
+    ]);
+})->name('security.txt');
+
+Route::get('/security-policy', fn (): Response => response(
+    File::get(base_path('SECURITY.md')),
+    headers: [
+        'Content-Type' => 'text/markdown; charset=UTF-8',
+        'X-Content-Type-Options' => 'nosniff',
+    ],
+))->name('security.policy');
 
 Route::get('/source-and-licence', fn (): View => view('source-and-licence', [
     'repository' => config('source.repository'),

--- a/tests/Feature/SecurityDisclosureTest.php
+++ b/tests/Feature/SecurityDisclosureTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Models\Organisation;
+use Illuminate\Support\Carbon;
+
+it('publishes host-correct RFC 9116 discovery without tenant content on every hosted surface', function (string $host) {
+    Organisation::factory()->create(['name' => 'Do not expose this tenant']);
+
+    $this->get("https://{$host}/.well-known/security.txt")
+        ->assertOk()
+        ->assertHeader('Content-Type', 'text/plain; charset=UTF-8')
+        ->assertSee('Contact: https://github.com/datashaman/community-kind/security/advisories/new', false)
+        ->assertSee('Expires: 2027-08-30T00:00:00Z', false)
+        ->assertSee("Canonical: https://{$host}/.well-known/security.txt", false)
+        ->assertSee("Policy: https://{$host}/security-policy", false)
+        ->assertDontSee('Do not expose this tenant', false);
+})->with([
+    'central staff host' => 'platform.example.test',
+    'tenant public host' => 'harbourkind.example.test',
+    'custom domain' => 'community.example.org',
+]);
+
+it('publishes the coordinated vulnerability-reporting policy', function () {
+    $this->get('/security-policy')
+        ->assertOk()
+        ->assertHeader('Content-Type', 'text/markdown; charset=UTF-8')
+        ->assertSee('Do not report suspected vulnerabilities in a public issue.', false)
+        ->assertSee('business days', false)
+        ->assertSee('synthetic data', false);
+});
+
+it('keeps the RFC 9116 expiry current and within one year', function () {
+    $expires = Carbon::parse((string) config('security.security_txt_expires'));
+
+    expect($expires->isFuture())->toBeTrue()
+        ->and(now()->diffInDays($expires))->toBeLessThanOrEqual(365);
+});

--- a/tests/Feature/SecurityIncidentContainmentTest.php
+++ b/tests/Feature/SecurityIncidentContainmentTest.php
@@ -1,0 +1,266 @@
+<?php
+
+use App\Actions\Security\RecordSecurityIncidentEntry;
+use App\Actions\Security\ReportSecurityIncident;
+use App\Enums\IncidentReasonCode;
+use App\Enums\InstallationCapability;
+use App\Enums\SecurityIncidentClassification;
+use App\Enums\SecurityIncidentEntryType;
+use App\Enums\SecurityIncidentSeverity;
+use App\Enums\SecurityIncidentStatus;
+use App\Http\Middleware\EnsureInstallationAccess;
+use App\Models\InstallationControl;
+use App\Models\Organisation;
+use App\Models\OrganisationAccessHold;
+use App\Models\PlatformSecurityEvent;
+use App\Models\SecurityIncident;
+use App\Models\SecurityIncidentEntry;
+use App\Models\User;
+use App\Queue\Middleware\PauseForInstallationControl;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+
+it('keeps alerts distinct from incidents and records the restricted response register', function () {
+    $actor = User::factory()->create();
+    $report = app(ReportSecurityIncident::class);
+    $alert = $report->handle(
+        SecurityIncidentClassification::Alert,
+        SecurityIncidentSeverity::S4Low,
+        'control_monitor',
+        'Synthetic blocked attack.',
+        $actor,
+    );
+    $incident = $report->handle(
+        SecurityIncidentClassification::Incident,
+        SecurityIncidentSeverity::S2High,
+        'synthetic_exercise',
+        'Synthetic privileged-account compromise.',
+        $actor,
+    );
+    $entries = app(RecordSecurityIncidentEntry::class);
+
+    foreach (SecurityIncidentEntryType::cases() as $type) {
+        $entries->handle(
+            $incident,
+            $type,
+            "Synthetic {$type->value} entry.",
+            $actor,
+            reference: $type === SecurityIncidentEntryType::EvidenceReference ? 'evidence:synthetic-001' : null,
+            status: in_array($type, [SecurityIncidentEntryType::Action, SecurityIncidentEntryType::RecoveryGate, SecurityIncidentEntryType::CorrectiveAction], true) ? 'open' : null,
+            dueAt: $type === SecurityIncidentEntryType::CorrectiveAction ? now()->addDay() : null,
+        );
+    }
+
+    expect($alert->classification)->toBe(SecurityIncidentClassification::Alert)
+        ->and($incident->classification)->toBe(SecurityIncidentClassification::Incident)
+        ->and($incident->entries)->toHaveCount(count(SecurityIncidentEntryType::cases()));
+    $this->assertDatabaseHas('platform_security_events', [
+        'incident_uuid' => $incident->id,
+        'type' => 'incident_reported',
+    ]);
+});
+
+it('guards containment and atomically revokes access holds tenants and pauses installation capabilities', function () {
+    config(['session.driver' => 'database']);
+    $actor = User::factory()->create();
+    $target = User::factory()->create(['remember_token' => 'remember-me']);
+    $organisation = Organisation::factory()->active()->create(['name' => 'HarbourKind Private']);
+    $incident = app(ReportSecurityIncident::class)->handle(
+        SecurityIncidentClassification::Incident,
+        SecurityIncidentSeverity::S1Critical,
+        'synthetic_exercise',
+        'Synthetic cross-tenant exposure.',
+        $actor,
+    );
+    DB::table('sessions')->insert([
+        'id' => 'compromised-session',
+        'user_id' => $target->id,
+        'payload' => '',
+        'last_activity' => time(),
+    ]);
+    DB::table('password_reset_tokens')->insert([
+        'email' => $target->email,
+        'token' => 'hashed-token',
+        'created_at' => now(),
+    ]);
+
+    expect(Artisan::call('security:incident:contain', [
+        'incident' => $incident->id,
+        '--confirm' => $incident->id,
+        '--actor-user' => $actor->id,
+        '--reason-code' => IncidentReasonCode::SyntheticExercise->value,
+        '--revoke-user' => [$target->id],
+        '--hold-organisation' => [$organisation->uuid],
+        '--pause' => [
+            InstallationCapability::Queues->value,
+            InstallationCapability::Outbox->value,
+            InstallationCapability::Uploads->value,
+            InstallationCapability::Forms->value,
+        ],
+        '--freeze-writes' => true,
+        '--credential' => ['classified-data-key-v2'],
+    ]))->toBe(0);
+
+    expect($incident->fresh()->status)->toBe(SecurityIncidentStatus::Contained)
+        ->and($target->fresh()->remember_token)->toBeNull()
+        ->and(InstallationControl::isPaused(InstallationCapability::Writes))->toBeTrue()
+        ->and(InstallationControl::query()->whereNull('released_at')->count())->toBe(5)
+        ->and(OrganisationAccessHold::query()->where('incident_uuid', $incident->id)->whereNull('released_at')->count())->toBe(1);
+    $this->assertDatabaseMissing('sessions', ['id' => 'compromised-session']);
+    $this->assertDatabaseMissing('password_reset_tokens', ['email' => $target->email]);
+    $this->actingAs($actor)->post(route('organisations.store'))->assertServiceUnavailable();
+    $this->post('/logout')->assertRedirect();
+    $this->post('/login')->assertRedirect()->assertSessionHasErrors(['email', 'password']);
+
+    $metadata = PlatformSecurityEvent::query()
+        ->where('incident_uuid', $incident->id)
+        ->get()
+        ->pluck('metadata')
+        ->toJson();
+    expect($metadata)->not->toContain('HarbourKind Private')
+        ->not->toContain('Synthetic cross-tenant exposure')
+        ->not->toContain('remember-me')
+        ->not->toContain('hashed-token');
+});
+
+it('shuts down designated public forms without disabling authentication', function () {
+    InstallationControl::factory()->create(['capability' => InstallationCapability::Forms]);
+    Route::post('/synthetic-public-form', fn () => response()->noContent())
+        ->middleware(['web', EnsureInstallationAccess::class.':forms'])
+        ->name('forms.synthetic.store');
+
+    $this->post('/synthetic-public-form')->assertServiceUnavailable();
+    $this->post('/login')->assertRedirect()->assertSessionHasErrors(['email', 'password']);
+});
+
+it('retains queued work while an incident queue pause is active', function () {
+    InstallationControl::factory()->create(['capability' => InstallationCapability::Queues]);
+    $job = new class
+    {
+        public ?int $releasedFor = null;
+
+        public function release(int $delay): void
+        {
+            $this->releasedFor = $delay;
+        }
+    };
+    $continued = false;
+
+    (new PauseForInstallationControl)->handle($job, function () use (&$continued): void {
+        $continued = true;
+    });
+
+    expect($job->releasedFor)->toBe(60)
+        ->and($continued)->toBeFalse();
+});
+
+it('requires exact incident confirmation and leaves state unchanged when authorization fails', function () {
+    $actor = User::factory()->create();
+    $incident = SecurityIncident::factory()->create();
+
+    expect(Artisan::call('security:incident:contain', [
+        'incident' => $incident->id,
+        '--confirm' => 'wrong-incident',
+        '--actor-user' => $actor->id,
+        '--reason-code' => IncidentReasonCode::SyntheticExercise->value,
+        '--freeze-writes' => true,
+    ]))->toBe(1)
+        ->and(InstallationControl::query()->count())->toBe(0)
+        ->and($incident->fresh()->status)->toBe(SecurityIncidentStatus::Reported);
+});
+
+it('rejects missing containment targets instead of silently applying a partial response', function () {
+    $actor = User::factory()->create();
+    $incident = SecurityIncident::factory()->create();
+
+    expect(Artisan::call('security:incident:contain', [
+        'incident' => $incident->id,
+        '--confirm' => $incident->id,
+        '--actor-user' => $actor->id,
+        '--reason-code' => IncidentReasonCode::SyntheticExercise->value,
+        '--revoke-user' => ['999999'],
+    ]))->toBe(2)
+        ->and(InstallationControl::query()->count())->toBe(0)
+        ->and($incident->fresh()->status)->toBe(SecurityIncidentStatus::Reported);
+});
+
+it('is idempotent for active hold and capability targets while allowing containment expansion', function () {
+    $actor = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    $incident = SecurityIncident::factory()->create();
+    $options = [
+        'incident' => $incident->id,
+        '--confirm' => $incident->id,
+        '--actor-user' => $actor->id,
+        '--reason-code' => IncidentReasonCode::SyntheticExercise->value,
+        '--hold-organisation' => [$organisation->uuid],
+        '--hold-level' => 'read_only',
+        '--pause' => [InstallationCapability::Queues->value],
+    ];
+
+    expect(Artisan::call('security:incident:contain', $options))->toBe(0)
+        ->and(Artisan::call('security:incident:contain', $options))->toBe(0)
+        ->and(OrganisationAccessHold::query()->where('incident_uuid', $incident->id)->count())->toBe(1)
+        ->and(InstallationControl::query()->where('incident_uuid', $incident->id)->count())->toBe(1)
+        ->and(PlatformSecurityEvent::query()
+            ->where('incident_uuid', $incident->id)
+            ->where('type', 'incident_status_changed')
+            ->count())->toBe(1);
+
+    expect(Artisan::call('security:incident:contain', [
+        ...$options,
+        '--hold-level' => 'denied',
+    ]))->toBe(0)
+        ->and(OrganisationAccessHold::query()->where('incident_uuid', $incident->id)->count())->toBe(2);
+});
+
+it('releases only the selected incident controls and records a recovery gate', function () {
+    $actor = User::factory()->create();
+    $incident = SecurityIncident::factory()->create(['status' => SecurityIncidentStatus::Contained]);
+    $otherIncident = SecurityIncident::factory()->create(['status' => SecurityIncidentStatus::Contained]);
+    InstallationControl::factory()->for($incident, 'incident')->create(['capability' => InstallationCapability::Writes]);
+    InstallationControl::factory()->for($otherIncident, 'incident')->create(['capability' => InstallationCapability::Writes]);
+
+    expect(Artisan::call('security:incident:recover', [
+        'incident' => $incident->id,
+        '--confirm' => $incident->id,
+        '--actor-user' => $actor->id,
+        '--reason-code' => IncidentReasonCode::SyntheticExercise->value,
+    ]))->toBe(0)
+        ->and($incident->fresh()->status)->toBe(SecurityIncidentStatus::Recovering)
+        ->and($incident->installationControls()->whereNull('released_at')->count())->toBe(0)
+        ->and($otherIncident->installationControls()->whereNull('released_at')->count())->toBe(1)
+        ->and($incident->entries()->where('type', SecurityIncidentEntryType::RecoveryGate)->count())->toBe(1);
+});
+
+it('prevents platform event and incident entry tampering at the database boundary', function () {
+    $incident = SecurityIncident::factory()->create();
+    $entry = SecurityIncidentEntry::factory()->for($incident, 'incident')->create();
+    $event = PlatformSecurityEvent::factory()->create();
+
+    expect(fn () => DB::transaction(
+        fn () => DB::table('security_incident_entries')->where('id', $entry->id)->update(['summary' => 'tampered']),
+    ))->toThrow(QueryException::class, 'append-only');
+    expect(fn () => DB::transaction(
+        fn () => DB::table('platform_security_events')->where('id', $event->id)->delete(),
+    ))->toThrow(QueryException::class, 'append-only');
+});
+
+it('preserves immutable actor references without blocking account deletion', function () {
+    $actor = User::factory()->create();
+    $event = PlatformSecurityEvent::factory()->create([
+        'actor_user_id' => $actor->id,
+        'subject_user_id' => $actor->id,
+    ]);
+
+    $actor->delete();
+
+    $this->assertDatabaseMissing('users', ['id' => $actor->id]);
+    $this->assertDatabaseHas('platform_security_events', [
+        'id' => $event->id,
+        'actor_user_id' => $actor->id,
+        'subject_user_id' => $actor->id,
+    ]);
+});

--- a/tests/Feature/TenantAuditEventTest.php
+++ b/tests/Feature/TenantAuditEventTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Enums\OrganisationRole;
+use App\Enums\TenantAuditEventType;
+use App\Models\Organisation;
+use App\Models\Program;
+use App\Models\TenantAuditEvent;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+
+it('records an allowlisted tenant audit in the same transaction as a protected Program update', function () {
+    $user = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    $membership = $organisation->memberships()->create([
+        'user_id' => $user->id,
+        'role' => OrganisationRole::ProgramManager,
+    ]);
+    $program = app(OrganisationContext::class)->run(
+        $organisation,
+        fn (): Program => Program::factory()->for($organisation)->create(['name' => 'Before', 'slug' => 'before']),
+    );
+    app(OrganisationContext::class)->run($organisation, fn () => $membership->programs()->attach($program));
+
+    $this->actingAs($user)
+        ->patchJson(route('organisations.programs.update', [$organisation, $program]), [
+            'name' => 'After',
+            'slug' => 'after',
+        ])
+        ->assertOk();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($organisation, $user, $program): void {
+        $event = TenantAuditEvent::query()->sole();
+
+        expect($event->organisation_id)->toBe($organisation->id)
+            ->and($event->actor_user_id)->toBe($user->id)
+            ->and($event->type)->toBe(TenantAuditEventType::ProgramUpdated)
+            ->and($event->schema_version)->toBe(1)
+            ->and($event->payload)->toBe([
+                'program_id' => $program->id,
+                'changed_fields' => ['name', 'slug'],
+            ])
+            ->and(json_encode($event->payload, JSON_THROW_ON_ERROR))->not->toContain('Before')->not->toContain('After');
+    });
+});
+
+it('rolls back a protected mutation when its required tenant audit cannot be recorded', function () {
+    $user = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    $organisation->memberships()->create([
+        'user_id' => $user->id,
+        'role' => OrganisationRole::OrganisationAdministrator,
+    ]);
+    $program = app(OrganisationContext::class)->run(
+        $organisation,
+        fn (): Program => Program::factory()->for($organisation)->create(['name' => 'Before', 'slug' => 'before']),
+    );
+    $this->mock(RecordTenantAuditEvent::class, function ($mock): void {
+        $mock->shouldReceive('handle')->once()->andThrow(new RuntimeException('Audit unavailable.'));
+    });
+
+    $this->actingAs($user)
+        ->patchJson(route('organisations.programs.update', [$organisation, $program]), [
+            'name' => 'After',
+            'slug' => 'after',
+        ])
+        ->assertServerError();
+
+    expect(DB::table('programs')->where('id', $program->id)->value('name'))->toBe('Before')
+        ->and(DB::table('tenant_audit_events')->count())->toBe(0);
+});
+
+it('rejects non-allowlisted payload fields and prevents audit mutation at application and database boundaries', function () {
+    $organisation = Organisation::factory()->active()->create();
+    $user = User::factory()->create();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($organisation, $user): void {
+        expect(fn () => app(RecordTenantAuditEvent::class)->handle(
+            $organisation,
+            TenantAuditEventType::ProgramUpdated,
+            'program',
+            '1',
+            ['program_id' => 1, 'changed_fields' => ['name'], 'name' => 'secret'],
+            $user,
+        ))->toThrow(InvalidArgumentException::class, 'allowlist');
+
+        $event = app(RecordTenantAuditEvent::class)->handle(
+            $organisation,
+            TenantAuditEventType::ProgramUpdated,
+            'program',
+            '1',
+            ['program_id' => 1, 'changed_fields' => ['name']],
+            $user,
+        );
+
+        expect(fn () => $event->update(['subject_id' => '2']))
+            ->toThrow(LogicException::class, 'append-only');
+        expect(fn () => DB::transaction(
+            fn () => DB::table('tenant_audit_events')->where('id', $event->id)->delete(),
+        ))->toThrow(QueryException::class, 'append-only');
+    });
+});
+
+it('scopes tenant audits to the current Organisation', function () {
+    $first = Organisation::factory()->active()->create();
+    $second = Organisation::factory()->active()->create();
+
+    app(OrganisationContext::class)->run($first, fn () => TenantAuditEvent::factory()->for($first)->create());
+    app(OrganisationContext::class)->run($second, fn () => TenantAuditEvent::factory()->for($second)->create());
+
+    app(OrganisationContext::class)->run($first, function () use ($first): void {
+        expect(TenantAuditEvent::query()->count())->toBe(1)
+            ->and(TenantAuditEvent::query()->sole()->organisation_id)->toBe($first->id);
+    });
+});


### PR DESCRIPTION
Closes #8

## Summary

- add separate versioned tenant-audit and platform-security streams with exact payload allowlists, transactionally audit Program updates, and enforce append-only behavior in Eloquent and the database
- add a restricted alert/incident register with severity, lifecycle, Organisation impact projections, and append-only decisions, actions, evidence references, recovery gates, and corrective actions
- add guarded, reason-coded containment and recovery commands for User access revocation, Organisation Access Holds, Installation write freezes, queue/outbox/upload/form pauses, and credential-rotation coordination
- publish host-correct RFC 9116 security discovery and the coordinated reporting policy; enable GitHub private vulnerability reporting for the repository
- retain queue work during pauses and keep authentication, logout, MFA, password changes, and session revocation available during business-write freezes

## Review fixes

The required review against `origin/main` found and fixed:

- append-only actor foreign keys could make audited Users undeletable when `nullOnDelete` attempted to rewrite history
- repeated containment created duplicate active controls and misleading status events; it is now idempotent while allowing stricter escalation
- broad form/write controls initially blocked security-sensitive authentication actions
- the published private-advisory URL was unavailable until GitHub private vulnerability reporting was enabled

## Verification

- `composer test` — 232 tests, 958 assertions
- `npm run check`
- `npm run types:check`
- `npm test`
- `npm run build`
- `composer audit --locked`
- fresh SQLite migrations plus rollback of all seven new migrations
- populated local PostgreSQL 18 migration
