### PR TITLE
Resolve public Organisations from trusted subdomains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,7 @@ APP_URL=http://localhost
 APP_RELEASE=development
 APP_SOURCE_REPOSITORY=https://github.com/datashaman/community-kind
 ORGANISATION_SELF_SERVICE_PROVISIONING=false
+ORGANISATION_PUBLIC_DOMAIN=localhost
 # Hosted deployments should set this to the least-privileged application role, distinct from the migration role.
 AUDIT_RUNTIME_DATABASE_ROLE=
 SECURITY_CONTACT=https://github.com/datashaman/community-kind/security/advisories/new

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Install these services and tools locally:
 
 - PHP 8.4 or newer with the `mbstring`, `pdo_pgsql`, and `redis` extensions
 - Composer 2
+- Laravel Valet 4
 - Node.js 24 and npm 11 or newer
 - PostgreSQL 18
 - Redis 7
@@ -43,7 +44,8 @@ Update these values in `.env` for the locally installed services. Replace the
 database credentials with the user and password you created:
 
 ```dotenv
-APP_URL=http://localhost:8000
+APP_URL=https://community-kind.test
+ORGANISATION_PUBLIC_DOMAIN=community-kind.test
 ORGANISATION_SELF_SERVICE_PROVISIONING=true
 DB_HOST=127.0.0.1
 DB_DATABASE=community_kind
@@ -66,14 +68,25 @@ php artisan key:generate
 php artisan migrate
 ```
 
-Start the Laravel application, queue worker, and frontend development server:
+Link and secure the project with Valet. Valet routes the linked site's wildcard
+subdomains to the same Laravel application, so tenant hosts do not need separate
+local registrations:
 
 ```bash
-composer run dev
+valet link community-kind --secure
 ```
 
-Open `http://localhost:8000`. To inspect email locally, replace the log mailer
-with an SMTP catcher such as Mailpit and update the `MAIL_*` values in `.env`.
+Start the frontend development server and Horizon in separate terminals:
+
+```bash
+npm run dev
+php artisan horizon
+```
+
+Open `https://community-kind.test`. Tenant public pages use hosts such as
+`https://harbourkind.community-kind.test`. To inspect email locally, replace
+the log mailer with an SMTP catcher such as Mailpit and update the `MAIL_*`
+values in `.env`.
 
 ## Docker setup
 

--- a/app/Concerns/GeneratesUniqueOrganisationSlugs.php
+++ b/app/Concerns/GeneratesUniqueOrganisationSlugs.php
@@ -2,54 +2,64 @@
 
 namespace App\Concerns;
 
