### PR TITLE
Seed deterministic HarbourKind and NeighbourLink scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,41 @@ php artisan key:generate
 php artisan migrate
 ```
 
+The deterministic demo scenarios contain encrypted synthetic contact details.
+Generate two independent 32-byte keys, then add them to `.env` under distinct
+local key versions:
+
+```bash
+php -r 'echo "base64:".base64_encode(random_bytes(32)).PHP_EOL;'
+php -r 'echo "base64:".base64_encode(random_bytes(32)).PHP_EOL;'
+```
+
+```dotenv
+CLASSIFIED_DATA_KEY_CURRENT=local-data-v1
+CLASSIFIED_DATA_KEYS='{"local-data-v1":"paste-the-first-generated-value-here"}'
+CONTACT_INDEX_KEY_CURRENT=local-index-v1
+CONTACT_INDEX_KEYS='{"local-index-v1":"paste-the-second-generated-value-here"}'
+```
+
+Clear cached configuration and seed the fictional HarbourKind and
+NeighbourLink organisations:
+
+```bash
+php artisan config:clear
+php artisan db:seed
+```
+
+Scenario catalog version `2026.1` uses the fixed reporting instant
+`2026-06-30 23:59:59` in each Organisation's local timezone: HarbourKind uses
+`Africa/Johannesburg` and ZAR, while NeighbourLink uses `Europe/London` and
+GBP. It can be seeded repeatedly without duplicating its records. All demo
+users use the password `password`; useful starting accounts are:
+
+- `admin@harbourkind.example.test` for HarbourKind administration
+- `admin@neighbourlink.example.test` for NeighbourLink administration
+- `switcher@community-kind.example.test` for an account belonging to both
+  organisations
+
 Link and secure the project with Valet. Valet routes the linked site's wildcard
 subdomains to the same Laravel application, so tenant hosts do not need separate
 local registrations:

--- a/app/Actions/Demo/BuildOrganisationScenario.php
+++ b/app/Actions/Demo/BuildOrganisationScenario.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace App\Actions\Demo;
+
+use App\Actions\Parties\StorePartyContact;
+use App\Data\Demo\ScenarioCatalog;
+use App\Enums\OrganisationRole;
+use App\Enums\OrganisationStatus;
+use App\Enums\PartyContactType;
+use App\Enums\PartyKind;
+use App\Models\Membership;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\PartyContactPoint;
+use App\Models\Program;
+use App\Models\RoleAssignment;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * @phpstan-type ProgramDefinition array{name: string, slug: string}
+ * @phpstan-type MemberDefinition array{party_uuid: string, name: string, email: string, telephone: string, owner: bool, role: OrganisationRole|null, program_slugs: list<string>}
+ * @phpstan-type PartyDefinition array{uuid: string, kind: PartyKind, name: string, email?: string, telephone?: string}
+ * @phpstan-type ScenarioDefinition array{uuid: string, name: string, slug: string, timezone: string, currency: string, reporting_at: string, synthetic: true, party_population: array<string, int>, programs: list<ProgramDefinition>, members: list<MemberDefinition>, parties: list<PartyDefinition>}
+ */
+final class BuildOrganisationScenario
+{
+    public function __construct(
+        private readonly OrganisationContext $organisationContext,
+        private readonly StorePartyContact $storePartyContact,
+    ) {}
+
+    /** @param ScenarioDefinition $scenario */
+    public function handle(array $scenario): Organisation
+    {
+        return DB::transaction(function () use ($scenario): Organisation {
+            $organisation = Organisation::withTrashed()->firstOrNew(['uuid' => $scenario['uuid']]);
+
+            if ($organisation->exists && ($organisation->trashed() || $organisation->status !== OrganisationStatus::Active)) {
+                throw new LogicException("The {$scenario['name']} demo Organisation is not active and cannot be reseeded safely.");
+            }
+
+            $attributes = [
+                'uuid' => $scenario['uuid'],
+                'name' => $scenario['name'],
+                'slug' => $scenario['slug'],
+            ];
+
+            if (! $organisation->exists) {
+                $attributes += [
+                    'status' => OrganisationStatus::Active,
+                    'status_changed_at' => $scenario['reporting_at'],
+                    'access_version' => 1,
+                ];
+            }
+
+            $organisation->forceFill($attributes)->save();
+
+            $this->organisationContext->run($organisation, function () use ($organisation, $scenario): void {
+                $programs = $this->upsertPrograms($organisation, $scenario['programs']);
+
+                foreach ($scenario['members'] as $member) {
+                    $this->upsertMember($organisation, $member, $programs);
+                }
+
+                foreach ($scenario['parties'] as $identity) {
+                    $this->upsertParty($organisation, $identity);
+                }
+
+                $this->upsertPartyPopulation($organisation, $scenario);
+            });
+
+            return $organisation;
+        });
+    }
+
+    /**
+     * @param  list<array{name: string, slug: string}>  $programDefinitions
+     * @return Collection<string, Program>
+     */
+    private function upsertPrograms(Organisation $organisation, array $programDefinitions): Collection
+    {
+        return collect($programDefinitions)->mapWithKeys(function (array $definition) use ($organisation): array {
+            $program = Program::withTrashed()->firstOrNew([
+                'organisation_id' => $organisation->id,
+                'slug' => $definition['slug'],
+            ]);
+            $program->forceFill([
+                'organisation_id' => $organisation->id,
+                'name' => $definition['name'],
+                'slug' => $definition['slug'],
+                'deleted_at' => null,
+            ])->save();
+
+            return [$program->slug => $program];
+        });
+    }
+
+    /**
+     * @param  array{party_uuid: string, name: string, email: string, telephone: string, owner: bool, role: OrganisationRole|null, program_slugs: list<string>}  $member
+     * @param  Collection<string, Program>  $programs
+     */
+    private function upsertMember(Organisation $organisation, array $member, Collection $programs): void
+    {
+        $user = User::query()->firstOrNew(['email' => $member['email']]);
+        $user->fill([
+            'name' => $member['name'],
+            'password' => ScenarioCatalog::PASSWORD,
+        ])->forceFill(['email_verified_at' => now()])->save();
+        $party = $this->upsertParty($organisation, [
+            'uuid' => $member['party_uuid'],
+            'kind' => PartyKind::Person,
+            'name' => $member['name'],
+            'email' => $member['email'],
+            'telephone' => $member['telephone'],
+        ]);
+        $membership = Membership::query()->updateOrCreate(
+            ['organisation_id' => $organisation->id, 'user_id' => $user->id],
+            [
+                'person_party_id' => $party->id,
+                'is_owner' => $member['owner'],
+                'accepted_at' => now(),
+                'ended_at' => null,
+            ],
+        );
+
+        if ($member['role'] !== null) {
+            RoleAssignment::query()->updateOrCreate(
+                [
+                    'organisation_id' => $organisation->id,
+                    'membership_id' => $membership->id,
+                    'role' => $member['role']->value,
+                    'program_id' => null,
+                ],
+                ['ended_at' => null],
+            );
+        }
+
+        $membership->programs()->sync($programs->only($member['program_slugs'])->pluck('id')->all());
+
+        if ($user->current_organisation_id === null) {
+            $user->update(['current_organisation_id' => $organisation->id]);
+        }
+    }
+
+    /** @param array{uuid: string, kind: PartyKind, name: string, email?: string, telephone?: string} $identity */
+    private function upsertParty(Organisation $organisation, array $identity): Party
+    {
+        $party = Party::withTrashed()->firstOrNew(['uuid' => $identity['uuid']]);
+        $party->forceFill([
+            'uuid' => $identity['uuid'],
+            'organisation_id' => $organisation->id,
+            'kind' => $identity['kind'],
+            'display_name' => $identity['name'],
+            'deleted_at' => null,
+        ])->save();
+
+        $this->upsertContact($party, PartyContactType::Email, $identity['email'] ?? null);
+        $this->upsertContact($party, PartyContactType::Telephone, $identity['telephone'] ?? null);
+
+        return $party;
+    }
+
+    private function upsertContact(Party $party, PartyContactType $type, ?string $value): void
+    {
+        if ($value === null) {
+            return;
+        }
+
+        $contact = PartyContactPoint::query()
+            ->where('party_id', $party->id)
+            ->where('type', $type)
+            ->first();
+
+        if ($contact !== null && $contact->encrypted_value->reveal() === $value) {
+            return;
+        }
+
+        $contact?->delete();
+        $this->storePartyContact->handle($party, $type, $value);
+    }
+
+    /** @param ScenarioDefinition $scenario */
+    private function upsertPartyPopulation(Organisation $organisation, array $scenario): void
+    {
+        $namedKinds = [PartyKind::Person->value => count($scenario['members'])];
+
+        foreach ($scenario['parties'] as $party) {
+            $namedKinds[$party['kind']->value] = ($namedKinds[$party['kind']->value] ?? 0) + 1;
+        }
+
+        foreach ($scenario['party_population'] as $kind => $targetCount) {
+            $generatedCount = $targetCount - ($namedKinds[$kind] ?? 0);
+            $rows = [];
+
+            for ($index = 1; $index <= $generatedCount; $index++) {
+                $rows[] = [
+                    'uuid' => Uuid::uuid5($organisation->uuid, "scenario-party:{$kind}:{$index}")->toString(),
+                    'organisation_id' => $organisation->id,
+                    'kind' => $kind,
+                    'display_name' => sprintf('Synthetic %s %s %04d', $organisation->name, ucfirst($kind), $index),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                    'deleted_at' => null,
+                ];
+            }
+
+            foreach (array_chunk($rows, 500) as $chunk) {
+                Party::query()->upsert(
+                    $chunk,
+                    ['uuid'],
+                    ['organisation_id', 'kind', 'display_name', 'updated_at', 'deleted_at'],
+                );
+            }
+        }
+    }
+}

--- a/app/Data/Demo/ScenarioCatalog.php
+++ b/app/Data/Demo/ScenarioCatalog.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Data\Demo;
+
+use App\Enums\OrganisationRole;
+use App\Enums\PartyKind;
+use InvalidArgumentException;
+
+final class ScenarioCatalog
+{
+    public const VERSION = '2026.1';
+
+    public const AS_OF = '2026-06-30 23:59:59';
+
+    public const PASSWORD = 'password';
+
+    /** @return array<string, array{uuid: string, organisation_slug: string, synthetic: true}> */
+    public static function showcases(): array
+    {
+        return [
+            'request-to-outcome' => self::showcase('30000000-0000-4000-8000-000000000001', 'harbourkind'),
+            'donor-to-retained-supporter' => self::showcase('30000000-0000-4000-8000-000000000002', 'harbourkind'),
+            'contribution-to-impact' => self::showcase('30000000-0000-4000-8000-000000000003', 'harbourkind'),
+            'privacy-and-tenant-boundary' => self::showcase('30000000-0000-4000-8000-000000000004', 'neighbourlink'),
+        ];
+    }
+
+    /**
+     * @return list<array{
+     *     uuid: string, name: string, slug: string, timezone: string, currency: string, reporting_at: string, synthetic: true,
+     *     party_population: array<string, int>,
+     *     programs: list<array{name: string, slug: string}>,
+     *     members: list<array{party_uuid: string, name: string, email: string, telephone: string, owner: bool, role: OrganisationRole|null, program_slugs: list<string>}>,
+     *     parties: list<array{uuid: string, kind: PartyKind, name: string, email?: string, telephone?: string}>
+     * }>
+     */
+    public static function organisations(): array
+    {
+        $organisations = [
+            [
+                'uuid' => '10000000-0000-4000-8000-000000000001',
+                'name' => 'HarbourKind',
+                'slug' => 'harbourkind',
+                'timezone' => 'Africa/Johannesburg',
+                'currency' => 'ZAR',
+                'reporting_at' => '2026-06-30T23:59:59+02:00',
+                'synthetic' => true,
+                'party_population' => [
+                    PartyKind::Person->value => 1750,
+                    PartyKind::Organisation->value => 150,
+                    PartyKind::Household->value => 100,
+                ],
+                'programs' => [
+                    ['name' => 'Community Drop-in and Material Relief', 'slug' => 'community-drop-in'],
+                    ['name' => 'Housing and Homelessness Support', 'slug' => 'housing-support'],
+                    ['name' => 'Newcomer Settlement', 'slug' => 'newcomer-settlement'],
+                ],
+                'members' => [
+                    self::member('11000000-0000-4000-8000-000000000001', 'HarbourKind Demo Administrator', 'admin@harbourkind.example.test', '+1 202-555-0101', true, OrganisationRole::OrganisationAdministrator),
+                    self::member('11000000-0000-4000-8000-000000000002', 'HarbourKind Demo Programme Manager', 'manager@harbourkind.example.test', '+1 202-555-0102', false, OrganisationRole::ProgramManager, ['housing-support']),
+                    self::member('11000000-0000-4000-8000-000000000003', 'HarbourKind Demo Case Worker', 'caseworker@harbourkind.example.test', '+1 202-555-0103', false, OrganisationRole::CaseWorker, ['housing-support', 'newcomer-settlement']),
+                    self::member('11000000-0000-4000-8000-000000000004', 'HarbourKind Demo Engagement Officer', 'engagement@harbourkind.example.test', '+1 202-555-0104', false, OrganisationRole::EngagementOfficer, ['community-drop-in']),
+                    self::member('11000000-0000-4000-8000-000000000005', 'CommunityKind Demo Organisation Switcher', 'switcher@community-kind.example.test', '+1 202-555-0105', false, OrganisationRole::ExecutiveViewer),
+                    self::member('11000000-0000-4000-8000-000000000006', 'HarbourKind Demo Governance Owner', 'owner@harbourkind.example.test', '+1 202-555-0106', true),
+                    self::member('11000000-0000-4000-8000-000000000007', 'HarbourKind Demo Executive Viewer', 'executive@harbourkind.example.test', '+1 202-555-0107', false, OrganisationRole::ExecutiveViewer),
+                    self::member('11000000-0000-4000-8000-000000000008', 'HarbourKind Demo Outreach Worker', 'outreach@harbourkind.example.test', '+1 202-555-0108', false, OrganisationRole::CaseWorker, ['community-drop-in']),
+                    self::member('11000000-0000-4000-8000-000000000009', 'HarbourKind Demo Settlement Manager', 'settlement.manager@harbourkind.example.test', '+1 202-555-0109', false, OrganisationRole::ProgramManager, ['newcomer-settlement']),
+                ],
+                'parties' => [
+                    self::party('12000000-0000-4000-8000-000000000001', PartyKind::Person, 'Synthetic Client Amina Example', 'amina.client@harbourkind.example.test', '+1 202-555-0111'),
+                    self::party('12000000-0000-4000-8000-000000000002', PartyKind::Person, 'Synthetic Donor Rowan Example', 'rowan.donor@harbourkind.example.test', '+1 202-555-0112'),
+                    self::party('12000000-0000-4000-8000-000000000003', PartyKind::Household, 'Synthetic Hart Household'),
+                    self::party('12000000-0000-4000-8000-000000000004', PartyKind::Organisation, 'Synthetic Brightwell Community Fund', 'contact@brightwell.example.test', '+1 202-555-0113'),
+                ],
+            ],
+            [
+                'uuid' => '20000000-0000-4000-8000-000000000001',
+                'name' => 'NeighbourLink',
+                'slug' => 'neighbourlink',
+                'timezone' => 'Europe/London',
+                'currency' => 'GBP',
+                'reporting_at' => '2026-06-30T23:59:59+01:00',
+                'synthetic' => true,
+                'party_population' => [
+                    PartyKind::Person->value => 30,
+                ],
+                'programs' => [
+                    ['name' => 'Neighbour Support Network', 'slug' => 'neighbour-support'],
+                ],
+                'members' => [
+                    self::member('21000000-0000-4000-8000-000000000001', 'NeighbourLink Demo Administrator', 'admin@neighbourlink.example.test', '+1 202-555-0121', true, OrganisationRole::OrganisationAdministrator),
+                    self::member('21000000-0000-4000-8000-000000000002', 'CommunityKind Demo Organisation Switcher', 'switcher@community-kind.example.test', '+1 202-555-0105', false, OrganisationRole::ExecutiveViewer),
+                    self::member('21000000-0000-4000-8000-000000000003', 'NeighbourLink Demo Governance Owner', 'owner@neighbourlink.example.test', '+1 202-555-0122', true),
+                ],
+                'parties' => [
+                    self::party('22000000-0000-4000-8000-000000000001', PartyKind::Person, 'Synthetic Resident Noor Example', 'noor.resident@neighbourlink.example.test', '+1 202-555-0123'),
+                ],
+            ],
+        ];
+
+        self::assertSafe($organisations);
+
+        return $organisations;
+    }
+
+    /** @param list<array<string, mixed>> $organisations */
+    private static function assertSafe(array $organisations): void
+    {
+        foreach ($organisations as $organisation) {
+            if (($organisation['synthetic'] ?? false) !== true) {
+                throw new InvalidArgumentException('Every demo organisation must be marked synthetic.');
+            }
+
+            foreach ([...$organisation['members'], ...$organisation['parties']] as $identity) {
+                if (isset($identity['email']) && ! str_ends_with($identity['email'], '.example.test')) {
+                    throw new InvalidArgumentException('Demo email addresses must use the reserved .example.test suffix.');
+                }
+
+                if (isset($identity['telephone']) && ! str_starts_with($identity['telephone'], '+1 202-555-01')) {
+                    throw new InvalidArgumentException('Demo telephone numbers must use the fictional 202-555-01xx range.');
+                }
+            }
+        }
+    }
+
+    /**
+     * @param  list<string>  $programSlugs
+     * @return array{party_uuid: string, name: string, email: string, telephone: string, owner: bool, role: OrganisationRole|null, program_slugs: list<string>}
+     */
+    private static function member(string $partyUuid, string $name, string $email, string $telephone, bool $owner, ?OrganisationRole $role = null, array $programSlugs = []): array
+    {
+        return compact('name', 'email', 'telephone', 'owner', 'role') + [
+            'party_uuid' => $partyUuid,
+            'program_slugs' => $programSlugs,
+        ];
+    }
+
+    /** @return array{uuid: string, kind: PartyKind, name: string, email?: string, telephone?: string} */
+    private static function party(string $uuid, PartyKind $kind, string $name, ?string $email = null, ?string $telephone = null): array
+    {
+        return array_filter(compact('uuid', 'kind', 'name', 'email', 'telephone'), fn (mixed $value): bool => $value !== null);
+    }
+
+    /** @return array{uuid: string, organisation_slug: string, synthetic: true} */
+    private static function showcase(string $uuid, string $organisationSlug): array
+    {
+        return ['uuid' => $uuid, 'organisation_slug' => $organisationSlug, 'synthetic' => true];
+    }
+}

--- a/database/seeders/CommunityKindScenarioSeeder.php
+++ b/database/seeders/CommunityKindScenarioSeeder.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Actions\Demo\BuildOrganisationScenario;
+use App\Data\Demo\ScenarioCatalog;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Date;
+use LogicException;
+
+class CommunityKindScenarioSeeder extends Seeder
+{
+    public function run(BuildOrganisationScenario $buildOrganisationScenario): void
+    {
+        if (app()->isProduction()) {
+            throw new LogicException('Synthetic demo scenarios cannot be seeded in production.');
+        }
+
+        try {
+            foreach (ScenarioCatalog::organisations() as $scenario) {
+                Date::setTestNow($scenario['reporting_at']);
+                $buildOrganisationScenario->handle($scenario);
+            }
+        } finally {
+            Date::setTestNow();
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,24 +2,15 @@
 
 namespace Database\Seeders;
 
-use App\Models\User;
-use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
 {
-    use WithoutModelEvents;
-
     /**
      * Seed the application's database.
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        $this->call(CommunityKindScenarioSeeder::class);
     }
 }

--- a/tests/Feature/CommunityKindScenarioSeederTest.php
+++ b/tests/Feature/CommunityKindScenarioSeederTest.php
@@ -1,0 +1,209 @@
+<?php
+
+use App\Actions\Demo\BuildOrganisationScenario;
+use App\Actions\Programs\BuildProgramReport;
+use App\Actions\Programs\SearchPrograms;
+use App\Data\Demo\ScenarioCatalog;
+use App\Enums\OrganisationStatus;
+use App\Models\Membership;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\PartyContactPoint;
+use App\Models\Program;
+use App\Models\RoleAssignment;
+use App\Models\User;
+use App\OrganisationCache;
+use App\OrganisationContext;
+use App\OrganisationStorage;
+use Database\Seeders\CommunityKindScenarioSeeder;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    $key = 'base64:'.base64_encode(str_repeat('d', 32));
+
+    config([
+        'classified_data.encryption.current_version' => 'scenario-data-v1',
+        'classified_data.encryption.keys' => ['scenario-data-v1' => $key],
+        'classified_data.contact_index.current_version' => 'scenario-index-v1',
+        'classified_data.contact_index.previous_version' => null,
+        'classified_data.contact_index.keys' => ['scenario-index-v1' => $key],
+        'cache.default' => 'array',
+    ]);
+});
+
+it('seeds the versioned synthetic scenarios deterministically', function () {
+    $this->seed(CommunityKindScenarioSeeder::class);
+
+    $contactIds = PartyContactPoint::withoutGlobalScopes()->orderBy('id')->pluck('id')->all();
+    $partyIds = Party::withoutGlobalScopes()->orderBy('uuid')->pluck('id', 'uuid')->all();
+    $harbourKindId = Organisation::query()->where('slug', 'harbourkind')->valueOrFail('id');
+    $neighbourLinkId = Organisation::query()->where('slug', 'neighbourlink')->valueOrFail('id');
+    $harbourKindPartyCounts = DB::table('parties')
+        ->where('organisation_id', $harbourKindId)
+        ->selectRaw('kind, count(*) as aggregate')
+        ->groupBy('kind')
+        ->pluck('aggregate', 'kind')
+        ->map(fn (int|string $count): int => (int) $count)
+        ->all();
+    $neighbourLinkPartyCounts = DB::table('parties')
+        ->where('organisation_id', $neighbourLinkId)
+        ->selectRaw('kind, count(*) as aggregate')
+        ->groupBy('kind')
+        ->pluck('aggregate', 'kind')
+        ->map(fn (int|string $count): int => (int) $count)
+        ->all();
+
+    expect(ScenarioCatalog::VERSION)->toBe('2026.1')
+        ->and(ScenarioCatalog::AS_OF)->toBe('2026-06-30 23:59:59')
+        ->and(Date::getTestNow())->toBeNull()
+        ->and(Organisation::query()->count())->toBe(2)
+        ->and(User::query()->count())->toBe(11)
+        ->and(Membership::withoutGlobalScopes()->count())->toBe(12)
+        ->and(Party::withoutGlobalScopes()->count())->toBe(2030)
+        ->and(PartyContactPoint::withoutGlobalScopes()->count())->toBe(32)
+        ->and(Program::withoutGlobalScopes()->count())->toBe(4)
+        ->and(RoleAssignment::withoutGlobalScopes()->count())->toBe(10)
+        ->and(DB::table('membership_program')->count())->toBe(6)
+        ->and(Membership::withoutGlobalScopes()->where('organisation_id', $harbourKindId)->count())->toBe(9)
+        ->and(Membership::withoutGlobalScopes()->where('organisation_id', $neighbourLinkId)->count())->toBe(3)
+        ->and($harbourKindPartyCounts)->toBe(['household' => 100, 'organisation' => 150, 'person' => 1750])
+        ->and($neighbourLinkPartyCounts)->toBe(['person' => 30])
+        ->and(Organisation::query()->where('slug', 'harbourkind')->value('uuid'))->toBe('10000000-0000-4000-8000-000000000001')
+        ->and(Organisation::query()->where('slug', 'neighbourlink')->value('uuid'))->toBe('20000000-0000-4000-8000-000000000001')
+        ->and(User::query()->where('email', 'switcher@community-kind.example.test')->value('name'))->toBe('CommunityKind Demo Organisation Switcher');
+
+    $this->seed(CommunityKindScenarioSeeder::class);
+
+    expect(Organisation::query()->count())->toBe(2)
+        ->and(User::query()->count())->toBe(11)
+        ->and(Membership::withoutGlobalScopes()->count())->toBe(12)
+        ->and(Party::withoutGlobalScopes()->count())->toBe(2030)
+        ->and(PartyContactPoint::withoutGlobalScopes()->orderBy('id')->pluck('id')->all())->toBe($contactIds)
+        ->and(Party::withoutGlobalScopes()->orderBy('uuid')->pluck('id', 'uuid')->all())->toBe($partyIds);
+});
+
+it('keeps every scenario identity and reserved showcase explicitly synthetic', function () {
+    $organisations = ScenarioCatalog::organisations();
+    $identities = collect($organisations)->flatMap(fn (array $organisation): array => [
+        ...$organisation['members'],
+        ...$organisation['parties'],
+    ]);
+
+    expect(collect($organisations)->every(fn (array $organisation): bool => $organisation['synthetic']))->toBeTrue()
+        ->and($organisations[0]['timezone'])->toBe('Africa/Johannesburg')
+        ->and($organisations[0]['currency'])->toBe('ZAR')
+        ->and($organisations[0]['reporting_at'])->toBe('2026-06-30T23:59:59+02:00')
+        ->and(array_sum($organisations[0]['party_population']))->toBe(2000)
+        ->and($organisations[1]['timezone'])->toBe('Europe/London')
+        ->and($organisations[1]['currency'])->toBe('GBP')
+        ->and($organisations[1]['reporting_at'])->toBe('2026-06-30T23:59:59+01:00')
+        ->and(array_sum($organisations[1]['party_population']))->toBe(30)
+        ->and(ScenarioCatalog::showcases())->toHaveCount(4)
+        ->and(collect(ScenarioCatalog::showcases())->pluck('uuid')->unique())->toHaveCount(4)
+        ->and(collect(ScenarioCatalog::showcases())->every(fn (array $showcase): bool => $showcase['synthetic']))->toBeTrue()
+        ->and($identities->whereNotNull('email')->every(fn (array $identity): bool => str_ends_with($identity['email'], '.example.test')))->toBeTrue()
+        ->and($identities->whereNotNull('telephone')->every(fn (array $identity): bool => str_starts_with($identity['telephone'], '+1 202-555-01')))->toBeTrue();
+});
+
+it('reconciles tenant relationships and isolates search files cache and aggregates', function () {
+    Storage::fake();
+    Cache::flush();
+    $this->seed(CommunityKindScenarioSeeder::class);
+
+    $harbourKind = Organisation::query()->where('slug', 'harbourkind')->firstOrFail();
+    $neighbourLink = Organisation::query()->where('slug', 'neighbourlink')->firstOrFail();
+    $context = app(OrganisationContext::class);
+    $storage = app(OrganisationStorage::class);
+    $cache = app(OrganisationCache::class);
+
+    $harbour = $context->run($harbourKind, function () use ($storage, $cache): array {
+        $path = $storage->put('scenario-proof.txt', 'HarbourKind synthetic proof');
+        $report = app(BuildProgramReport::class)->handle();
+
+        return [
+            'report' => $report,
+            'other_search_count' => app(SearchPrograms::class)->handle('Neighbour Support Network')->count(),
+            'path' => $path,
+            'cache_key' => $cache->key('scenario-proof'),
+            'cached' => $cache->remember('scenario-proof', 60, fn (): string => 'HarbourKind synthetic cache'),
+        ];
+    });
+    $neighbour = $context->run($neighbourLink, function () use ($storage, $cache): array {
+        $path = $storage->put('scenario-proof.txt', 'NeighbourLink synthetic proof');
+        $report = app(BuildProgramReport::class)->handle();
+
+        return [
+            'report' => $report,
+            'other_search_count' => app(SearchPrograms::class)->handle('Housing and Homelessness Support')->count(),
+            'path' => $path,
+            'cache_key' => $cache->key('scenario-proof'),
+            'cached' => $cache->remember('scenario-proof', 60, fn (): string => 'NeighbourLink synthetic cache'),
+        ];
+    });
+
+    expect($harbour['report']['program_count'])->toBe(3)
+        ->and($neighbour['report']['program_count'])->toBe(1)
+        ->and($harbour['report']['program_names'])->not->toContain('Neighbour Support Network')
+        ->and($neighbour['report']['program_names'])->not->toContain('Housing and Homelessness Support')
+        ->and($harbour['other_search_count'])->toBe(0)
+        ->and($neighbour['other_search_count'])->toBe(0)
+        ->and($harbour['path'])->not->toBe($neighbour['path'])
+        ->and($harbour['cache_key'])->not->toBe($neighbour['cache_key'])
+        ->and($harbour['cached'])->toBe('HarbourKind synthetic cache')
+        ->and($neighbour['cached'])->toBe('NeighbourLink synthetic cache')
+        ->and(Storage::get($harbour['path']))->toBe('HarbourKind synthetic proof')
+        ->and(Storage::get($neighbour['path']))->toBe('NeighbourLink synthetic proof')
+        ->and(DB::table('organisation_members as memberships')
+            ->join('parties', 'parties.id', '=', 'memberships.person_party_id')
+            ->whereColumn('memberships.organisation_id', '!=', 'parties.organisation_id')
+            ->count())->toBe(0)
+        ->and(DB::table('role_assignments as roles')
+            ->join('organisation_members as memberships', 'memberships.id', '=', 'roles.membership_id')
+            ->whereColumn('roles.organisation_id', '!=', 'memberships.organisation_id')
+            ->count())->toBe(0)
+        ->and(DB::table('membership_program as access')
+            ->join('programs', 'programs.id', '=', 'access.program_id')
+            ->whereColumn('access.organisation_id', '!=', 'programs.organisation_id')
+            ->count())->toBe(0);
+});
+
+it('stores scenario contacts as classified ciphertext', function () {
+    $this->seed(CommunityKindScenarioSeeder::class);
+
+    $ciphertexts = DB::table('party_contact_points')->pluck('encrypted_value');
+
+    expect($ciphertexts)->toHaveCount(32)
+        ->and($ciphertexts->every(fn (string $ciphertext): bool => ! str_contains($ciphertext, '@') && ! str_contains($ciphertext, '555')))->toBeTrue();
+});
+
+it('refuses to install the synthetic scenarios in production', function () {
+    $environment = app()->environment();
+    app()->detectEnvironment(fn (): string => 'production');
+
+    try {
+        expect(fn () => app(CommunityKindScenarioSeeder::class)->run(app(BuildOrganisationScenario::class)))
+            ->toThrow(LogicException::class, 'Synthetic demo scenarios cannot be seeded in production.');
+    } finally {
+        app()->detectEnvironment(fn (): string => $environment);
+    }
+});
+
+it('does not reactivate an archived scenario organisation while reseeding', function () {
+    Organisation::factory()->create([
+        'uuid' => '10000000-0000-4000-8000-000000000001',
+        'name' => 'HarbourKind',
+        'slug' => 'harbourkind',
+        'status' => OrganisationStatus::Archived,
+        'access_version' => 4,
+    ]);
+
+    expect(fn () => $this->seed(CommunityKindScenarioSeeder::class))
+        ->toThrow(LogicException::class, 'The HarbourKind demo Organisation is not active and cannot be reseeded safely.');
+
+    expect(Organisation::query()->where('slug', 'harbourkind')->firstOrFail())
+        ->status->toBe(OrganisationStatus::Archived)
+        ->access_version->toBe(4);
+});


### PR DESCRIPTION
## Summary

- add a pinned synthetic scenario catalog for HarbourKind and NeighbourLink with fixed showcase UUIDs and reporting date
- seed encrypted contacts, programmes, memberships, role assignments, and cross-organisation switcher access idempotently
- document local encryption-key setup and demo credentials
- reconcile scenario counts and prove relationship, search, file, cache, and aggregate isolation
- refuse production seeding and fail closed for archived/deleted scenario organisations

## Verification

- `composer ci:check` (258 tests, 1,047 assertions)
- `npm test`
- `npm run build`
- repeated `php artisan db:seed --no-interaction` against local PostgreSQL
- verified `https://harbourkind.community-kind.test/` and `https://neighbourlink.community-kind.test/` through Valet

Closes #9