-use App\Models\Organisation;
 use App\Models\OrganisationSlug;
 use Illuminate\Support\Str;
 
 trait GeneratesUniqueOrganisationSlugs
 {
+    private const int MAXIMUM_SLUG_LENGTH = 63;
+
     /**
      * Generate a unique slug for the organisation.
      */
     protected static function generateUniqueOrganisationSlug(string $name, ?int $excludeId = null): string
     {
-        $defaultSlug = Str::slug($name);
+        $baseSlug = rtrim(Str::substr(Str::slug($name), 0, self::MAXIMUM_SLUG_LENGTH), '-');
+        $searchPrefix = Str::substr($baseSlug, 0, min(strlen($baseSlug), 31));
 
-        $query = static::withTrashed()
-            ->where(function ($query) use ($defaultSlug) {
-                $query->where('slug', $defaultSlug)
-                    ->orWhere('slug', 'like', $defaultSlug.'-%');
-            });
-
-        if ($excludeId) {
-            $query->where('id', '!=', $excludeId);
-        }
-
-        $existingSlugs = $query->pluck('slug')
+        $existingSlugs = static::withTrashed()
+            ->where('slug', 'like', $searchPrefix.'%')
+            ->when($excludeId !== null, fn ($query) => $query->whereKeyNot($excludeId))
+            ->pluck('slug')
             ->merge(OrganisationSlug::query()
+                ->where('slug', 'like', $searchPrefix.'%')
                 ->where('quarantined_until', '>', now())
-                ->where(function ($query) use ($defaultSlug) {
-                    $query->where('slug', $defaultSlug)
-                        ->orWhere('slug', 'like', $defaultSlug.'-%');
-                })
                 ->pluck('slug'))
             ->unique();
 
         $maxSuffix = $existingSlugs
-            ->map(function (string $slug) use ($defaultSlug): ?int {
-                if ($slug === $defaultSlug) {
+            ->map(function (string $slug) use ($baseSlug): ?int {
+                if ($slug === $baseSlug) {
                     return 0;
-                } elseif (preg_match('/^'.preg_quote($defaultSlug, '/').'-(\d+)$/', $slug, $matches)) {
-                    return (int) $matches[1];
                 }
 
-                return null;
+                if (preg_match('/-(\d+)$/', $slug, $matches) !== 1) {
+                    return null;
+                }
+
+                $suffixNumber = (int) $matches[1];
+
+                return self::slugWithSuffix($baseSlug, $suffixNumber) === $slug
+                    ? $suffixNumber
+                    : null;
             })
             ->filter(fn (?int $suffix) => $suffix !== null)
-            ->max() ?? 0;
+            ->max();
 
-        return $existingSlugs->isEmpty()
-            ? $defaultSlug
-            : $defaultSlug.'-'.($maxSuffix + 1);
+        return $maxSuffix === null
+            ? $baseSlug
+            : self::slugWithSuffix($baseSlug, $maxSuffix + 1);
+    }
+
+    private static function slugWithSuffix(string $baseSlug, int $suffixNumber): string
+    {
+        $suffix = '-'.$suffixNumber;
+        $prefix = rtrim(Str::substr(
+            $baseSlug,
+            0,
+            self::MAXIMUM_SLUG_LENGTH - strlen($suffix),
+        ), '-');
+
+        return $prefix.$suffix;
     }
 }

--- a/app/Http/Controllers/Public/OrganisationController.php
+++ b/app/Http/Controllers/Public/OrganisationController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Public;
+
+use App\Http\Controllers\Controller;
+use App\Models\Organisation;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+
+class OrganisationController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request): View
+    {
+        $organisation = $request->attributes->get('public_organisation');
+
+        abort_unless($organisation instanceof Organisation, 404);
+
+        return view('public.organisation', [
+            'organisationName' => $organisation->name,
+            'canonicalUrl' => route('public.organisations.show', [
+                'public_organisation' => $organisation->slug,
+            ]),
+            'sourceUrl' => rtrim((string) config('app.url'), '/').'/source-and-licence',
+        ]);
+    }
+}

--- a/app/Http/Middleware/EnsureTrustedApplicationHost.php
+++ b/app/Http/Middleware/EnsureTrustedApplicationHost.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureTrustedApplicationHost
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $platformDomain = config('organisations.platform_domain');
+        $routeName = $request->route()?->getName();
+
+        if (is_string($platformDomain) && $request->getHost() === $platformDomain) {
+            return $next($request);
+        }
+
+        if (is_string($routeName) && str_starts_with($routeName, 'public.')) {
+            return $next($request);
+        }
+
+        abort(Response::HTTP_NOT_FOUND);
+    }
+}

--- a/app/Http/Middleware/ResolvePublicOrganisation.php
+++ b/app/Http/Middleware/ResolvePublicOrganisation.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Actions\Organisations\ResolveOrganisationAccess;
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Models\Organisation;
+use App\Models\OrganisationSlug;
+use App\OrganisationContext;
+use Closure;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ResolvePublicOrganisation
+{
+    public function __construct(
+        private ResolveOrganisationAccess $resolveOrganisationAccess,
+        private OrganisationContext $organisationContext,
+    ) {}
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $slug = $request->route('public_organisation');
+
+        abort_unless($this->isValidPublicSlug($slug), Response::HTTP_NOT_FOUND);
+
+        $organisation = Organisation::query()->where('slug', $slug)->first();
+
+        if ($organisation === null) {
+            $previousSlug = OrganisationSlug::query()
+                ->with('organisation')
+                ->where('slug', $slug)
+                ->where('redirect_until', '>', now())
+                ->first();
+            $organisation = $previousSlug?->organisation;
+
+            abort_unless($this->isPubliclyAvailable($organisation), Response::HTTP_NOT_FOUND);
+
+            return $this->redirectToCanonicalHost($request, $organisation);
+        }
+
+        abort_unless($this->isPubliclyAvailable($organisation), Response::HTTP_NOT_FOUND);
+
+        $request->attributes->set('public_organisation', $organisation);
+
+        return $this->organisationContext->run(
+            $organisation,
+            fn (): Response => $next($request),
+        );
+    }
+
+    private function isValidPublicSlug(mixed $slug): bool
+    {
+        return is_string($slug)
+            && strlen($slug) <= 63
+            && preg_match('/^[a-z0-9]+(?:-[a-z0-9]+)*$/', $slug) === 1
+            && ! in_array($slug, (array) config('organisations.reserved_public_subdomains', []), true);
+    }
+
+    private function isPubliclyAvailable(?Organisation $organisation): bool
+    {
+        return $organisation !== null
+            && $this->resolveOrganisationAccess->handle($organisation, OrganisationAccessScope::Public)
+                === OrganisationAccessLevel::Full;
+    }
+
+    private function redirectToCanonicalHost(Request $request, Organisation $organisation): RedirectResponse
+    {
+        $route = $request->route();
+        $routeName = $route?->getName();
+
+        abort_unless(is_string($routeName) && str_starts_with($routeName, 'public.'), Response::HTTP_NOT_FOUND);
+
+        $parameters = $route->parameters();
+        $parameters['public_organisation'] = $organisation->slug;
+        $url = route($routeName, $parameters);
+
+        if ($request->getQueryString() !== null) {
+            $url .= '?'.$request->getQueryString();
+        }
+
+        return redirect()->away($url, $request->isMethodSafe() ? 302 : 307);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 use App\Http\Middleware\EnforceAbsoluteSessionLifetime;
 use App\Http\Middleware\EnsureInstallationAccess;
+use App\Http\Middleware\EnsureTrustedApplicationHost;
 use App\Http\Middleware\HandleAppearance;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\ProtectSensitiveFortifyRoutes;
@@ -21,7 +22,9 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->encryptCookies(except: ['appearance', 'sidebar_state']);
 
-        $middleware->web(append: [
+        $middleware->web(prepend: [
+            EnsureTrustedApplicationHost::class,
+        ], append: [
             EnsureInstallationAccess::class,
             EnforceAbsoluteSessionLifetime::class,
             ProtectSensitiveFortifyRoutes::class,

--- a/config/organisations.php
+++ b/config/organisations.php
@@ -2,4 +2,27 @@
 
 return [
     'self_service_provisioning' => (bool) env('ORGANISATION_SELF_SERVICE_PROVISIONING', false),
+
+    'platform_domain' => parse_url((string) env('APP_URL', 'http://localhost'), PHP_URL_HOST) ?: 'localhost',
+
+    'public_domain' => env(
+        'ORGANISATION_PUBLIC_DOMAIN',
+        parse_url((string) env('APP_URL', 'http://localhost'), PHP_URL_HOST) ?: 'localhost',
+    ),
+
+    'reserved_public_subdomains' => [
+        'admin',
+        'api',
+        'app',
+        'assets',
+        'auth',
+        'cdn',
+        'demo',
+        'mail',
+        'platform',
+        'static',
+        'status',
+        'support',
+        'www',
+    ],
 ];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_URL" value="http://localhost"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>
@@ -27,6 +28,7 @@
         <env name="DB_DATABASE" value=":memory:"/>
         <env name="DB_URL" value=""/>
         <env name="MAIL_MAILER" value="array"/>
+        <env name="ORGANISATION_PUBLIC_DOMAIN" value="community-kind.test"/>
         <env name="ORGANISATION_SELF_SERVICE_PROVISIONING" value="true"/>
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>

--- a/resources/views/public/organisation.blade.php
+++ b/resources/views/public/organisation.blade.php
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <link rel="canonical" href="{{ $canonicalUrl }}">
+        <title>{{ $organisationName }}</title>
+        <style>
+            :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, sans-serif; line-height: 1.6; }
+            body { margin: 0; background: Canvas; color: CanvasText; }
+            main { width: min(42rem, calc(100% - 2rem)); margin: 5rem auto; }
+            .eyebrow { color: GrayText; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+        </style>
+    </head>
+    <body>
+        <main>
+            <p class="eyebrow">CommunityKind organisation</p>
+            <h1>{{ $organisationName }}</h1>
+            <p>This is the verified public home of {{ $organisationName }}.</p>
+            <p><a href="{{ $sourceUrl }}">Source and licence</a></p>
+        </main>
+    </body>
+</html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,9 +2,11 @@
 
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Organisations\OrganisationInvitationController;
+use App\Http\Controllers\Public\OrganisationController as PublicOrganisationController;
 use App\Http\Middleware\EnsureOrganisationAccess;
 use App\Http\Middleware\EnsureOrganisationMembership;
 use App\Http\Middleware\EnsureStaffSecurityRequirements;
+use App\Http\Middleware\ResolvePublicOrganisation;
 use App\Http\Middleware\UseOrganisationContext;
 use App\Models\Organisation;
 use Illuminate\Contracts\View\View;
@@ -13,10 +15,7 @@ use Illuminate\Http\Response;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 
-Route::inertia('/', 'welcome')->name('home');
-Route::model('current_organisation', Organisation::class);
-
-Route::get('/.well-known/security.txt', function (Request $request): Response {
+$securityText = function (Request $request): Response {
     $host = $request->getSchemeAndHttpHost();
     $contents = implode("\n", [
         'Contact: '.config('security.vulnerability_contact'),
@@ -31,15 +30,29 @@ Route::get('/.well-known/security.txt', function (Request $request): Response {
         'Cache-Control' => 'public, max-age=3600',
         'X-Content-Type-Options' => 'nosniff',
     ]);
-})->name('security.txt');
-
-Route::get('/security-policy', fn (): Response => response(
+};
+$securityPolicy = fn (): Response => response(
     File::get(base_path('SECURITY.md')),
     headers: [
         'Content-Type' => 'text/markdown; charset=UTF-8',
         'X-Content-Type-Options' => 'nosniff',
     ],
-))->name('security.policy');
+);
+
+Route::domain('{public_organisation}.'.config('organisations.public_domain'))
+    ->middleware(ResolvePublicOrganisation::class)
+    ->group(function () use ($securityPolicy, $securityText): void {
+        Route::get('/', PublicOrganisationController::class)->name('public.organisations.show');
+        Route::get('/.well-known/security.txt', $securityText)->name('public.security.txt');
+        Route::get('/security-policy', $securityPolicy)->name('public.security.policy');
+    });
+
+Route::inertia('/', 'welcome')->name('home');
+Route::model('current_organisation', Organisation::class);
+
+Route::get('/.well-known/security.txt', $securityText)->name('security.txt');
+
+Route::get('/security-policy', $securityPolicy)->name('security.policy');
 
 Route::get('/source-and-licence', fn (): View => view('source-and-licence', [
     'repository' => config('source.repository'),

--- a/tests/Feature/PublicOrganisationHostTest.php
+++ b/tests/Feature/PublicOrganisationHostTest.php
@@ -1,0 +1,239 @@
+<?php
+
+use App\Enums\OrganisationAccessLevel;
+use App\Enums\OrganisationAccessScope;
+use App\Enums\OrganisationStatus;
+use App\Models\Organisation;
+use App\Models\OrganisationAccessHold;
+use App\Models\OrganisationSlug;
+use App\Models\User;
+
+it('renders only the Organisation resolved from the exact public host', function () {
+    Organisation::factory()->active()->create([
+        'name' => 'HarbourKind',
+        'slug' => 'harbourkind',
+    ]);
+    $neighbourLink = Organisation::factory()->active()->create([
+        'name' => 'NeighbourLink',
+        'slug' => 'neighbourlink',
+    ]);
+    $staffUser = User::factory()->create();
+    $neighbourLink->memberships()->create([
+        'user_id' => $staffUser->id,
+    ]);
+    $staffUser->switchOrganisation($neighbourLink);
+
+    $response = $this
+        ->actingAs($staffUser)
+        ->get('https://harbourkind.community-kind.test/?organisation=neighbourlink');
+
+    $response
+        ->assertOk()
+        ->assertSee('HarbourKind')
+        ->assertDontSee('NeighbourLink')
+        ->assertSee('<link rel="canonical" href="https://harbourkind.community-kind.test">', false);
+});
+
+it('provisions unique DNS-length slugs for long Organisation names', function () {
+    $name = str_repeat('Long Community Name ', 5);
+    $firstOrganisation = Organisation::factory()->active()->create([
+        'name' => $name,
+        'slug' => null,
+    ]);
+    $secondOrganisation = Organisation::factory()->active()->create([
+        'name' => $name,
+        'slug' => null,
+    ]);
+
+    $response = $this->get("https://{$secondOrganisation->slug}.community-kind.test/");
+
+    $response->assertSee($name);
+    expect(strlen($firstOrganisation->slug))->toBeLessThanOrEqual(63)
+        ->and(strlen($secondOrganisation->slug))->toBeLessThanOrEqual(63)
+        ->and($secondOrganisation->slug)->not->toBe($firstOrganisation->slug);
+});
+
+it('does not serve staff routes from a tenant public host', function () {
+    Organisation::factory()->active()->create([
+        'name' => 'HarbourKind',
+        'slug' => 'harbourkind',
+    ]);
+
+    $response = $this->get('https://harbourkind.community-kind.test/login');
+
+    $response->assertNotFound();
+});
+
+it('does not serve public discovery from an unknown tenant host', function () {
+    $response = $this->get('https://unknown.community-kind.test/.well-known/security.txt');
+
+    $response->assertNotFound();
+});
+
+it('does not serve application routes from an unverified custom domain', function () {
+    $response = $this->get('https://community.example.org/');
+
+    $response->assertNotFound();
+});
+
+it('rejects an unverified host before a previous staff slug can reveal an Organisation', function () {
+    $organisation = Organisation::factory()->active()->create([
+        'name' => 'HarbourKind',
+        'slug' => 'harbourkind',
+    ]);
+    OrganisationSlug::factory()->for($organisation)->create([
+        'slug' => 'old-harbourkind',
+        'redirect_until' => now()->addDay(),
+    ]);
+
+    $response = $this->get('https://community.example.org/settings/organisations/old-harbourkind');
+
+    $response->assertNotFound();
+});
+
+it('escapes the Organisation name on its public home', function () {
+    Organisation::factory()->active()->create([
+        'name' => 'HarbourKind <script>alert("tenant")</script>',
+        'slug' => 'harbourkind',
+    ]);
+
+    $response = $this->get('https://harbourkind.community-kind.test/');
+
+    $response
+        ->assertOk()
+        ->assertSee('HarbourKind &lt;script&gt;alert(&quot;tenant&quot;)&lt;/script&gt;', false)
+        ->assertDontSee('<script>alert("tenant")</script>', false);
+});
+
+it('returns a neutral 404 for Organisations that are not active', function (OrganisationStatus $status) {
+    Organisation::factory()->create([
+        'name' => 'Private Lifecycle Organisation',
+        'slug' => 'private-lifecycle',
+        'status' => $status,
+        'deletion_scheduled_for' => $status === OrganisationStatus::ScheduledForDeletion
+            ? now()->addMonth()
+            : null,
+    ]);
+
+    $response = $this->get('https://private-lifecycle.community-kind.test/');
+
+    $response
+        ->assertNotFound()
+        ->assertDontSee('Private Lifecycle Organisation');
+})->with([
+    'pending' => OrganisationStatus::Pending,
+    'archived' => OrganisationStatus::Archived,
+    'scheduled for deletion' => OrganisationStatus::ScheduledForDeletion,
+    'deleted' => OrganisationStatus::Deleted,
+]);
+
+it('returns a neutral 404 for a soft-deleted Organisation', function () {
+    Organisation::factory()->active()->trashed()->create([
+        'name' => 'Deleted HarbourKind',
+        'slug' => 'deleted-harbourkind',
+    ]);
+
+    $response = $this->get('https://deleted-harbourkind.community-kind.test/');
+
+    $response
+        ->assertNotFound()
+        ->assertDontSee('Deleted HarbourKind');
+});
+
+it('returns a neutral 404 while an applicable public Access Hold restricts the Organisation', function () {
+    $organisation = Organisation::factory()->active()->create([
+        'name' => 'Held HarbourKind',
+        'slug' => 'held-harbourkind',
+    ]);
+    OrganisationAccessHold::factory()->for($organisation)->create([
+        'scope' => OrganisationAccessScope::Public,
+        'access_level' => OrganisationAccessLevel::ReadOnly,
+    ]);
+
+    $response = $this->get('https://held-harbourkind.community-kind.test/');
+
+    $response
+        ->assertNotFound()
+        ->assertDontSee('Held HarbourKind');
+});
+
+it('does not apply a staff-only Access Hold to the public host', function () {
+    $organisation = Organisation::factory()->active()->create([
+        'name' => 'Public HarbourKind',
+        'slug' => 'public-harbourkind',
+    ]);
+    OrganisationAccessHold::factory()->for($organisation)->create([
+        'scope' => OrganisationAccessScope::Staff,
+        'access_level' => OrganisationAccessLevel::Denied,
+    ]);
+
+    $response = $this->get('https://public-harbourkind.community-kind.test/');
+
+    $response->assertSee('Public HarbourKind');
+});
+
+it('returns the same neutral response for unknown reserved and malformed public hosts', function (string $host) {
+    Organisation::factory()->active()->create([
+        'name' => 'Reserved Platform Organisation',
+        'slug' => 'app',
+    ]);
+
+    $unknownResponse = $this->get('https://unknown.community-kind.test/');
+    $candidateResponse = $this->get("https://{$host}/");
+
+    $unknownResponse->assertNotFound();
+    $candidateResponse->assertNotFound();
+    expect($candidateResponse->getContent())->toBe($unknownResponse->getContent());
+})->with([
+    'reserved subdomain' => 'app.community-kind.test',
+    'nested subdomain' => 'nested.harbourkind.community-kind.test',
+    'lookalike parent domain' => 'harbourkind.evil-community-kind.test',
+    'appended parent domain' => 'harbourkind.community-kind.test.evil.test',
+]);
+
+it('redirects an active previous slug to the canonical public host while preserving the query', function () {
+    $organisation = Organisation::factory()->active()->create([
+        'name' => 'HarbourKind',
+        'slug' => 'harbourkind',
+    ]);
+    OrganisationSlug::factory()->for($organisation)->create([
+        'slug' => 'old-harbourkind',
+        'redirect_until' => now()->addDay(),
+    ]);
+
+    $response = $this->get('https://old-harbourkind.community-kind.test/?campaign=spring');
+
+    $response->assertRedirect('https://harbourkind.community-kind.test?campaign=spring');
+});
+
+it('preserves the public route when redirecting a previous slug', function () {
+    $organisation = Organisation::factory()->active()->create([
+        'name' => 'HarbourKind',
+        'slug' => 'harbourkind',
+    ]);
+    OrganisationSlug::factory()->for($organisation)->create([
+        'slug' => 'old-harbourkind',
+        'redirect_until' => now()->addDay(),
+    ]);
+
+    $response = $this->get('https://old-harbourkind.community-kind.test/.well-known/security.txt');
+
+    $response->assertRedirect('https://harbourkind.community-kind.test/.well-known/security.txt');
+});
+
+it('returns a neutral 404 after a previous public slug redirect expires', function () {
+    $organisation = Organisation::factory()->active()->create([
+        'name' => 'HarbourKind',
+        'slug' => 'harbourkind',
+    ]);
+    OrganisationSlug::factory()->for($organisation)->create([
+        'slug' => 'expired-harbourkind',
+        'redirect_until' => now()->subSecond(),
+    ]);
+
+    $response = $this->get('https://expired-harbourkind.community-kind.test/');
+
+    $response
+        ->assertNotFound()
+        ->assertDontSee('HarbourKind');
+});

--- a/tests/Feature/SecurityDisclosureTest.php
+++ b/tests/Feature/SecurityDisclosureTest.php
@@ -3,22 +3,35 @@
 use App\Models\Organisation;
 use Illuminate\Support\Carbon;
 
-it('publishes host-correct RFC 9116 discovery without tenant content on every hosted surface', function (string $host) {
+it('publishes host-correct RFC 9116 discovery without tenant content on the central host', function () {
     Organisation::factory()->create(['name' => 'Do not expose this tenant']);
 
-    $this->get("https://{$host}/.well-known/security.txt")
+    $this->get('https://localhost/.well-known/security.txt')
         ->assertOk()
         ->assertHeader('Content-Type', 'text/plain; charset=UTF-8')
         ->assertSee('Contact: https://github.com/datashaman/community-kind/security/advisories/new', false)
         ->assertSee('Expires: 2027-08-30T00:00:00Z', false)
-        ->assertSee("Canonical: https://{$host}/.well-known/security.txt", false)
-        ->assertSee("Policy: https://{$host}/security-policy", false)
+        ->assertSee('Canonical: https://localhost/.well-known/security.txt', false)
+        ->assertSee('Policy: https://localhost/security-policy', false)
         ->assertDontSee('Do not expose this tenant', false);
-})->with([
-    'central staff host' => 'platform.example.test',
-    'tenant public host' => 'harbourkind.example.test',
-    'custom domain' => 'community.example.org',
-]);
+});
+
+it('publishes host-correct RFC 9116 discovery without tenant content on an active public host', function () {
+    Organisation::factory()->create(['name' => 'Do not expose this tenant']);
+    Organisation::factory()->active()->create([
+        'name' => 'HarbourKind',
+        'slug' => 'harbourkind',
+    ]);
+
+    $this->get('https://harbourkind.community-kind.test/.well-known/security.txt')
+        ->assertOk()
+        ->assertHeader('Content-Type', 'text/plain; charset=UTF-8')
+        ->assertSee('Contact: https://github.com/datashaman/community-kind/security/advisories/new', false)
+        ->assertSee('Expires: 2027-08-30T00:00:00Z', false)
+        ->assertSee('Canonical: https://harbourkind.community-kind.test/.well-known/security.txt', false)
+        ->assertSee('Policy: https://harbourkind.community-kind.test/security-policy', false)
+        ->assertDontSee('Do not expose this tenant', false);
+});
 
 it('publishes the coordinated vulnerability-reporting policy', function () {
     $this->get('/security-policy')


### PR DESCRIPTION
## Summary

- resolve active Organisations exclusively from validated canonical platform subdomains
- reject untrusted, reserved, malformed, lifecycle-restricted, and Access Hold-restricted hosts without staff-session fallback
- serve a tenant-branded public home plus host-correct security discovery, with quarantined-slug redirects to canonical hosts
- enforce DNS-valid unique slug generation and document Laravel Valet wildcard subdomains for local development

## Verification

- `composer validate --strict`
- `composer ci:check` (252 tests, 998 assertions)
- `npm test`
- `npm run build`
- `npm run licenses:check`
- `composer audit --locked --no-dev`
- `npm audit --omit=dev --audit-level=high`
- `php artisan route:cache`
- live Valet checks for the central host and unknown tenant/staff paths

Closes #6