### PR TITLE
Issue #10: configure programs and maintain Party profiles

### DIFF
--- a/app/Actions/Demo/BuildOrganisationScenario.php
+++ b/app/Actions/Demo/BuildOrganisationScenario.php
@@ -6,25 +6,29 @@ use App\Actions\Parties\StorePartyContact;
 use App\Data\Demo\ScenarioCatalog;
 use App\Enums\OrganisationRole;
 use App\Enums\OrganisationStatus;
+use App\Enums\PartyBusinessRole;
 use App\Enums\PartyContactType;
 use App\Enums\PartyKind;
 use App\Models\Membership;
 use App\Models\Organisation;
 use App\Models\Party;
 use App\Models\PartyContactPoint;
+use App\Models\PartyInterest;
+use App\Models\PartyRole;
 use App\Models\Program;
 use App\Models\RoleAssignment;
 use App\Models\User;
 use App\OrganisationContext;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use LogicException;
 use Ramsey\Uuid\Uuid;
 
 /**
- * @phpstan-type ProgramDefinition array{name: string, slug: string}
+ * @phpstan-type ProgramDefinition array{name: string, slug: string, configuration: array<string, mixed>}
  * @phpstan-type MemberDefinition array{party_uuid: string, name: string, email: string, telephone: string, owner: bool, role: OrganisationRole|null, program_slugs: list<string>}
- * @phpstan-type PartyDefinition array{uuid: string, kind: PartyKind, name: string, email?: string, telephone?: string}
+ * @phpstan-type PartyDefinition array{uuid: string, kind: PartyKind, name: string, email?: string, telephone?: string, program_slugs?: list<string>, roles?: list<PartyBusinessRole>, interests?: list<string>}
  * @phpstan-type ScenarioDefinition array{uuid: string, name: string, slug: string, timezone: string, currency: string, reporting_at: string, synthetic: true, party_population: array<string, int>, programs: list<ProgramDefinition>, members: list<MemberDefinition>, parties: list<PartyDefinition>}
  */
 final class BuildOrganisationScenario
@@ -68,7 +72,8 @@ final class BuildOrganisationScenario
                 }
 
                 foreach ($scenario['parties'] as $identity) {
-                    $this->upsertParty($organisation, $identity);
+                    $party = $this->upsertParty($organisation, $identity);
+                    $this->upsertPartyProfile($party, $identity, $programs);
                 }
 
                 $this->upsertPartyPopulation($organisation, $scenario);
@@ -79,7 +84,7 @@ final class BuildOrganisationScenario
     }
 
     /**
-     * @param  list<array{name: string, slug: string}>  $programDefinitions
+     * @param  list<ProgramDefinition>  $programDefinitions
      * @return Collection<string, Program>
      */
     private function upsertPrograms(Organisation $organisation, array $programDefinitions): Collection
@@ -93,6 +98,7 @@ final class BuildOrganisationScenario
                 'organisation_id' => $organisation->id,
                 'name' => $definition['name'],
                 'slug' => $definition['slug'],
+                'configuration' => $definition['configuration'],
                 'deleted_at' => null,
             ])->save();
 
@@ -182,6 +188,34 @@ final class BuildOrganisationScenario
 
         $contact?->delete();
         $this->storePartyContact->handle($party, $type, $value);
+    }
+
+    /**
+     * @param  PartyDefinition  $identity
+     * @param  Collection<string, Program>  $programs
+     */
+    private function upsertPartyProfile(Party $party, array $identity, Collection $programs): void
+    {
+        $party->programs()->sync($programs->only($identity['program_slugs'] ?? [])->pluck('id')->all());
+
+        PartyRole::query()->where('party_id', $party->id)->delete();
+        foreach ($identity['roles'] ?? [] as $role) {
+            PartyRole::query()->create([
+                'organisation_id' => $party->organisation_id,
+                'party_id' => $party->id,
+                'role' => $role,
+            ]);
+        }
+
+        PartyInterest::query()->where('party_id', $party->id)->delete();
+        foreach ($identity['interests'] ?? [] as $interest) {
+            PartyInterest::query()->create([
+                'organisation_id' => $party->organisation_id,
+                'party_id' => $party->id,
+                'slug' => Str::slug($interest),
+                'label' => $interest,
+            ]);
+        }
     }
 
     /** @param ScenarioDefinition $scenario */

--- a/app/Actions/Parties/CreatePartyProfile.php
+++ b/app/Actions/Parties/CreatePartyProfile.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Actions\Parties;
+
+use App\Enums\PartyBusinessRole;
+use App\Enums\PartyKind;
+use App\Enums\PartyTimelineEventType;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+final class CreatePartyProfile
+{
+    public function __construct(
+        private readonly OrganisationContext $organisationContext,
+        private readonly SyncPartyContacts $syncPartyContacts,
+        private readonly RecordPartyTimelineEvent $recordTimelineEvent,
+    ) {}
+
+    /**
+     * @param  array{kind: PartyKind, display_name: string, email: string|null, telephone: string|null, program_ids: list<int>, roles: list<PartyBusinessRole>, interests: list<string>}  $attributes
+     */
+    public function handle(Organisation $organisation, array $attributes, User $actor): Party
+    {
+        $this->organisationContext->ensureOwns($organisation->id);
+
+        return DB::transaction(function () use ($organisation, $attributes, $actor): Party {
+            $party = Party::query()->create([
+                'organisation_id' => $organisation->id,
+                'kind' => $attributes['kind'],
+                'display_name' => $attributes['display_name'],
+            ]);
+
+            $party->programs()->sync($attributes['program_ids']);
+            $party->businessRoles()->createMany(collect($attributes['roles'])
+                ->map(fn (PartyBusinessRole $role): array => [
+                    'organisation_id' => $organisation->id,
+                    'role' => $role,
+                ])->all());
+            $party->interests()->createMany(collect($attributes['interests'])
+                ->map(fn (string $interest): array => [
+                    'organisation_id' => $organisation->id,
+                    'slug' => Str::slug($interest),
+                    'label' => $interest,
+                ])->all());
+            $this->syncPartyContacts->handle($party, [
+                'email' => $attributes['email'],
+                'telephone' => $attributes['telephone'],
+            ]);
+            $this->recordTimelineEvent->handle(
+                $party,
+                PartyTimelineEventType::ProfileCreated,
+                'Profile created',
+                $actor,
+                'party',
+                $party->uuid,
+            );
+
+            return $party;
+        });
+    }
+}

--- a/app/Actions/Parties/CreatePartyRelationship.php
+++ b/app/Actions/Parties/CreatePartyRelationship.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Actions\Parties;
+
+use App\Enums\PartyTimelineEventType;
+use App\Models\Party;
+use App\Models\PartyRelationship;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+final class CreatePartyRelationship
+{
+    public function __construct(
+        private readonly OrganisationContext $organisationContext,
+        private readonly RecordPartyTimelineEvent $recordTimelineEvent,
+    ) {}
+
+    /** @param array{related_party: Party, type: string, started_at: string|null} $attributes */
+    public function handle(Party $party, array $attributes, User $actor): PartyRelationship
+    {
+        $this->organisationContext->ensureOwns($party->organisation_id);
+        $this->organisationContext->ensureOwns($attributes['related_party']->organisation_id);
+
+        if ($party->is($attributes['related_party'])) {
+            throw new LogicException('A Party cannot have a relationship with itself.');
+        }
+
+        return DB::transaction(function () use ($party, $attributes, $actor): PartyRelationship {
+            $relationship = PartyRelationship::query()->create([
+                'organisation_id' => $party->organisation_id,
+                'party_id' => $party->id,
+                'related_party_id' => $attributes['related_party']->id,
+                'type' => $attributes['type'],
+                'started_at' => $attributes['started_at'],
+            ]);
+            $this->recordTimelineEvent->handle(
+                $party,
+                PartyTimelineEventType::RelationshipAdded,
+                'Relationship added',
+                $actor,
+                'party_relationship',
+                $relationship->id,
+                ['type' => $attributes['type']],
+            );
+
+            return $relationship;
+        });
+    }
+}

--- a/app/Actions/Parties/RecordPartyConsent.php
+++ b/app/Actions/Parties/RecordPartyConsent.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Actions\Parties;
+
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use App\Enums\PartyTimelineEventType;
+use App\Models\Party;
+use App\Models\PartyConsent;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+final class RecordPartyConsent
+{
+    public function __construct(
+        private readonly OrganisationContext $organisationContext,
+        private readonly RecordPartyTimelineEvent $recordTimelineEvent,
+    ) {}
+
+    /** @param array{purpose: ConsentPurpose, decision: ConsentDecision, wording_version: string, wording: string, source: string, occurred_at: string} $attributes */
+    public function handle(Party $party, array $attributes, User $actor): PartyConsent
+    {
+        $this->organisationContext->ensureOwns($party->organisation_id);
+
+        return DB::transaction(function () use ($party, $attributes, $actor): PartyConsent {
+            $latest = PartyConsent::query()
+                ->where('party_id', $party->id)
+                ->where('purpose', $attributes['purpose'])
+                ->latest('occurred_at')
+                ->latest('id')
+                ->lockForUpdate()
+                ->first();
+
+            if ($attributes['decision'] === ConsentDecision::Withdrawn
+                && ! $this->isGranted($latest)) {
+                throw new LogicException('Consent can only be withdrawn after it has been granted.');
+            }
+
+            $consent = PartyConsent::query()->create([
+                'organisation_id' => $party->organisation_id,
+                'party_id' => $party->id,
+                ...$attributes,
+                'supersedes_id' => $latest?->id,
+                'recorded_by_user_id' => $actor->id,
+            ]);
+            $this->recordTimelineEvent->handle(
+                $party,
+                PartyTimelineEventType::ConsentRecorded,
+                ucfirst($attributes['purpose']->value).' consent '.$attributes['decision']->value,
+                $actor,
+                'party_consent',
+                $consent->id,
+                [
+                    'purpose' => $attributes['purpose']->value,
+                    'decision' => $attributes['decision']->value,
+                    'wording_version' => $attributes['wording_version'],
+                ],
+            );
+
+            return $consent;
+        });
+    }
+
+    private function isGranted(?PartyConsent $consent): bool
+    {
+        return $consent !== null && $consent->decision === ConsentDecision::Granted;
+    }
+}

--- a/app/Actions/Parties/RecordPartyTimelineEvent.php
+++ b/app/Actions/Parties/RecordPartyTimelineEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Actions\Parties;
+
+use App\Enums\PartyTimelineEventType;
+use App\Models\Party;
+use App\Models\PartyTimelineEvent;
+use App\Models\User;
+use App\OrganisationContext;
+
+final class RecordPartyTimelineEvent
+{
+    public function __construct(private readonly OrganisationContext $organisationContext) {}
+
+    /** @param array<string, bool|int|string|null> $metadata */
+    public function handle(
+        Party $party,
+        PartyTimelineEventType $type,
+        string $summary,
+        ?User $actor = null,
+        ?string $subjectType = null,
+        int|string|null $subjectId = null,
+        array $metadata = [],
+    ): PartyTimelineEvent {
+        $this->organisationContext->ensureOwns($party->organisation_id);
+
+        return PartyTimelineEvent::query()->create([
+            'organisation_id' => $party->organisation_id,
+            'party_id' => $party->id,
+            'type' => $type,
+            'subject_type' => $subjectType,
+            'subject_id' => $subjectId === null ? null : (string) $subjectId,
+            'summary' => $summary,
+            'metadata' => $metadata,
+            'occurred_at' => now(),
+            'recorded_by_user_id' => $actor?->id,
+        ]);
+    }
+}

--- a/app/Actions/Parties/StorePartyAddress.php
+++ b/app/Actions/Parties/StorePartyAddress.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Actions\Parties;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\PartyTimelineEventType;
+use App\Models\Party;
+use App\Models\PartyAddress;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+
+final class StorePartyAddress
+{
+    public function __construct(
+        private readonly OrganisationContext $organisationContext,
+        private readonly ClassifiedDataEncrypter $encrypter,
+        private readonly RecordPartyTimelineEvent $recordTimelineEvent,
+    ) {}
+
+    /** @param array{label: string, address: string, service_area: string|null, country_code: string} $attributes */
+    public function handle(Party $party, array $attributes, User $actor): PartyAddress
+    {
+        $this->organisationContext->ensureOwns($party->organisation_id);
+
+        return DB::transaction(function () use ($party, $attributes, $actor): PartyAddress {
+            $address = new PartyAddress;
+            $address->forceFill([
+                'id' => $address->newUniqueId(),
+                'organisation_id' => $party->organisation_id,
+                'party_id' => $party->id,
+                'type' => 'address',
+                'label' => $attributes['label'],
+                'data_key_version' => $this->encrypter->currentVersion(),
+                'service_area' => $attributes['service_area'],
+                'country_code' => $attributes['country_code'],
+            ]);
+            $address->encrypted_value = new ClassifiedValue($attributes['address']);
+            $address->save();
+            $this->recordTimelineEvent->handle(
+                $party,
+                PartyTimelineEventType::AddressAdded,
+                $attributes['label'].' address added',
+                $actor,
+                'party_address',
+                $address->id,
+                ['service_area' => $attributes['service_area']],
+            );
+
+            return $address;
+        });
+    }
+}

--- a/app/Actions/Parties/StoreSafeContactInstruction.php
+++ b/app/Actions/Parties/StoreSafeContactInstruction.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Actions\Parties;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\PartyTimelineEventType;
+use App\Models\Party;
+use App\Models\PartySafeContactInstruction;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+
+final class StoreSafeContactInstruction
+{
+    public function __construct(
+        private readonly OrganisationContext $organisationContext,
+        private readonly ClassifiedDataEncrypter $encrypter,
+        private readonly RecordPartyTimelineEvent $recordTimelineEvent,
+    ) {}
+
+    /** @param array{instruction: string, source: string, effective_at: string} $attributes */
+    public function handle(Party $party, array $attributes, User $actor): PartySafeContactInstruction
+    {
+        $this->organisationContext->ensureOwns($party->organisation_id);
+
+        return DB::transaction(function () use ($party, $attributes, $actor): PartySafeContactInstruction {
+            $instruction = new PartySafeContactInstruction;
+            $instruction->forceFill([
+                'id' => $instruction->newUniqueId(),
+                'organisation_id' => $party->organisation_id,
+                'party_id' => $party->id,
+                'type' => 'instruction',
+                'data_key_version' => $this->encrypter->currentVersion(),
+                'source' => $attributes['source'],
+                'effective_at' => $attributes['effective_at'],
+                'recorded_by_user_id' => $actor->id,
+            ]);
+            $instruction->encrypted_value = new ClassifiedValue($attributes['instruction']);
+            $instruction->save();
+            $this->recordTimelineEvent->handle(
+                $party,
+                PartyTimelineEventType::SafeContactInstructionRecorded,
+                'Safe-contact instruction recorded',
+                $actor,
+                'party_safe_contact_instruction',
+                $instruction->id,
+            );
+
+            return $instruction;
+        });
+    }
+}

--- a/app/Actions/Parties/SyncPartyContacts.php
+++ b/app/Actions/Parties/SyncPartyContacts.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Actions\Parties;
+
+use App\Enums\PartyContactType;
+use App\Models\Party;
+use App\Models\PartyContactPoint;
+use App\OrganisationContext;
+
+final class SyncPartyContacts
+{
+    public function __construct(
+        private readonly OrganisationContext $organisationContext,
+        private readonly StorePartyContact $storePartyContact,
+    ) {}
+
+    /** @param array{email: string|null, telephone: string|null} $contacts */
+    public function handle(Party $party, array $contacts): void
+    {
+        $this->organisationContext->ensureOwns($party->organisation_id);
+        $this->sync($party, PartyContactType::Email, $contacts['email']);
+        $this->sync($party, PartyContactType::Telephone, $contacts['telephone']);
+    }
+
+    private function sync(Party $party, PartyContactType $type, ?string $value): void
+    {
+        $contact = PartyContactPoint::query()
+            ->where('party_id', $party->id)
+            ->where('type', $type)
+            ->first();
+
+        if ($contact !== null && $value !== null && $contact->encrypted_value->reveal() === $value) {
+            return;
+        }
+
+        $contact?->delete();
+
+        if ($value !== null) {
+            $this->storePartyContact->handle($party, $type, $value);
+        }
+    }
+}

--- a/app/Actions/Parties/UpdatePartyProfile.php
+++ b/app/Actions/Parties/UpdatePartyProfile.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Actions\Parties;
+
+use App\Enums\PartyBusinessRole;
+use App\Enums\PartyKind;
+use App\Enums\PartyTimelineEventType;
+use App\Models\Party;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+final class UpdatePartyProfile
+{
+    public function __construct(
+        private readonly OrganisationContext $organisationContext,
+        private readonly SyncPartyContacts $syncPartyContacts,
+        private readonly RecordPartyTimelineEvent $recordTimelineEvent,
+    ) {}
+
+    /**
+     * @param  array{kind: PartyKind, display_name: string, email: string|null, telephone: string|null, program_ids: list<int>, roles: list<PartyBusinessRole>, interests: list<string>}  $attributes
+     */
+    public function handle(Party $party, array $attributes, User $actor): Party
+    {
+        $this->organisationContext->ensureOwns($party->organisation_id);
+
+        return DB::transaction(function () use ($party, $attributes, $actor): Party {
+            $party->fill([
+                'kind' => $attributes['kind'],
+                'display_name' => $attributes['display_name'],
+            ]);
+            $changedFields = array_keys($party->getDirty());
+            $party->save();
+            $party->programs()->sync($attributes['program_ids']);
+            $party->businessRoles()->delete();
+            $party->businessRoles()->createMany(collect($attributes['roles'])
+                ->map(fn (PartyBusinessRole $role): array => [
+                    'organisation_id' => $party->organisation_id,
+                    'role' => $role,
+                ])->all());
+            $party->interests()->delete();
+            $party->interests()->createMany(collect($attributes['interests'])
+                ->map(fn (string $interest): array => [
+                    'organisation_id' => $party->organisation_id,
+                    'slug' => Str::slug($interest),
+                    'label' => $interest,
+                ])->all());
+            $this->syncPartyContacts->handle($party, [
+                'email' => $attributes['email'],
+                'telephone' => $attributes['telephone'],
+            ]);
+            $this->recordTimelineEvent->handle(
+                $party,
+                PartyTimelineEventType::ProfileUpdated,
+                'Profile updated',
+                $actor,
+                'party',
+                $party->uuid,
+                ['changed_fields' => implode(',', $changedFields)],
+            );
+
+            return $party->refresh();
+        });
+    }
+}

--- a/app/Actions/Programs/UpdateProgram.php
+++ b/app/Actions/Programs/UpdateProgram.php
@@ -12,7 +12,7 @@ class UpdateProgram
 {
     public function __construct(private RecordTenantAuditEvent $recordTenantAuditEvent) {}
 
-    /** @param array{name: string, slug: string} $attributes */
+    /** @param array{name: string, slug: string, configuration?: array<string, mixed>} $attributes */
     public function handle(Program $program, array $attributes, User $actor): Program
     {
         return DB::transaction(function () use ($program, $attributes, $actor): Program {

--- a/app/Data/Demo/ScenarioCatalog.php
+++ b/app/Data/Demo/ScenarioCatalog.php
@@ -3,6 +3,7 @@
 namespace App\Data\Demo;
 
 use App\Enums\OrganisationRole;
+use App\Enums\PartyBusinessRole;
 use App\Enums\PartyKind;
 use InvalidArgumentException;
 
@@ -29,9 +30,9 @@ final class ScenarioCatalog
      * @return list<array{
      *     uuid: string, name: string, slug: string, timezone: string, currency: string, reporting_at: string, synthetic: true,
      *     party_population: array<string, int>,
-     *     programs: list<array{name: string, slug: string}>,
+     *     programs: list<array{name: string, slug: string, configuration: array<string, mixed>}>,
      *     members: list<array{party_uuid: string, name: string, email: string, telephone: string, owner: bool, role: OrganisationRole|null, program_slugs: list<string>}>,
-     *     parties: list<array{uuid: string, kind: PartyKind, name: string, email?: string, telephone?: string}>
+     *     parties: list<array{uuid: string, kind: PartyKind, name: string, email?: string, telephone?: string, program_slugs?: list<string>, roles?: list<PartyBusinessRole>, interests?: list<string>}>
      * }>
      */
     public static function organisations(): array
@@ -51,9 +52,9 @@ final class ScenarioCatalog
                     PartyKind::Household->value => 100,
                 ],
                 'programs' => [
-                    ['name' => 'Community Drop-in and Material Relief', 'slug' => 'community-drop-in'],
-                    ['name' => 'Housing and Homelessness Support', 'slug' => 'housing-support'],
-                    ['name' => 'Newcomer Settlement', 'slug' => 'newcomer-settlement'],
+                    self::program('Community Drop-in and Material Relief', 'community-drop-in', 'Request', 'Support case', ['received' => 'Received', 'assisted' => 'Assisted']),
+                    self::program('Housing and Homelessness Support', 'housing-support', 'Housing request', 'Housing journey', ['referred' => 'Referred', 'housed' => 'Housed']),
+                    self::program('Newcomer Settlement', 'newcomer-settlement', 'Settlement request', 'Settlement journey', ['intake' => 'Intake', 'settled' => 'Settled']),
                 ],
                 'members' => [
                     self::member('11000000-0000-4000-8000-000000000001', 'HarbourKind Demo Administrator', 'admin@harbourkind.example.test', '+1 202-555-0101', true, OrganisationRole::OrganisationAdministrator),
@@ -67,10 +68,10 @@ final class ScenarioCatalog
                     self::member('11000000-0000-4000-8000-000000000009', 'HarbourKind Demo Settlement Manager', 'settlement.manager@harbourkind.example.test', '+1 202-555-0109', false, OrganisationRole::ProgramManager, ['newcomer-settlement']),
                 ],
                 'parties' => [
-                    self::party('12000000-0000-4000-8000-000000000001', PartyKind::Person, 'Synthetic Client Amina Example', 'amina.client@harbourkind.example.test', '+1 202-555-0111'),
-                    self::party('12000000-0000-4000-8000-000000000002', PartyKind::Person, 'Synthetic Donor Rowan Example', 'rowan.donor@harbourkind.example.test', '+1 202-555-0112'),
-                    self::party('12000000-0000-4000-8000-000000000003', PartyKind::Household, 'Synthetic Hart Household'),
-                    self::party('12000000-0000-4000-8000-000000000004', PartyKind::Organisation, 'Synthetic Brightwell Community Fund', 'contact@brightwell.example.test', '+1 202-555-0113'),
+                    self::party('12000000-0000-4000-8000-000000000001', PartyKind::Person, 'Synthetic Client Amina Example', 'amina.client@harbourkind.example.test', '+1 202-555-0111', ['housing-support'], [PartyBusinessRole::Client, PartyBusinessRole::Volunteer], ['Housing', 'Employment']),
+                    self::party('12000000-0000-4000-8000-000000000002', PartyKind::Person, 'Synthetic Donor Rowan Example', 'rowan.donor@harbourkind.example.test', '+1 202-555-0112', ['community-drop-in'], [PartyBusinessRole::Donor]),
+                    self::party('12000000-0000-4000-8000-000000000003', PartyKind::Household, 'Synthetic Hart Household', programSlugs: ['housing-support'], roles: [PartyBusinessRole::Client], interests: ['Housing']),
+                    self::party('12000000-0000-4000-8000-000000000004', PartyKind::Organisation, 'Synthetic Brightwell Community Fund', 'contact@brightwell.example.test', '+1 202-555-0113', ['community-drop-in'], [PartyBusinessRole::Donor, PartyBusinessRole::PartnerContact]),
                 ],
             ],
             [
@@ -85,7 +86,7 @@ final class ScenarioCatalog
                     PartyKind::Person->value => 30,
                 ],
                 'programs' => [
-                    ['name' => 'Neighbour Support Network', 'slug' => 'neighbour-support'],
+                    self::program('Neighbour Support Network', 'neighbour-support', 'Neighbour request', 'Support case', ['received' => 'Received', 'connected' => 'Connected']),
                 ],
                 'members' => [
                     self::member('21000000-0000-4000-8000-000000000001', 'NeighbourLink Demo Administrator', 'admin@neighbourlink.example.test', '+1 202-555-0121', true, OrganisationRole::OrganisationAdministrator),
@@ -93,7 +94,7 @@ final class ScenarioCatalog
                     self::member('21000000-0000-4000-8000-000000000003', 'NeighbourLink Demo Governance Owner', 'owner@neighbourlink.example.test', '+1 202-555-0122', true),
                 ],
                 'parties' => [
-                    self::party('22000000-0000-4000-8000-000000000001', PartyKind::Person, 'Synthetic Resident Noor Example', 'noor.resident@neighbourlink.example.test', '+1 202-555-0123'),
+                    self::party('22000000-0000-4000-8000-000000000001', PartyKind::Person, 'Synthetic Resident Noor Example', 'noor.resident@neighbourlink.example.test', '+1 202-555-0123', ['neighbour-support'], [PartyBusinessRole::Client], ['Neighbour connection']),
                 ],
             ],
         ];
@@ -135,10 +136,37 @@ final class ScenarioCatalog
         ];
     }
 
-    /** @return array{uuid: string, kind: PartyKind, name: string, email?: string, telephone?: string} */
-    private static function party(string $uuid, PartyKind $kind, string $name, ?string $email = null, ?string $telephone = null): array
+    /**
+     * @param  list<string>  $programSlugs
+     * @param  list<PartyBusinessRole>  $roles
+     * @param  list<string>  $interests
+     * @return array{uuid: string, kind: PartyKind, name: string, email?: string, telephone?: string, program_slugs?: list<string>, roles?: list<PartyBusinessRole>, interests?: list<string>}
+     */
+    private static function party(string $uuid, PartyKind $kind, string $name, ?string $email = null, ?string $telephone = null, array $programSlugs = [], array $roles = [], array $interests = []): array
     {
-        return array_filter(compact('uuid', 'kind', 'name', 'email', 'telephone'), fn (mixed $value): bool => $value !== null);
+        return array_filter(compact('uuid', 'kind', 'name', 'email', 'telephone') + [
+            'program_slugs' => $programSlugs,
+            'roles' => $roles,
+            'interests' => $interests,
+        ], fn (mixed $value): bool => $value !== null && $value !== []);
+    }
+
+    /**
+     * @param  array<string, string>  $stages
+     * @return array{name: string, slug: string, configuration: array{labels: array{request: string, case: string}, stages: list<array{key: string, label: string}>, outcome_measures: list<array{key: string, label: string, unit: string}>, taxonomies: list<array{key: string, label: string, values: list<string>}>}}
+     */
+    private static function program(string $name, string $slug, string $requestLabel, string $caseLabel, array $stages): array
+    {
+        return [
+            'name' => $name,
+            'slug' => $slug,
+            'configuration' => [
+                'labels' => ['request' => $requestLabel, 'case' => $caseLabel],
+                'stages' => array_values(collect($stages)->map(fn (string $label, string $key): array => compact('key', 'label'))->all()),
+                'outcome_measures' => [['key' => 'progress', 'label' => 'Progress', 'unit' => 'score']],
+                'taxonomies' => [['key' => 'need', 'label' => 'Presenting need', 'values' => ['Housing', 'Food', 'Employment', 'Connection']]],
+            ],
+        ];
     }
 
     /** @return array{uuid: string, organisation_slug: string, synthetic: true} */

--- a/app/Enums/ConsentDecision.php
+++ b/app/Enums/ConsentDecision.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum ConsentDecision: string
+{
+    case Granted = 'granted';
+    case Withdrawn = 'withdrawn';
+}

--- a/app/Enums/ConsentPurpose.php
+++ b/app/Enums/ConsentPurpose.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum ConsentPurpose: string
+{
+    case Service = 'service';
+    case Referral = 'referral';
+    case SafeContact = 'safe_contact';
+}

--- a/app/Enums/PartyBusinessRole.php
+++ b/app/Enums/PartyBusinessRole.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Enums;
+
+enum PartyBusinessRole: string
+{
+    case Client = 'client';
+    case Donor = 'donor';
+    case Volunteer = 'volunteer';
+    case PartnerContact = 'partner_contact';
+    case EventAttendee = 'event_attendee';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Client => 'Client',
+            self::Donor => 'Donor',
+            self::Volunteer => 'Volunteer',
+            self::PartnerContact => 'Partner contact',
+            self::EventAttendee => 'Event attendee',
+        };
+    }
+}

--- a/app/Enums/PartyTimelineEventType.php
+++ b/app/Enums/PartyTimelineEventType.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Enums;
+
+enum PartyTimelineEventType: string
+{
+    case ProfileCreated = 'profile_created';
+    case ProfileUpdated = 'profile_updated';
+    case RoleAssigned = 'role_assigned';
+    case RelationshipAdded = 'relationship_added';
+    case AddressAdded = 'address_added';
+    case InterestAdded = 'interest_added';
+    case ConsentRecorded = 'consent_recorded';
+    case SafeContactInstructionRecorded = 'safe_contact_instruction_recorded';
+}

--- a/app/Http/Controllers/Organisations/PartyAddressController.php
+++ b/app/Http/Controllers/Organisations/PartyAddressController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Parties\StorePartyAddress;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\StorePartyAddressRequest;
+use App\Models\Organisation;
+use App\Models\Party;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+
+class PartyAddressController extends Controller
+{
+    public function store(
+        StorePartyAddressRequest $request,
+        Organisation $currentOrganisation,
+        string $party,
+        StorePartyAddress $storePartyAddress,
+    ): RedirectResponse {
+        $party = Party::query()->where('uuid', $party)->firstOrFail();
+        Gate::authorize('update', $party);
+        $storePartyAddress->handle($party, [
+            'label' => $request->string('label')->toString(),
+            'address' => $request->string('address')->toString(),
+            'service_area' => $request->filled('service_area') ? $request->string('service_area')->toString() : null,
+            'country_code' => strtoupper($request->string('country_code')->toString()),
+        ], $request->user());
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Organisations/PartyConsentController.php
+++ b/app/Http/Controllers/Organisations/PartyConsentController.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Parties\RecordPartyConsent;
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\RecordPartyConsentRequest;
+use App\Models\Organisation;
+use App\Models\Party;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+
+class PartyConsentController extends Controller
+{
+    public function store(
+        RecordPartyConsentRequest $request,
+        Organisation $currentOrganisation,
+        string $party,
+        RecordPartyConsent $recordPartyConsent,
+    ): RedirectResponse {
+        $party = Party::query()->where('uuid', $party)->firstOrFail();
+        Gate::authorize('recordConsent', $party);
+        $recordPartyConsent->handle($party, [
+            'purpose' => ConsentPurpose::from($request->string('purpose')->toString()),
+            'decision' => ConsentDecision::from($request->string('decision')->toString()),
+            'wording_version' => $request->string('wording_version')->toString(),
+            'wording' => $request->string('wording')->toString(),
+            'source' => $request->string('source')->toString(),
+            'occurred_at' => $request->string('occurred_at')->toString(),
+        ], $request->user());
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Organisations/PartyController.php
+++ b/app/Http/Controllers/Organisations/PartyController.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Parties\CreatePartyProfile;
+use App\Actions\Parties\UpdatePartyProfile;
+use App\Enums\OrganisationRole;
+use App\Enums\PartyBusinessRole;
+use App\Enums\PartyContactType;
+use App\Enums\PartyKind;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\StorePartyProfileRequest;
+use App\Http\Requests\Organisations\UpdatePartyProfileRequest;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\PartyContactPoint;
+use App\Models\PartyRole;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class PartyController extends Controller
+{
+    public function index(Request $request, Organisation $currentOrganisation): Response
+    {
+        Gate::authorize('viewAny', [Party::class, $currentOrganisation]);
+        $request->validate(['query' => ['nullable', 'string', 'max:100']]);
+        $parties = $this->visibleParties($request->user(), $currentOrganisation)
+            ->with(['businessRoles', 'programs:id,name,slug'])
+            ->when($request->string('query')->isNotEmpty(), fn (Builder $query) => $query
+                ->where('display_name', 'like', '%'.$request->string('query')->toString().'%'))
+            ->orderBy('display_name')
+            ->orderBy('id')
+            ->paginate(25)
+            ->withQueryString()
+            ->through(fn (Party $party): array => [
+                'uuid' => $party->uuid,
+                'kind' => $party->kind->value,
+                'displayName' => $party->display_name,
+                'roles' => $party->businessRoles->map(fn (PartyRole $role): string => $role->role->label())->values(),
+                'programs' => $party->programs->pluck('name')->values(),
+            ]);
+
+        return Inertia::render('parties/index', [
+            'parties' => $parties,
+            'query' => $request->string('query')->toString(),
+            'canCreate' => Gate::allows('create', [Party::class, $currentOrganisation]),
+            ...$this->formOptions($currentOrganisation),
+        ]);
+    }
+
+    public function store(
+        StorePartyProfileRequest $request,
+        Organisation $currentOrganisation,
+        CreatePartyProfile $createPartyProfile,
+    ): RedirectResponse {
+        Gate::authorize('create', [Party::class, $currentOrganisation]);
+        $party = $createPartyProfile->handle(
+            $currentOrganisation,
+            $this->profileAttributes($request),
+            $request->user(),
+        );
+
+        return to_route('parties.show', [$currentOrganisation, $party]);
+    }
+
+    public function show(Request $request, Organisation $currentOrganisation, string $party): Response
+    {
+        $party = $this->findParty($party);
+        Gate::authorize('view', $party);
+        $party->load([
+            'addresses',
+            'businessRoles',
+            'consents' => fn ($query) => $query->latest('occurred_at')->latest('id'),
+            'contactPoints',
+            'interests',
+            'programs:id,name,slug',
+            'relationships.relatedParty',
+            'timelineEvents' => fn ($query) => $query->latest('occurred_at')->latest('id')->limit(100),
+        ]);
+        $canManageSafeContact = Gate::allows('manageSafeContact', $party);
+
+        if ($canManageSafeContact) {
+            $party->load(['safeContactInstructions' => fn ($query) => $query->latest('effective_at')]);
+        }
+
+        return Inertia::render('parties/show', [
+            'party' => [
+                'uuid' => $party->uuid,
+                'kind' => $party->kind->value,
+                'displayName' => $party->display_name,
+                'email' => $this->contactValue($party, PartyContactType::Email),
+                'telephone' => $this->contactValue($party, PartyContactType::Telephone),
+                'programIds' => $party->programs->modelKeys(),
+                'roles' => $party->businessRoles->pluck('role')->map->value->values(),
+                'interests' => $party->interests->pluck('label')->values(),
+                'addresses' => $party->addresses->map(fn ($address): array => [
+                    'id' => $address->id,
+                    'label' => $address->label,
+                    'address' => $address->encrypted_value->reveal(),
+                    'serviceArea' => $address->service_area,
+                    'countryCode' => $address->country_code,
+                ])->values(),
+                'relationships' => $party->relationships->map(fn ($relationship): array => [
+                    'id' => $relationship->id,
+                    'type' => $relationship->type,
+                    'relatedParty' => [
+                        'uuid' => $relationship->relatedParty->uuid,
+                        'displayName' => $relationship->relatedParty->display_name,
+                    ],
+                    'startedAt' => $relationship->started_at?->toAtomString(),
+                    'endedAt' => $relationship->ended_at?->toAtomString(),
+                ])->values(),
+                'consents' => $party->consents->map(fn ($consent): array => [
+                    'id' => $consent->id,
+                    'purpose' => $consent->purpose->value,
+                    'decision' => $consent->decision->value,
+                    'wordingVersion' => $consent->wording_version,
+                    'wording' => $consent->wording,
+                    'source' => $consent->source,
+                    'occurredAt' => $consent->occurred_at->toAtomString(),
+                    'supersedesId' => $consent->supersedes_id,
+                ])->values(),
+                'safeContactInstructions' => $canManageSafeContact
+                    ? $party->safeContactInstructions->map(fn ($instruction): array => [
+                        'id' => $instruction->id,
+                        'instruction' => $instruction->encrypted_value->reveal(),
+                        'source' => $instruction->source,
+                        'effectiveAt' => $instruction->effective_at->toAtomString(),
+                        'endedAt' => $instruction->ended_at?->toAtomString(),
+                    ])->values()
+                    : [],
+                'timeline' => $party->timelineEvents->map(fn ($event): array => [
+                    'id' => $event->id,
+                    'type' => $event->type->value,
+                    'summary' => $event->summary,
+                    'occurredAt' => $event->occurred_at->toAtomString(),
+                ])->values(),
+            ],
+            'canUpdate' => Gate::allows('update', $party),
+            'canRecordConsent' => Gate::allows('recordConsent', $party),
+            'canManageSafeContact' => $canManageSafeContact,
+            'relationshipCandidates' => Party::query()
+                ->whereKeyNot($party->id)
+                ->orderBy('display_name')
+                ->limit(100)
+                ->get(['id', 'uuid', 'display_name'])
+                ->map(fn (Party $candidate): array => [
+                    'id' => $candidate->id,
+                    'uuid' => $candidate->uuid,
+                    'displayName' => $candidate->display_name,
+                ]),
+            ...$this->formOptions($currentOrganisation),
+        ]);
+    }
+
+    public function update(
+        UpdatePartyProfileRequest $request,
+        Organisation $currentOrganisation,
+        string $party,
+        UpdatePartyProfile $updatePartyProfile,
+    ): RedirectResponse {
+        $party = $this->findParty($party);
+        Gate::authorize('update', $party);
+        $updatePartyProfile->handle($party, $this->profileAttributes($request), $request->user());
+
+        return back();
+    }
+
+    /**
+     * @return array{kind: PartyKind, display_name: string, email: string|null, telephone: string|null, program_ids: list<int>, roles: list<PartyBusinessRole>, interests: list<string>}
+     */
+    private function profileAttributes(StorePartyProfileRequest $request): array
+    {
+        return [
+            'kind' => PartyKind::from($request->string('kind')->toString()),
+            'display_name' => $request->string('display_name')->toString(),
+            'email' => $request->filled('email') ? $request->string('email')->toString() : null,
+            'telephone' => $request->filled('telephone') ? $request->string('telephone')->toString() : null,
+            'program_ids' => array_values(array_map(intval(...), $request->array('program_ids'))),
+            'roles' => array_values(array_map(fn (mixed $role): PartyBusinessRole => PartyBusinessRole::from((string) $role), $request->array('roles'))),
+            'interests' => array_values(array_map(strval(...), $request->array('interests'))),
+        ];
+    }
+
+    /** @return array{programs: mixed, partyKinds: list<array{value: string, label: string}>, partyRoles: list<array{value: string, label: string}>} */
+    private function formOptions(Organisation $organisation): array
+    {
+        return [
+            'programs' => $organisation->programs()->orderBy('name')->get(['id', 'name', 'slug']),
+            'partyKinds' => array_values(collect(PartyKind::cases())->map(fn (PartyKind $kind): array => [
+                'value' => $kind->value,
+                'label' => ucfirst($kind->value),
+            ])->all()),
+            'partyRoles' => array_values(collect(PartyBusinessRole::cases())->map(fn (PartyBusinessRole $role): array => [
+                'value' => $role->value,
+                'label' => $role->label(),
+            ])->all()),
+        ];
+    }
+
+    private function contactValue(Party $party, PartyContactType $type): ?string
+    {
+        $contact = $party->contactPoints->first(
+            fn (PartyContactPoint $contact): bool => $contact->type === $type,
+        );
+
+        return $contact?->encrypted_value->reveal();
+    }
+
+    private function findParty(string $uuid): Party
+    {
+        return Party::query()->where('uuid', $uuid)->firstOrFail();
+    }
+
+    /** @return Builder<Party> */
+    private function visibleParties(User $user, Organisation $organisation): Builder
+    {
+        if ($user->hasOrganisationRole($organisation, OrganisationRole::OrganisationAdministrator)) {
+            return Party::query();
+        }
+
+        $membership = $user->organisationMembership($organisation);
+        $programIds = $membership?->roleAssignments()
+            ->whereNull('ended_at')
+            ->where('role', OrganisationRole::ProgramManager)
+            ->pluck('program_id');
+
+        if ($programIds?->contains(null)) {
+            return Party::query();
+        }
+
+        return Party::query()->whereHas('programs', fn (Builder $query) => $query->whereKey($programIds ?? []));
+    }
+}

--- a/app/Http/Controllers/Organisations/PartyRelationshipController.php
+++ b/app/Http/Controllers/Organisations/PartyRelationshipController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Parties\CreatePartyRelationship;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\StorePartyRelationshipRequest;
+use App\Models\Organisation;
+use App\Models\Party;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+
+class PartyRelationshipController extends Controller
+{
+    public function store(
+        StorePartyRelationshipRequest $request,
+        Organisation $currentOrganisation,
+        string $party,
+        CreatePartyRelationship $createPartyRelationship,
+    ): RedirectResponse {
+        $party = Party::query()->where('uuid', $party)->firstOrFail();
+        Gate::authorize('update', $party);
+        $relatedParty = Party::query()->findOrFail($request->integer('related_party_id'));
+        $createPartyRelationship->handle($party, [
+            'related_party' => $relatedParty,
+            'type' => $request->string('type')->toString(),
+            'started_at' => $request->filled('started_at') ? $request->string('started_at')->toString() : null,
+        ], $request->user());
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Organisations/PartySafeContactInstructionController.php
+++ b/app/Http/Controllers/Organisations/PartySafeContactInstructionController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Parties\StoreSafeContactInstruction;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\StorePartySafeContactInstructionRequest;
+use App\Models\Organisation;
+use App\Models\Party;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+
+class PartySafeContactInstructionController extends Controller
+{
+    public function store(
+        StorePartySafeContactInstructionRequest $request,
+        Organisation $currentOrganisation,
+        string $party,
+        StoreSafeContactInstruction $storeSafeContactInstruction,
+    ): RedirectResponse {
+        $party = Party::query()->where('uuid', $party)->firstOrFail();
+        Gate::authorize('manageSafeContact', $party);
+        $storeSafeContactInstruction->handle($party, [
+            'instruction' => $request->string('instruction')->toString(),
+            'source' => $request->string('source')->toString(),
+            'effective_at' => $request->string('effective_at')->toString(),
+        ], $request->user());
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Organisations/ProgramController.php
+++ b/app/Http/Controllers/Organisations/ProgramController.php
@@ -14,28 +14,42 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
+use Inertia\Inertia;
+use Inertia\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ProgramController extends Controller
 {
+    public function index(Organisation $currentOrganisation): Response
+    {
+        Gate::authorize('viewAny', [Program::class, $currentOrganisation]);
+
+        return Inertia::render('programs/index', [
+            'programs' => Program::query()
+                ->orderBy('name')
+                ->get(['id', 'organisation_id', 'name', 'slug', 'configuration'])
+                ->map(fn (Program $program): array => [
+                    ...$program->only(['id', 'name', 'slug', 'configuration']),
+                    'canUpdate' => Gate::allows('update', $program),
+                ]),
+        ]);
+    }
+
     public function show(Organisation $organisation, string $program): JsonResponse
     {
         $program = $this->findProgram($program);
         Gate::authorize('view', $program);
 
-        return response()->json($program->only(['id', 'organisation_id', 'name', 'slug']));
+        return response()->json($program->only(['id', 'organisation_id', 'name', 'slug', 'configuration']));
     }
 
     public function update(UpdateProgramRequest $request, Organisation $organisation, string $program, UpdateProgram $updateProgram): JsonResponse
     {
         $program = $this->findProgram($program);
         Gate::authorize('update', $program);
-        $program = $updateProgram->handle($program, [
-            'name' => $request->string('name')->toString(),
-            'slug' => $request->string('slug')->toString(),
-        ], $request->user());
+        $program = $updateProgram->handle($program, $this->updateAttributes($request), $request->user());
 
-        return response()->json($program->only(['id', 'organisation_id', 'name', 'slug']));
+        return response()->json($program->only(['id', 'organisation_id', 'name', 'slug', 'configuration']));
     }
 
     public function search(Request $request, Organisation $organisation, SearchPrograms $searchPrograms): JsonResponse
@@ -65,5 +79,22 @@ class ProgramController extends Controller
         return ctype_digit($identifier)
             ? Program::query()->findOrFail((int) $identifier)
             : Program::query()->where('slug', $identifier)->firstOrFail();
+    }
+
+    /** @return array{name: string, slug: string, configuration?: array<string, mixed>} */
+    private function updateAttributes(UpdateProgramRequest $request): array
+    {
+        $configuration = $request->validated('configuration');
+
+        return $request->has('configuration') && is_array($configuration)
+            ? [
+                'name' => $request->string('name')->toString(),
+                'slug' => $request->string('slug')->toString(),
+                'configuration' => $configuration,
+            ]
+            : [
+                'name' => $request->string('name')->toString(),
+                'slug' => $request->string('slug')->toString(),
+            ];
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -3,8 +3,11 @@
 namespace App\Http\Middleware;
 
 use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\Program;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Gate;
 use Inertia\Middleware;
 
 class HandleInertiaRequests extends Middleware
@@ -42,6 +45,7 @@ class HandleInertiaRequests extends Middleware
         $organisations = function () use ($user, &$organisationData): Collection {
             return $organisationData ??= $user?->toUserOrganisations(includeCurrent: true) ?? collect();
         };
+        $routeOrganisation = $request->route('current_organisation');
 
         return [
             ...parent::share($request),
@@ -53,6 +57,10 @@ class HandleInertiaRequests extends Middleware
             'canCreateOrganisation' => $user?->can('create', Organisation::class) ?? false,
             'currentOrganisation' => fn () => $organisations()->first(fn ($organisation) => $organisation->isCurrent),
             'organisations' => $organisations,
+            'canViewParties' => fn (): bool => $routeOrganisation instanceof Organisation
+                && Gate::allows('viewAny', [Party::class, $routeOrganisation]),
+            'canViewPrograms' => fn (): bool => $routeOrganisation instanceof Organisation
+                && Gate::allows('viewAny', [Program::class, $routeOrganisation]),
         ];
     }
 }

--- a/app/Http/Requests/Organisations/RecordPartyConsentRequest.php
+++ b/app/Http/Requests/Organisations/RecordPartyConsentRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class RecordPartyConsentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'purpose' => ['required', Rule::enum(ConsentPurpose::class)],
+            'decision' => ['required', Rule::enum(ConsentDecision::class)],
+            'wording_version' => ['required', 'string', 'max:64'],
+            'wording' => ['required', 'string', 'max:2000'],
+            'source' => ['required', 'string', 'max:100'],
+            'occurred_at' => ['required', 'date', 'before_or_equal:now'],
+        ];
+    }
+}

--- a/app/Http/Requests/Organisations/StorePartyAddressRequest.php
+++ b/app/Http/Requests/Organisations/StorePartyAddressRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePartyAddressRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'label' => ['required', 'string', 'max:100'],
+            'address' => ['required', 'string', 'max:1000'],
+            'service_area' => ['nullable', 'string', 'max:100'],
+            'country_code' => ['required', 'string', 'size:2', 'uppercase'],
+        ];
+    }
+}

--- a/app/Http/Requests/Organisations/StorePartyProfileRequest.php
+++ b/app/Http/Requests/Organisations/StorePartyProfileRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Enums\PartyBusinessRole;
+use App\Enums\PartyKind;
+use App\Models\Organisation;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StorePartyProfileRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $organisation = $this->route('current_organisation');
+        $organisationId = $organisation instanceof Organisation ? $organisation->id : 0;
+
+        return [
+            'kind' => ['required', Rule::enum(PartyKind::class)],
+            'display_name' => ['required', 'string', 'max:255'],
+            'email' => ['nullable', 'email:rfc', 'max:255'],
+            'telephone' => ['nullable', 'string', 'max:50'],
+            'program_ids' => ['present', 'array', 'max:20'],
+            'program_ids.*' => ['integer', 'distinct', Rule::exists('programs', 'id')->where('organisation_id', $organisationId)],
+            'roles' => ['present', 'array', 'max:10'],
+            'roles.*' => ['distinct', Rule::enum(PartyBusinessRole::class)],
+            'interests' => ['present', 'array', 'max:20'],
+            'interests.*' => ['string', 'max:100', 'distinct:ignore_case'],
+        ];
+    }
+}

--- a/app/Http/Requests/Organisations/StorePartyRelationshipRequest.php
+++ b/app/Http/Requests/Organisations/StorePartyRelationshipRequest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Models\Organisation;
+use App\Models\Party;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StorePartyRelationshipRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $organisation = $this->route('current_organisation');
+        $partyIdentifier = $this->route('party');
+        $party = is_string($partyIdentifier)
+            ? Party::query()->where('uuid', $partyIdentifier)->first()
+            : null;
+
+        return [
+            'related_party_id' => [
+                'required',
+                'integer',
+                Rule::exists('parties', 'id')->where(
+                    'organisation_id',
+                    $organisation instanceof Organisation ? $organisation->id : 0,
+                ),
+                Rule::notIn([$party instanceof Party ? $party->id : 0]),
+            ],
+            'type' => ['required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/'],
+            'started_at' => ['nullable', 'date'],
+        ];
+    }
+}

--- a/app/Http/Requests/Organisations/StorePartySafeContactInstructionRequest.php
+++ b/app/Http/Requests/Organisations/StorePartySafeContactInstructionRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StorePartySafeContactInstructionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'instruction' => ['required', 'string', 'max:2000'],
+            'source' => ['required', 'string', 'max:100'],
+            'effective_at' => ['required', 'date'],
+        ];
+    }
+}

--- a/app/Http/Requests/Organisations/UpdatePartyProfileRequest.php
+++ b/app/Http/Requests/Organisations/UpdatePartyProfileRequest.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+class UpdatePartyProfileRequest extends StorePartyProfileRequest {}

--- a/app/Http/Requests/Organisations/UpdateProgramRequest.php
+++ b/app/Http/Requests/Organisations/UpdateProgramRequest.php
@@ -42,6 +42,25 @@ class UpdateProgramRequest extends FormRequest
                     ->where('organisation_id', $organisation instanceof Organisation ? $organisation->id : 0)
                     ->ignore($program?->id),
             ],
+            'configuration' => ['sometimes', 'array:labels,stages,outcome_measures,taxonomies'],
+            'configuration.labels' => ['required_with:configuration', 'array:request,case'],
+            'configuration.labels.request' => ['required_with:configuration', 'string', 'max:100'],
+            'configuration.labels.case' => ['required_with:configuration', 'string', 'max:100'],
+            'configuration.stages' => ['required_with:configuration', 'array', 'max:20'],
+            'configuration.stages.*' => ['array:key,label'],
+            'configuration.stages.*.key' => ['required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/', 'distinct'],
+            'configuration.stages.*.label' => ['required', 'string', 'max:100'],
+            'configuration.outcome_measures' => ['required_with:configuration', 'array', 'max:20'],
+            'configuration.outcome_measures.*' => ['array:key,label,unit'],
+            'configuration.outcome_measures.*.key' => ['required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/', 'distinct'],
+            'configuration.outcome_measures.*.label' => ['required', 'string', 'max:100'],
+            'configuration.outcome_measures.*.unit' => ['nullable', 'string', 'max:50'],
+            'configuration.taxonomies' => ['required_with:configuration', 'array', 'max:20'],
+            'configuration.taxonomies.*' => ['array:key,label,values'],
+            'configuration.taxonomies.*.key' => ['required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/', 'distinct'],
+            'configuration.taxonomies.*.label' => ['required', 'string', 'max:100'],
+            'configuration.taxonomies.*.values' => ['required', 'array', 'max:50'],
+            'configuration.taxonomies.*.values.*' => ['required', 'string', 'max:100', 'distinct'],
         ];
     }
 }

--- a/app/Models/Party.php
+++ b/app/Models/Party.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Concerns\BelongsToOrganisation;
 use App\Enums\PartyKind;
+use App\OrganisationContext;
 use Database\Factories\PartyFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Collection;
@@ -11,6 +12,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
@@ -54,9 +56,64 @@ class Party extends Model
         return $this->hasMany(PartyContactPoint::class);
     }
 
+    /** @return BelongsToMany<Program, $this> */
+    public function programs(): BelongsToMany
+    {
+        return $this->belongsToMany(Program::class, 'party_program')
+            ->withPivotValue('organisation_id', app(OrganisationContext::class)->id())
+            ->withTimestamps();
+    }
+
+    /** @return HasMany<PartyRole, $this> */
+    public function businessRoles(): HasMany
+    {
+        return $this->hasMany(PartyRole::class);
+    }
+
+    /** @return HasMany<PartyRelationship, $this> */
+    public function relationships(): HasMany
+    {
+        return $this->hasMany(PartyRelationship::class);
+    }
+
+    /** @return HasMany<PartyAddress, $this> */
+    public function addresses(): HasMany
+    {
+        return $this->hasMany(PartyAddress::class);
+    }
+
+    /** @return HasMany<PartyInterest, $this> */
+    public function interests(): HasMany
+    {
+        return $this->hasMany(PartyInterest::class);
+    }
+
+    /** @return HasMany<PartyConsent, $this> */
+    public function consents(): HasMany
+    {
+        return $this->hasMany(PartyConsent::class);
+    }
+
+    /** @return HasMany<PartySafeContactInstruction, $this> */
+    public function safeContactInstructions(): HasMany
+    {
+        return $this->hasMany(PartySafeContactInstruction::class);
+    }
+
+    /** @return HasMany<PartyTimelineEvent, $this> */
+    public function timelineEvents(): HasMany
+    {
+        return $this->hasMany(PartyTimelineEvent::class);
+    }
+
     /** @return array<string, string> */
     protected function casts(): array
     {
         return ['kind' => PartyKind::class];
+    }
+
+    public function getRouteKeyName(): string
+    {
+        return 'uuid';
     }
 }

--- a/app/Models/PartyAddress.php
+++ b/app/Models/PartyAddress.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\ClassifiedValueCast;
+use App\Concerns\BelongsToOrganisation;
+use App\Data\Values\ClassifiedValue;
+use Database\Factories\PartyAddressFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property int $party_id
+ * @property string $label
+ * @property ClassifiedValue $encrypted_value
+ * @property string|null $service_area
+ * @property string $country_code
+ */
+#[Fillable(['organisation_id', 'party_id', 'label', 'encrypted_value', 'service_area', 'country_code'])]
+class PartyAddress extends Model
+{
+    /** @use HasFactory<PartyAddressFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    /** @return BelongsTo<Party, $this> */
+    public function party(): BelongsTo
+    {
+        return $this->belongsTo(Party::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['encrypted_value' => ClassifiedValueCast::class.':party_address'];
+    }
+}

--- a/app/Models/PartyConsent.php
+++ b/app/Models/PartyConsent.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use Database\Factories\PartyConsentFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property ConsentPurpose $purpose
+ * @property ConsentDecision $decision
+ * @property string $wording_version
+ * @property string $wording
+ * @property string $source
+ * @property Carbon $occurred_at
+ * @property string|null $supersedes_id
+ */
+#[Fillable(['organisation_id', 'party_id', 'purpose', 'decision', 'wording_version', 'wording', 'source', 'occurred_at', 'supersedes_id', 'recorded_by_user_id'])]
+class PartyConsent extends Model
+{
+    /** @use HasFactory<PartyConsentFactory> */
+    use BelongsToOrganisation, HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Party consent history is append-only.'));
+        static::deleting(fn () => throw new LogicException('Party consent history is append-only.'));
+    }
+
+    /** @return BelongsTo<Party, $this> */
+    public function party(): BelongsTo
+    {
+        return $this->belongsTo(Party::class);
+    }
+
+    /** @return BelongsTo<PartyConsent, $this> */
+    public function supersedes(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'supersedes_id');
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function recordedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'recorded_by_user_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'purpose' => ConsentPurpose::class,
+            'decision' => ConsentDecision::class,
+            'occurred_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/PartyInterest.php
+++ b/app/Models/PartyInterest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use Database\Factories\PartyInterestFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable(['organisation_id', 'party_id', 'slug', 'label'])]
+class PartyInterest extends Model
+{
+    /** @use HasFactory<PartyInterestFactory> */
+    use BelongsToOrganisation, HasFactory;
+
+    /** @return BelongsTo<Party, $this> */
+    public function party(): BelongsTo
+    {
+        return $this->belongsTo(Party::class);
+    }
+}

--- a/app/Models/PartyRelationship.php
+++ b/app/Models/PartyRelationship.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use Database\Factories\PartyRelationshipFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property string $type
+ * @property Carbon|null $started_at
+ * @property Carbon|null $ended_at
+ * @property-read Party $relatedParty
+ */
+#[Fillable(['organisation_id', 'party_id', 'related_party_id', 'type', 'started_at', 'ended_at'])]
+class PartyRelationship extends Model
+{
+    /** @use HasFactory<PartyRelationshipFactory> */
+    use BelongsToOrganisation, HasFactory;
+
+    /** @return BelongsTo<Party, $this> */
+    public function party(): BelongsTo
+    {
+        return $this->belongsTo(Party::class);
+    }
+
+    /** @return BelongsTo<Party, $this> */
+    public function relatedParty(): BelongsTo
+    {
+        return $this->belongsTo(Party::class, 'related_party_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['started_at' => 'datetime', 'ended_at' => 'datetime'];
+    }
+}

--- a/app/Models/PartyRole.php
+++ b/app/Models/PartyRole.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\PartyBusinessRole;
+use Database\Factories\PartyRoleFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/** @property PartyBusinessRole $role */
+#[Fillable(['organisation_id', 'party_id', 'role'])]
+class PartyRole extends Model
+{
+    /** @use HasFactory<PartyRoleFactory> */
+    use BelongsToOrganisation, HasFactory;
+
+    /** @return BelongsTo<Party, $this> */
+    public function party(): BelongsTo
+    {
+        return $this->belongsTo(Party::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['role' => PartyBusinessRole::class];
+    }
+}

--- a/app/Models/PartySafeContactInstruction.php
+++ b/app/Models/PartySafeContactInstruction.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\ClassifiedValueCast;
+use App\Concerns\BelongsToOrganisation;
+use App\Data\Values\ClassifiedValue;
+use Database\Factories\PartySafeContactInstructionFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property ClassifiedValue $encrypted_value
+ * @property string $source
+ * @property Carbon $effective_at
+ * @property Carbon|null $ended_at
+ */
+#[Fillable(['organisation_id', 'party_id', 'encrypted_value', 'source', 'effective_at', 'ended_at', 'recorded_by_user_id'])]
+class PartySafeContactInstruction extends Model
+{
+    /** @use HasFactory<PartySafeContactInstructionFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    /** @return BelongsTo<Party, $this> */
+    public function party(): BelongsTo
+    {
+        return $this->belongsTo(Party::class);
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function recordedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'recorded_by_user_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'encrypted_value' => ClassifiedValueCast::class.':party_safe_contact',
+            'effective_at' => 'datetime',
+            'ended_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/PartyTimelineEvent.php
+++ b/app/Models/PartyTimelineEvent.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\PartyTimelineEventType;
+use Database\Factories\PartyTimelineEventFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property PartyTimelineEventType $type
+ * @property string $summary
+ * @property Carbon $occurred_at
+ */
+#[Fillable(['organisation_id', 'party_id', 'type', 'subject_type', 'subject_id', 'summary', 'metadata', 'occurred_at', 'recorded_by_user_id'])]
+class PartyTimelineEvent extends Model
+{
+    /** @use HasFactory<PartyTimelineEventFactory> */
+    use BelongsToOrganisation, HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Party timeline events are append-only.'));
+        static::deleting(fn () => throw new LogicException('Party timeline events are append-only.'));
+    }
+
+    /** @return BelongsTo<Party, $this> */
+    public function party(): BelongsTo
+    {
+        return $this->belongsTo(Party::class);
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function recordedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'recorded_by_user_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'type' => PartyTimelineEventType::class,
+            'metadata' => 'array',
+            'occurred_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/Program.php
+++ b/app/Models/Program.php
@@ -20,7 +20,7 @@ use Laravel\Scout\Searchable;
  * @property string $slug
  * @property-read Organisation $organisation
  */
-#[Fillable(['organisation_id', 'name', 'slug'])]
+#[Fillable(['organisation_id', 'name', 'slug', 'configuration'])]
 class Program extends Model
 {
     /** @use HasFactory<ProgramFactory> */
@@ -47,6 +47,14 @@ class Program extends Model
             ->withPivotValue('organisation_id', app(OrganisationContext::class)->id());
     }
 
+    /** @return BelongsToMany<Party, $this> */
+    public function parties(): BelongsToMany
+    {
+        return $this->belongsToMany(Party::class, 'party_program')
+            ->withPivotValue('organisation_id', app(OrganisationContext::class)->id())
+            ->withTimestamps();
+    }
+
     /** @return array<string, int|string> */
     public function toSearchableArray(): array
     {
@@ -56,5 +64,11 @@ class Program extends Model
             'name' => $this->name,
             'slug' => $this->slug,
         ];
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['configuration' => 'array'];
     }
 }

--- a/app/Policies/PartyPolicy.php
+++ b/app/Policies/PartyPolicy.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\User;
+
+class PartyPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user, Organisation $organisation): bool
+    {
+        return $user->hasOrganisationRole($organisation, OrganisationRole::OrganisationAdministrator)
+            || $this->hasRoleInAnyScope($user, $organisation, OrganisationRole::ProgramManager);
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Party $party): bool
+    {
+        if ($user->hasOrganisationRole($party->organisation, OrganisationRole::OrganisationAdministrator)) {
+            return true;
+        }
+
+        if ($user->hasOrganisationRole($party->organisation, OrganisationRole::ProgramManager)) {
+            return true;
+        }
+
+        return $party->programs()
+            ->get()
+            ->contains(fn ($program): bool => $user->hasOrganisationRole(
+                $party->organisation,
+                OrganisationRole::ProgramManager,
+                $program,
+            ));
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user, Organisation $organisation): bool
+    {
+        return $user->hasOrganisationRole($organisation, OrganisationRole::OrganisationAdministrator);
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, Party $party): bool
+    {
+        return $user->hasOrganisationRole($party->organisation, OrganisationRole::OrganisationAdministrator);
+    }
+
+    public function recordConsent(User $user, Party $party): bool
+    {
+        return $this->view($user, $party);
+    }
+
+    public function manageSafeContact(User $user, Party $party): bool
+    {
+        if ($user->hasOrganisationRole($party->organisation, OrganisationRole::ProgramManager)) {
+            return true;
+        }
+
+        return $party->programs()
+            ->get()
+            ->contains(fn ($program): bool => $user->hasOrganisationRole(
+                $party->organisation,
+                OrganisationRole::ProgramManager,
+                $program,
+            ));
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, Party $party): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, Party $party): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, Party $party): bool
+    {
+        return false;
+    }
+
+    private function hasRoleInAnyScope(User $user, Organisation $organisation, OrganisationRole $role): bool
+    {
+        $membership = $user->organisationMembership($organisation);
+
+        if ($membership === null || $membership->isHeld()) {
+            return false;
+        }
+
+        return $membership->roleAssignments()
+            ->whereNull('ended_at')
+            ->where('role', $role)
+            ->exists();
+    }
+}

--- a/database/factories/PartyAddressFactory.php
+++ b/database/factories/PartyAddressFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Models\Party;
+use App\Models\PartyAddress;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PartyAddress>
+ */
+class PartyAddressFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $address = new PartyAddress;
+        $organisationId = app(OrganisationContext::class)->id();
+
+        return [
+            'id' => $address->newUniqueId(),
+            'organisation_id' => $organisationId,
+            'party_id' => Party::factory()->state(['organisation_id' => $organisationId]),
+            'type' => 'address',
+            'label' => 'Home',
+            'encrypted_value' => new ClassifiedValue(fake()->address()),
+            'data_key_version' => app(ClassifiedDataEncrypter::class)->currentVersion(),
+            'service_area' => fake()->city(),
+            'country_code' => 'ZA',
+        ];
+    }
+}

--- a/database/factories/PartyConsentFactory.php
+++ b/database/factories/PartyConsentFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use App\Models\Party;
+use App\Models\PartyConsent;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PartyConsent>
+ */
+class PartyConsentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'party_id' => Party::factory()->state(['organisation_id' => app(OrganisationContext::class)->id()]),
+            'purpose' => ConsentPurpose::Service,
+            'decision' => ConsentDecision::Granted,
+            'wording_version' => 'v1',
+            'wording' => 'I consent to receiving this service.',
+            'source' => 'in_person',
+            'occurred_at' => now(),
+        ];
+    }
+}

--- a/database/factories/PartyInterestFactory.php
+++ b/database/factories/PartyInterestFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Party;
+use App\Models\PartyInterest;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<PartyInterest>
+ */
+class PartyInterestFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $label = fake()->word().' '.fake()->word();
+
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'party_id' => Party::factory()->state(['organisation_id' => app(OrganisationContext::class)->id()]),
+            'slug' => Str::slug($label),
+            'label' => $label,
+        ];
+    }
+}

--- a/database/factories/PartyRelationshipFactory.php
+++ b/database/factories/PartyRelationshipFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Party;
+use App\Models\PartyRelationship;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PartyRelationship>
+ */
+class PartyRelationshipFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $organisationId = app(OrganisationContext::class)->id();
+
+        return [
+            'organisation_id' => $organisationId,
+            'party_id' => Party::factory()->state(['organisation_id' => $organisationId]),
+            'related_party_id' => Party::factory()->state(['organisation_id' => $organisationId]),
+            'type' => 'household_member',
+            'started_at' => now(),
+        ];
+    }
+}

--- a/database/factories/PartyRoleFactory.php
+++ b/database/factories/PartyRoleFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\PartyBusinessRole;
+use App\Models\Party;
+use App\Models\PartyRole;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PartyRole>
+ */
+class PartyRoleFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'party_id' => Party::factory()->state(['organisation_id' => app(OrganisationContext::class)->id()]),
+            'role' => PartyBusinessRole::Client,
+        ];
+    }
+}

--- a/database/factories/PartySafeContactInstructionFactory.php
+++ b/database/factories/PartySafeContactInstructionFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Models\Party;
+use App\Models\PartySafeContactInstruction;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PartySafeContactInstruction>
+ */
+class PartySafeContactInstructionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $instruction = new PartySafeContactInstruction;
+        $organisationId = app(OrganisationContext::class)->id();
+
+        return [
+            'id' => $instruction->newUniqueId(),
+            'organisation_id' => $organisationId,
+            'party_id' => Party::factory()->state(['organisation_id' => $organisationId]),
+            'type' => 'instruction',
+            'encrypted_value' => new ClassifiedValue('Text messages only.'),
+            'data_key_version' => app(ClassifiedDataEncrypter::class)->currentVersion(),
+            'source' => 'in_person',
+            'effective_at' => now(),
+        ];
+    }
+}

--- a/database/factories/PartyTimelineEventFactory.php
+++ b/database/factories/PartyTimelineEventFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\PartyTimelineEventType;
+use App\Models\Party;
+use App\Models\PartyTimelineEvent;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PartyTimelineEvent>
+ */
+class PartyTimelineEventFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'party_id' => Party::factory()->state(['organisation_id' => app(OrganisationContext::class)->id()]),
+            'type' => PartyTimelineEventType::ProfileUpdated,
+            'summary' => 'Profile updated',
+            'metadata' => [],
+            'occurred_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/2026_08_31_044036_add_configuration_to_programs_table.php
+++ b/database/migrations/2026_08_31_044036_add_configuration_to_programs_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('programs', function (Blueprint $table) {
+            $table->json('configuration')->default('{}')->after('slug');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('programs', function (Blueprint $table) {
+            $table->dropColumn('configuration');
+        });
+    }
+};

--- a/database/migrations/2026_08_31_044040_create_party_profile_tables.php
+++ b/database/migrations/2026_08_31_044040_create_party_profile_tables.php
@@ -1,0 +1,171 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('party_program', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('party_id');
+            $table->foreignId('program_id');
+            $table->timestamps();
+
+            $table->foreign(['organisation_id', 'party_id'])
+                ->references(['organisation_id', 'id'])->on('parties')->cascadeOnDelete();
+            $table->foreign(['organisation_id', 'program_id'])
+                ->references(['organisation_id', 'id'])->on('programs')->cascadeOnDelete();
+            $table->unique(['organisation_id', 'party_id', 'program_id']);
+        });
+
+        Schema::create('party_roles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('party_id');
+            $table->string('role', 64);
+            $table->timestamps();
+
+            $table->foreign(['organisation_id', 'party_id'])
+                ->references(['organisation_id', 'id'])->on('parties')->cascadeOnDelete();
+            $table->unique(['organisation_id', 'party_id', 'role']);
+        });
+
+        Schema::create('party_relationships', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('party_id');
+            $table->foreignId('related_party_id');
+            $table->string('type', 64);
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('ended_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign(['organisation_id', 'party_id'], 'party_relationships_party_foreign')
+                ->references(['organisation_id', 'id'])->on('parties')->cascadeOnDelete();
+            $table->foreign(['organisation_id', 'related_party_id'], 'party_relationships_related_party_foreign')
+                ->references(['organisation_id', 'id'])->on('parties')->restrictOnDelete();
+            $table->index(['organisation_id', 'party_id', 'ended_at']);
+        });
+
+        Schema::create('party_addresses', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('party_id');
+            $table->string('type', 32)->default('address');
+            $table->string('label', 100);
+            $table->text('encrypted_value');
+            $table->string('data_key_version', 64);
+            $table->string('service_area', 100)->nullable();
+            $table->char('country_code', 2);
+            $table->timestamps();
+
+            $table->foreign(['organisation_id', 'party_id'])
+                ->references(['organisation_id', 'id'])->on('parties')->cascadeOnDelete();
+            $table->index(['organisation_id', 'service_area']);
+        });
+
+        Schema::create('party_interests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('party_id');
+            $table->string('slug', 100);
+            $table->string('label', 100);
+            $table->timestamps();
+
+            $table->foreign(['organisation_id', 'party_id'])
+                ->references(['organisation_id', 'id'])->on('parties')->cascadeOnDelete();
+            $table->unique(['organisation_id', 'party_id', 'slug']);
+        });
+
+        Schema::create('party_consents', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('party_id');
+            $table->string('purpose', 32);
+            $table->string('decision', 32);
+            $table->string('wording_version', 64);
+            $table->text('wording');
+            $table->string('source', 100);
+            $table->timestamp('occurred_at');
+            $table->ulid('supersedes_id')->nullable();
+            $table->unsignedBigInteger('recorded_by_user_id')->nullable()->index();
+
+            $table->foreign(['organisation_id', 'party_id'])
+                ->references(['organisation_id', 'id'])->on('parties')->cascadeOnDelete();
+            $table->unique(['organisation_id', 'id']);
+            $table->index(['organisation_id', 'party_id', 'purpose', 'occurred_at']);
+        });
+
+        Schema::table('party_consents', function (Blueprint $table) {
+            $table->foreign(['organisation_id', 'supersedes_id'])
+                ->references(['organisation_id', 'id'])->on('party_consents')->restrictOnDelete();
+        });
+
+        Schema::create('party_safe_contact_instructions', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('party_id');
+            $table->string('type', 32)->default('instruction');
+            $table->text('encrypted_value');
+            $table->string('data_key_version', 64);
+            $table->string('source', 100);
+            $table->timestamp('effective_at');
+            $table->timestamp('ended_at')->nullable();
+            $table->foreignId('recorded_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->foreign(['organisation_id', 'party_id'])
+                ->references(['organisation_id', 'id'])->on('parties')->cascadeOnDelete();
+            $table->index(['organisation_id', 'party_id', 'ended_at']);
+        });
+
+        Schema::create('party_timeline_events', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('party_id');
+            $table->string('type', 64);
+            $table->string('subject_type', 64)->nullable();
+            $table->string('subject_id', 64)->nullable();
+            $table->string('summary', 255);
+            $table->json('metadata')->default('{}');
+            $table->timestamp('occurred_at');
+            $table->unsignedBigInteger('recorded_by_user_id')->nullable()->index();
+
+            $table->foreign(['organisation_id', 'party_id'])
+                ->references(['organisation_id', 'id'])->on('parties')->cascadeOnDelete();
+            $table->index(['organisation_id', 'party_id', 'occurred_at']);
+        });
+
+        foreach (['party_consents', 'party_timeline_events'] as $table) {
+            if (DB::getDriverName() === 'pgsql') {
+                DB::unprepared("CREATE TRIGGER {$table}_append_only BEFORE UPDATE OR DELETE OR TRUNCATE ON {$table} FOR EACH STATEMENT EXECUTE FUNCTION prevent_append_only_mutation() ");
+            } elseif (DB::getDriverName() === 'sqlite') {
+                DB::unprepared("CREATE TRIGGER {$table}_append_only_update BEFORE UPDATE ON {$table} BEGIN SELECT RAISE(ABORT, 'append-only table'); END");
+                DB::unprepared("CREATE TRIGGER {$table}_append_only_delete BEFORE DELETE ON {$table} BEGIN SELECT RAISE(ABORT, 'append-only table'); END");
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('party_timeline_events');
+        Schema::dropIfExists('party_safe_contact_instructions');
+        Schema::dropIfExists('party_consents');
+        Schema::dropIfExists('party_interests');
+        Schema::dropIfExists('party_addresses');
+        Schema::dropIfExists('party_relationships');
+        Schema::dropIfExists('party_roles');
+        Schema::dropIfExists('party_program');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,6 +24,11 @@
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>
         <env name="CACHE_STORE" value="array"/>
+        <env name="CLASSIFIED_DATA_KEY_CURRENT" value="test-v1"/>
+        <env name="CLASSIFIED_DATA_KEYS" value="{&quot;test-v1&quot;:&quot;base64:VFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFRUVFQ=&quot;}"/>
+        <env name="CONTACT_INDEX_KEY_CURRENT" value="test-v1"/>
+        <env name="CONTACT_INDEX_KEY_PREVIOUS" value=""/>
+        <env name="CONTACT_INDEX_KEYS" value="{&quot;test-v1&quot;:&quot;base64:SUlJSUlJSUlJSUlJSUlJSUlJSUlJSUlJSUlJSUlJSUk=&quot;}"/>
         <env name="DB_CONNECTION" value="sqlite"/>
         <env name="DB_DATABASE" value=":memory:"/>
         <env name="DB_URL" value=""/>

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -1,5 +1,11 @@
 import { Link, usePage } from '@inertiajs/react';
-import { FolderGit2, LayoutGrid, Scale } from 'lucide-react';
+import {
+    FolderGit2,
+    LayoutGrid,
+    Scale,
+    Settings2,
+    UsersRound,
+} from 'lucide-react';
 import AppLogo from '@/components/app-logo';
 import { NavFooter } from '@/components/nav-footer';
 import { NavMain } from '@/components/nav-main';
@@ -15,6 +21,8 @@ import {
     SidebarMenuItem,
 } from '@/components/ui/sidebar';
 import { dashboard } from '@/routes';
+import { index as partiesIndex } from '@/routes/parties';
+import { index as programsIndex } from '@/routes/programs';
 import type { NavItem } from '@/types';
 
 export function AppSidebar() {
@@ -29,6 +37,24 @@ export function AppSidebar() {
             href: dashboardUrl,
             icon: LayoutGrid,
         },
+        ...(page.props.canViewParties && page.props.currentOrganisation
+            ? [
+                  {
+                      title: 'Party profiles',
+                      href: partiesIndex(page.props.currentOrganisation.slug),
+                      icon: UsersRound,
+                  },
+              ]
+            : []),
+        ...(page.props.canViewPrograms && page.props.currentOrganisation
+            ? [
+                  {
+                      title: 'Program configuration',
+                      href: programsIndex(page.props.currentOrganisation.slug),
+                      icon: Settings2,
+                  },
+              ]
+            : []),
     ];
 
     const footerNavItems: NavItem[] = [

--- a/resources/js/components/ui/textarea.tsx
+++ b/resources/js/components/ui/textarea.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { cn } from '@/lib/utils';
+
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+    return (
+        <textarea
+            data-slot="textarea"
+            className={cn(
+                'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex min-h-24 w-full rounded-md border bg-transparent px-3 py-2 text-sm shadow-xs outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50',
+                className,
+            )}
+            {...props}
+        />
+    );
+}
+
+export { Textarea };

--- a/resources/js/pages/parties/index.tsx
+++ b/resources/js/pages/parties/index.tsx
@@ -1,0 +1,315 @@
+import { Head, Link, router, useForm, usePage } from '@inertiajs/react';
+import { FormEvent } from 'react';
+import Heading from '@/components/heading';
+import InputError from '@/components/input-error';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { index, show, store } from '@/routes/parties';
+
+type Option = { value: string; label: string };
+type Program = { id: number; name: string; slug: string };
+type Party = {
+    uuid: string;
+    kind: string;
+    displayName: string;
+    roles: string[];
+    programs: string[];
+};
+type Props = {
+    parties: {
+        data: Party[];
+        links: { url: string | null; label: string; active: boolean }[];
+    };
+    query: string;
+    canCreate: boolean;
+    programs: Program[];
+    partyKinds: Option[];
+    partyRoles: Option[];
+};
+
+export default function PartiesIndex({
+    parties,
+    query,
+    canCreate,
+    programs,
+    partyKinds,
+    partyRoles,
+}: Props) {
+    const organisation = usePage().props.currentOrganisation!;
+    const form = useForm({
+        kind: partyKinds[0]?.value ?? 'person',
+        display_name: '',
+        email: '',
+        telephone: '',
+        program_ids: [] as number[],
+        roles: [] as string[],
+        interests: '',
+    });
+
+    const submit = (event: FormEvent) => {
+        event.preventDefault();
+        form.transform((data) => ({
+            ...data,
+            interests: data.interests
+                .split(',')
+                .map((value) => value.trim())
+                .filter(Boolean),
+        }));
+        form.post(store.url(organisation.slug), {
+            onSuccess: () => form.reset(),
+        });
+    };
+
+    return (
+        <>
+            <Head title="Party profiles" />
+            <div className="space-y-8 p-4">
+                <Heading
+                    title="Party profiles"
+                    description="Tenant-local people, households, and organisations."
+                />
+                <form
+                    className="flex gap-2"
+                    onSubmit={(event) => {
+                        event.preventDefault();
+                        router.get(
+                            index.url(organisation.slug),
+                            {
+                                query: new FormData(event.currentTarget).get(
+                                    'query',
+                                ),
+                            },
+                            { preserveState: true },
+                        );
+                    }}
+                >
+                    <Input
+                        name="query"
+                        defaultValue={query}
+                        placeholder="Search by name"
+                    />
+                    <Button type="submit" variant="outline">
+                        Search
+                    </Button>
+                </form>
+                {canCreate ? (
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Create profile</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <form
+                                onSubmit={submit}
+                                className="grid gap-4 md:grid-cols-2"
+                            >
+                                <div>
+                                    <Label htmlFor="display_name">
+                                        Display name
+                                    </Label>
+                                    <Input
+                                        id="display_name"
+                                        value={form.data.display_name}
+                                        onChange={(e) =>
+                                            form.setData(
+                                                'display_name',
+                                                e.target.value,
+                                            )
+                                        }
+                                        required
+                                    />
+                                    <InputError
+                                        message={form.errors.display_name}
+                                    />
+                                </div>
+                                <div>
+                                    <Label htmlFor="kind">Party kind</Label>
+                                    <select
+                                        id="kind"
+                                        className="h-9 w-full rounded-md border bg-transparent px-3"
+                                        value={form.data.kind}
+                                        onChange={(e) =>
+                                            form.setData('kind', e.target.value)
+                                        }
+                                    >
+                                        {partyKinds.map((kind) => (
+                                            <option
+                                                key={kind.value}
+                                                value={kind.value}
+                                            >
+                                                {kind.label}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                                <div>
+                                    <Label htmlFor="email">Email</Label>
+                                    <Input
+                                        id="email"
+                                        type="email"
+                                        value={form.data.email}
+                                        onChange={(e) =>
+                                            form.setData(
+                                                'email',
+                                                e.target.value,
+                                            )
+                                        }
+                                    />
+                                </div>
+                                <div>
+                                    <Label htmlFor="telephone">Telephone</Label>
+                                    <Input
+                                        id="telephone"
+                                        value={form.data.telephone}
+                                        onChange={(e) =>
+                                            form.setData(
+                                                'telephone',
+                                                e.target.value,
+                                            )
+                                        }
+                                    />
+                                </div>
+                                <fieldset>
+                                    <legend className="text-sm font-medium">
+                                        Programs
+                                    </legend>
+                                    {programs.map((program) => (
+                                        <label
+                                            key={program.id}
+                                            className="mt-2 flex gap-2 text-sm"
+                                        >
+                                            <input
+                                                type="checkbox"
+                                                checked={form.data.program_ids.includes(
+                                                    program.id,
+                                                )}
+                                                onChange={(e) =>
+                                                    form.setData(
+                                                        'program_ids',
+                                                        e.target.checked
+                                                            ? [
+                                                                  ...form.data
+                                                                      .program_ids,
+                                                                  program.id,
+                                                              ]
+                                                            : form.data.program_ids.filter(
+                                                                  (id) =>
+                                                                      id !==
+                                                                      program.id,
+                                                              ),
+                                                    )
+                                                }
+                                            />
+                                            {program.name}
+                                        </label>
+                                    ))}
+                                </fieldset>
+                                <fieldset>
+                                    <legend className="text-sm font-medium">
+                                        Business roles
+                                    </legend>
+                                    {partyRoles.map((role) => (
+                                        <label
+                                            key={role.value}
+                                            className="mt-2 flex gap-2 text-sm"
+                                        >
+                                            <input
+                                                type="checkbox"
+                                                checked={form.data.roles.includes(
+                                                    role.value,
+                                                )}
+                                                onChange={(e) =>
+                                                    form.setData(
+                                                        'roles',
+                                                        e.target.checked
+                                                            ? [
+                                                                  ...form.data
+                                                                      .roles,
+                                                                  role.value,
+                                                              ]
+                                                            : form.data.roles.filter(
+                                                                  (value) =>
+                                                                      value !==
+                                                                      role.value,
+                                                              ),
+                                                    )
+                                                }
+                                            />
+                                            {role.label}
+                                        </label>
+                                    ))}
+                                </fieldset>
+                                <div className="md:col-span-2">
+                                    <Label htmlFor="interests">
+                                        Interests (comma separated)
+                                    </Label>
+                                    <Input
+                                        id="interests"
+                                        value={form.data.interests}
+                                        onChange={(e) =>
+                                            form.setData(
+                                                'interests',
+                                                e.target.value,
+                                            )
+                                        }
+                                    />
+                                    <InputError
+                                        message={form.errors.interests}
+                                    />
+                                </div>
+                                <Button
+                                    type="submit"
+                                    disabled={form.processing}
+                                >
+                                    Create profile
+                                </Button>
+                            </form>
+                        </CardContent>
+                    </Card>
+                ) : null}
+                <div className="space-y-3">
+                    {parties.data.map((party) => (
+                        <Link
+                            key={party.uuid}
+                            href={show.url([organisation.slug, party.uuid])}
+                            className="hover:bg-muted/50 block rounded-lg border p-4"
+                        >
+                            <div className="flex items-center justify-between">
+                                <strong>{party.displayName}</strong>
+                                <Badge variant="outline">{party.kind}</Badge>
+                            </div>
+                            <p className="text-muted-foreground mt-2 text-sm">
+                                {[...party.roles, ...party.programs].join(
+                                    ' · ',
+                                ) || 'No roles or programs assigned'}
+                            </p>
+                        </Link>
+                    ))}
+                </div>
+                <nav className="flex flex-wrap gap-2">
+                    {parties.links.map((link) => (
+                        <Button
+                            key={link.label}
+                            variant={link.active ? 'default' : 'outline'}
+                            size="sm"
+                            disabled={!link.url}
+                            onClick={() => link.url && router.visit(link.url)}
+                            dangerouslySetInnerHTML={{ __html: link.label }}
+                        />
+                    ))}
+                </nav>
+            </div>
+        </>
+    );
+}
+
+PartiesIndex.layout = (props: { currentOrganisation: { slug: string } }) => ({
+    breadcrumbs: [
+        {
+            title: 'Party profiles',
+            href: index(props.currentOrganisation.slug),
+        },
+    ],
+});

--- a/resources/js/pages/parties/show.tsx
+++ b/resources/js/pages/parties/show.tsx
@@ -1,0 +1,556 @@
+import { Form, Head, Link, usePage } from '@inertiajs/react';
+import Heading from '@/components/heading';
+import InputError from '@/components/input-error';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { index, update } from '@/routes/parties';
+import { store as storeAddress } from '@/routes/parties/addresses';
+import { store as storeConsent } from '@/routes/parties/consents';
+import { store as storeRelationship } from '@/routes/parties/relationships';
+import { store as storeSafeContact } from '@/routes/parties/safe-contact-instructions';
+
+type Program = { id: number; name: string };
+type Option = { value: string; label: string };
+type Props = {
+    party: any;
+    canUpdate: boolean;
+    canRecordConsent: boolean;
+    canManageSafeContact: boolean;
+    programs: Program[];
+    partyKinds: Option[];
+    partyRoles: Option[];
+    relationshipCandidates: { id: number; uuid: string; displayName: string }[];
+};
+const nowLocal = () =>
+    new Date(Date.now() - new Date().getTimezoneOffset() * 60000)
+        .toISOString()
+        .slice(0, 16);
+const formArray = (value: unknown): string[] =>
+    Array.isArray(value)
+        ? value.map(String)
+        : typeof value === 'string' && value !== ''
+          ? [value]
+          : [];
+const commaArray = (value: unknown): string[] =>
+    typeof value === 'string'
+        ? value
+              .split(',')
+              .map((item) => item.trim())
+              .filter(Boolean)
+        : formArray(value);
+
+export default function PartyShow({
+    party,
+    canUpdate,
+    canRecordConsent,
+    canManageSafeContact,
+    programs,
+    partyKinds,
+    partyRoles,
+    relationshipCandidates,
+}: Props) {
+    const organisation = usePage().props.currentOrganisation!;
+    const args = [organisation.slug, party.uuid] as [string, string];
+    return (
+        <>
+            <Head title={party.displayName} />
+            <div className="space-y-8 p-4">
+                <div>
+                    <Link
+                        className="text-muted-foreground text-sm"
+                        href={index.url(organisation.slug)}
+                    >
+                        ← Party profiles
+                    </Link>
+                    <Heading
+                        title={party.displayName}
+                        description={`${party.kind} profile`}
+                    />
+                </div>
+                <div className="grid gap-6 lg:grid-cols-2">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Profile summary</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-3 text-sm">
+                            <div className="flex flex-wrap gap-2">
+                                {party.roles.map((role: string) => (
+                                    <Badge key={role}>{role}</Badge>
+                                ))}
+                                {party.interests.map((interest: string) => (
+                                    <Badge key={interest} variant="outline">
+                                        {interest}
+                                    </Badge>
+                                ))}
+                            </div>
+                            <p>
+                                {programs
+                                    .filter((program) =>
+                                        party.programIds.includes(program.id),
+                                    )
+                                    .map((program) => program.name)
+                                    .join(' · ') || 'No programs assigned'}
+                            </p>
+                            {party.email ? <p>{party.email}</p> : null}
+                            {party.telephone ? <p>{party.telephone}</p> : null}
+                        </CardContent>
+                    </Card>
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Addresses and relationships</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-3 text-sm">
+                            {party.addresses.map((address: any) => (
+                                <div key={address.id}>
+                                    <strong>{address.label}</strong>
+                                    <p>{address.address}</p>
+                                    <p className="text-muted-foreground text-xs">
+                                        {[
+                                            address.serviceArea,
+                                            address.countryCode,
+                                        ]
+                                            .filter(Boolean)
+                                            .join(' · ')}
+                                    </p>
+                                </div>
+                            ))}
+                            {party.relationships.map((relationship: any) => (
+                                <div key={relationship.id}>
+                                    <strong>
+                                        {relationship.relatedParty.displayName}
+                                    </strong>{' '}
+                                    <span className="text-muted-foreground">
+                                        {relationship.type.replaceAll('_', ' ')}
+                                    </span>
+                                </div>
+                            ))}
+                            {party.addresses.length === 0 &&
+                            party.relationships.length === 0 ? (
+                                <p className="text-muted-foreground">
+                                    No addresses or relationships recorded.
+                                </p>
+                            ) : null}
+                        </CardContent>
+                    </Card>
+                </div>
+                {canUpdate ? (
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Profile</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <Form
+                                {...update.form(args)}
+                                transform={(data) => ({
+                                    ...data,
+                                    program_ids: formArray(data.program_ids),
+                                    roles: formArray(data.roles),
+                                    interests: commaArray(data.interests),
+                                })}
+                                className="grid gap-4 md:grid-cols-2"
+                            >
+                                {({ errors, processing }) => (
+                                    <>
+                                        <div>
+                                            <Label htmlFor="display_name">
+                                                Display name
+                                            </Label>
+                                            <Input
+                                                id="display_name"
+                                                name="display_name"
+                                                defaultValue={party.displayName}
+                                                required
+                                            />
+                                            <InputError
+                                                message={errors.display_name}
+                                            />
+                                        </div>
+                                        <div>
+                                            <Label htmlFor="kind">Kind</Label>
+                                            <select
+                                                id="kind"
+                                                name="kind"
+                                                defaultValue={party.kind}
+                                                className="h-9 w-full rounded-md border bg-transparent px-3"
+                                            >
+                                                {partyKinds.map((kind) => (
+                                                    <option
+                                                        key={kind.value}
+                                                        value={kind.value}
+                                                    >
+                                                        {kind.label}
+                                                    </option>
+                                                ))}
+                                            </select>
+                                        </div>
+                                        <div>
+                                            <Label htmlFor="email">Email</Label>
+                                            <Input
+                                                id="email"
+                                                name="email"
+                                                type="email"
+                                                defaultValue={party.email ?? ''}
+                                            />
+                                        </div>
+                                        <div>
+                                            <Label htmlFor="telephone">
+                                                Telephone
+                                            </Label>
+                                            <Input
+                                                id="telephone"
+                                                name="telephone"
+                                                defaultValue={
+                                                    party.telephone ?? ''
+                                                }
+                                            />
+                                        </div>
+                                        <fieldset>
+                                            <legend className="text-sm font-medium">
+                                                Programs
+                                            </legend>
+                                            {programs.map((program) => (
+                                                <label
+                                                    key={program.id}
+                                                    className="mt-2 flex gap-2 text-sm"
+                                                >
+                                                    <input
+                                                        type="checkbox"
+                                                        name="program_ids[]"
+                                                        value={program.id}
+                                                        defaultChecked={party.programIds.includes(
+                                                            program.id,
+                                                        )}
+                                                    />
+                                                    {program.name}
+                                                </label>
+                                            ))}
+                                        </fieldset>
+                                        <fieldset>
+                                            <legend className="text-sm font-medium">
+                                                Business roles
+                                            </legend>
+                                            {partyRoles.map((role) => (
+                                                <label
+                                                    key={role.value}
+                                                    className="mt-2 flex gap-2 text-sm"
+                                                >
+                                                    <input
+                                                        type="checkbox"
+                                                        name="roles[]"
+                                                        value={role.value}
+                                                        defaultChecked={party.roles.includes(
+                                                            role.value,
+                                                        )}
+                                                    />
+                                                    {role.label}
+                                                </label>
+                                            ))}
+                                        </fieldset>
+                                        <div className="md:col-span-2">
+                                            <Label htmlFor="interests">
+                                                Interests (comma separated)
+                                            </Label>
+                                            <Input
+                                                id="interests"
+                                                name="interests"
+                                                defaultValue={party.interests.join(
+                                                    ', ',
+                                                )}
+                                            />
+                                            <InputError
+                                                message={errors.interests}
+                                            />
+                                        </div>
+                                        <Button
+                                            type="submit"
+                                            disabled={processing}
+                                        >
+                                            Save profile
+                                        </Button>
+                                    </>
+                                )}
+                            </Form>
+                        </CardContent>
+                    </Card>
+                ) : null}
+                <div className="grid gap-6 lg:grid-cols-2">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Consent history</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-3">
+                            {party.consents.map((consent: any) => (
+                                <div
+                                    key={consent.id}
+                                    className="rounded border p-3"
+                                >
+                                    <div className="flex gap-2">
+                                        <Badge>{consent.purpose}</Badge>
+                                        <Badge variant="outline">
+                                            {consent.decision}
+                                        </Badge>
+                                    </div>
+                                    <p className="mt-2 text-sm">
+                                        {consent.wording}
+                                    </p>
+                                    <p className="text-muted-foreground text-xs">
+                                        {consent.wordingVersion} ·{' '}
+                                        {consent.source} ·{' '}
+                                        {new Date(
+                                            consent.occurredAt,
+                                        ).toLocaleString()}
+                                    </p>
+                                </div>
+                            ))}
+                        </CardContent>
+                    </Card>
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Timeline</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-3">
+                            {party.timeline.map((event: any) => (
+                                <div key={event.id} className="border-l-2 pl-3">
+                                    <p className="text-sm font-medium">
+                                        {event.summary}
+                                    </p>
+                                    <p className="text-muted-foreground text-xs">
+                                        {new Date(
+                                            event.occurredAt,
+                                        ).toLocaleString()}
+                                    </p>
+                                </div>
+                            ))}
+                        </CardContent>
+                    </Card>
+                </div>
+                {canRecordConsent ? (
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Record consent decision</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <Form
+                                {...storeConsent.form(args)}
+                                className="grid gap-4 md:grid-cols-2"
+                            >
+                                {({ errors, processing }) => (
+                                    <>
+                                        <select
+                                            name="purpose"
+                                            className="h-9 rounded-md border bg-transparent px-3"
+                                        >
+                                            <option value="service">
+                                                Service
+                                            </option>
+                                            <option value="referral">
+                                                Referral
+                                            </option>
+                                            <option value="safe_contact">
+                                                Safe contact
+                                            </option>
+                                        </select>
+                                        <select
+                                            name="decision"
+                                            className="h-9 rounded-md border bg-transparent px-3"
+                                        >
+                                            <option value="granted">
+                                                Granted
+                                            </option>
+                                            <option value="withdrawn">
+                                                Withdrawn
+                                            </option>
+                                        </select>
+                                        <Input
+                                            name="wording_version"
+                                            placeholder="Wording version"
+                                            required
+                                        />
+                                        <Input
+                                            name="source"
+                                            placeholder="Source"
+                                            required
+                                        />
+                                        <Textarea
+                                            name="wording"
+                                            placeholder="Exact consent wording"
+                                            required
+                                        />
+                                        <Input
+                                            name="occurred_at"
+                                            type="datetime-local"
+                                            defaultValue={nowLocal()}
+                                            required
+                                        />
+                                        <InputError message={errors.decision} />
+                                        <Button
+                                            type="submit"
+                                            disabled={processing}
+                                        >
+                                            Record immutable decision
+                                        </Button>
+                                    </>
+                                )}
+                            </Form>
+                        </CardContent>
+                    </Card>
+                ) : null}
+                {canUpdate ? (
+                    <div className="grid gap-6 lg:grid-cols-2">
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Add address</CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <Form
+                                    {...storeAddress.form(args)}
+                                    className="space-y-3"
+                                >
+                                    {({ processing }) => (
+                                        <>
+                                            <Input
+                                                name="label"
+                                                placeholder="Label"
+                                                required
+                                            />
+                                            <Textarea
+                                                name="address"
+                                                placeholder="Address"
+                                                required
+                                            />
+                                            <Input
+                                                name="service_area"
+                                                placeholder="Service area"
+                                            />
+                                            <Input
+                                                name="country_code"
+                                                placeholder="Country code"
+                                                maxLength={2}
+                                                required
+                                            />
+                                            <Button disabled={processing}>
+                                                Add address
+                                            </Button>
+                                        </>
+                                    )}
+                                </Form>
+                            </CardContent>
+                        </Card>
+                        <Card>
+                            <CardHeader>
+                                <CardTitle>Add relationship</CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <Form
+                                    {...storeRelationship.form(args)}
+                                    className="space-y-3"
+                                >
+                                    {({ processing }) => (
+                                        <>
+                                            <select
+                                                name="related_party_id"
+                                                className="h-9 w-full rounded-md border bg-transparent px-3"
+                                            >
+                                                {relationshipCandidates.map(
+                                                    (candidate) => (
+                                                        <option
+                                                            key={candidate.id}
+                                                            value={candidate.id}
+                                                        >
+                                                            {
+                                                                candidate.displayName
+                                                            }
+                                                        </option>
+                                                    ),
+                                                )}
+                                            </select>
+                                            <Input
+                                                name="type"
+                                                placeholder="relationship_type"
+                                                required
+                                            />
+                                            <Input
+                                                name="started_at"
+                                                type="datetime-local"
+                                            />
+                                            <Button disabled={processing}>
+                                                Add relationship
+                                            </Button>
+                                        </>
+                                    )}
+                                </Form>
+                            </CardContent>
+                        </Card>
+                    </div>
+                ) : null}
+                {canManageSafeContact ? (
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Safe-contact instructions</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            {party.safeContactInstructions.map(
+                                (instruction: any) => (
+                                    <div
+                                        key={instruction.id}
+                                        className="rounded border p-3 text-sm"
+                                    >
+                                        {instruction.instruction}
+                                        <p className="text-muted-foreground text-xs">
+                                            {instruction.source}
+                                        </p>
+                                    </div>
+                                ),
+                            )}
+                            <Form
+                                {...storeSafeContact.form(args)}
+                                className="space-y-3"
+                            >
+                                {({ processing }) => (
+                                    <>
+                                        <Textarea
+                                            name="instruction"
+                                            placeholder="Restricted contact instructions"
+                                            required
+                                        />
+                                        <Input
+                                            name="source"
+                                            placeholder="Source"
+                                            required
+                                        />
+                                        <Input
+                                            name="effective_at"
+                                            type="datetime-local"
+                                            defaultValue={nowLocal()}
+                                            required
+                                        />
+                                        <Button disabled={processing}>
+                                            Record instruction
+                                        </Button>
+                                    </>
+                                )}
+                            </Form>
+                        </CardContent>
+                    </Card>
+                ) : null}
+            </div>
+        </>
+    );
+}
+
+PartyShow.layout = (props: {
+    currentOrganisation: { slug: string };
+    party: { uuid: string; displayName: string };
+}) => ({
+    breadcrumbs: [
+        {
+            title: 'Party profiles',
+            href: index(props.currentOrganisation.slug),
+        },
+        { title: props.party.displayName, href: '#' },
+    ],
+});

--- a/resources/js/pages/programs/index.tsx
+++ b/resources/js/pages/programs/index.tsx
@@ -1,0 +1,125 @@
+import { Head, router, usePage } from '@inertiajs/react';
+import { useState } from 'react';
+import Heading from '@/components/heading';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { index } from '@/routes/programs';
+import { update } from '@/routes/organisations/programs';
+
+type Program = {
+    id: number;
+    name: string;
+    slug: string;
+    configuration: Record<string, unknown>;
+    canUpdate: boolean;
+};
+
+function ProgramEditor({
+    program,
+    organisation,
+}: {
+    program: Program;
+    organisation: string;
+}) {
+    const [name, setName] = useState(program.name);
+    const [slug, setSlug] = useState(program.slug);
+    const [configuration, setConfiguration] = useState(
+        JSON.stringify(program.configuration ?? {}, null, 2),
+    );
+    const [error, setError] = useState('');
+    const save = () => {
+        try {
+            const parsed = JSON.parse(configuration);
+            setError('');
+            router.patch(update.url([organisation, program.slug]), {
+                name,
+                slug,
+                configuration: parsed,
+            });
+        } catch {
+            setError('Configuration must be valid JSON.');
+        }
+    };
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>{program.name}</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+                <div>
+                    <Label>Name</Label>
+                    <Input
+                        value={name}
+                        onChange={(event) => setName(event.target.value)}
+                        disabled={!program.canUpdate}
+                    />
+                </div>
+                <div>
+                    <Label>Slug</Label>
+                    <Input
+                        value={slug}
+                        onChange={(event) => setSlug(event.target.value)}
+                        disabled={!program.canUpdate}
+                    />
+                </div>
+                <div>
+                    <Label>
+                        Labels, stages, outcome measures and taxonomies
+                    </Label>
+                    <Textarea
+                        className="min-h-72 font-mono text-xs"
+                        value={configuration}
+                        onChange={(event) =>
+                            setConfiguration(event.target.value)
+                        }
+                        disabled={!program.canUpdate}
+                    />
+                    <p className="text-muted-foreground mt-1 text-xs">
+                        Structured JSON is validated before it is saved.
+                    </p>
+                    {error ? (
+                        <p className="text-destructive text-sm">{error}</p>
+                    ) : null}
+                </div>
+                {program.canUpdate ? (
+                    <Button onClick={save}>Save configuration</Button>
+                ) : null}
+            </CardContent>
+        </Card>
+    );
+}
+
+export default function ProgramsIndex({ programs }: { programs: Program[] }) {
+    const organisation = usePage().props.currentOrganisation!;
+    return (
+        <>
+            <Head title="Program configuration" />
+            <div className="space-y-6 p-4">
+                <Heading
+                    title="Program configuration"
+                    description="Change operational language, stages, measures, and taxonomies without a deployment."
+                />
+                <div className="grid gap-6 xl:grid-cols-2">
+                    {programs.map((program) => (
+                        <ProgramEditor
+                            key={program.id}
+                            program={program}
+                            organisation={organisation.slug}
+                        />
+                    ))}
+                </div>
+            </div>
+        </>
+    );
+}
+ProgramsIndex.layout = (props: { currentOrganisation: { slug: string } }) => ({
+    breadcrumbs: [
+        {
+            title: 'Program configuration',
+            href: index(props.currentOrganisation.slug),
+        },
+    ],
+});

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -14,6 +14,8 @@ declare module '@inertiajs/core' {
             auth: Auth;
             sidebarOpen: boolean;
             canCreateOrganisation: boolean;
+            canViewParties: boolean;
+            canViewPrograms: boolean;
             currentOrganisation: Organisation | null;
             organisations: Organisation[];
             [key: string]: unknown;

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,12 @@
 
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Organisations\OrganisationInvitationController;
+use App\Http\Controllers\Organisations\PartyAddressController;
+use App\Http\Controllers\Organisations\PartyConsentController;
+use App\Http\Controllers\Organisations\PartyController;
+use App\Http\Controllers\Organisations\PartyRelationshipController;
+use App\Http\Controllers\Organisations\PartySafeContactInstructionController;
+use App\Http\Controllers\Organisations\ProgramController;
 use App\Http\Controllers\Public\OrganisationController as PublicOrganisationController;
 use App\Http\Middleware\EnsureOrganisationAccess;
 use App\Http\Middleware\EnsureOrganisationMembership;
@@ -68,6 +74,12 @@ Route::prefix('{current_organisation}')
     ->middleware(['auth', 'verified', EnsureStaffSecurityRequirements::class, EnsureOrganisationMembership::class, UseOrganisationContext::class, EnsureOrganisationAccess::class.':full'])
     ->group(function () {
         Route::get('dashboard', DashboardController::class)->name('dashboard');
+        Route::get('programs', [ProgramController::class, 'index'])->name('programs.index');
+        Route::resource('parties', PartyController::class)->only(['index', 'store', 'show', 'update']);
+        Route::post('parties/{party}/consents', [PartyConsentController::class, 'store'])->name('parties.consents.store');
+        Route::post('parties/{party}/addresses', [PartyAddressController::class, 'store'])->name('parties.addresses.store');
+        Route::post('parties/{party}/relationships', [PartyRelationshipController::class, 'store'])->name('parties.relationships.store');
+        Route::post('parties/{party}/safe-contact-instructions', [PartySafeContactInstructionController::class, 'store'])->name('parties.safe-contact-instructions.store');
     });
 
 Route::middleware(['auth', 'verified'])->group(function () {

--- a/tests/Feature/PartyProfileTest.php
+++ b/tests/Feature/PartyProfileTest.php
@@ -1,0 +1,171 @@
+<?php
+
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use App\Enums\OrganisationRole;
+use App\Enums\PartyBusinessRole;
+use App\Enums\PartyKind;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\PartyConsent;
+use App\Models\PartyRole;
+use App\Models\PartySafeContactInstruction;
+use App\Models\Program;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+
+function partyProfileFixture(OrganisationRole $role = OrganisationRole::OrganisationAdministrator): array
+{
+    $user = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    $membership = $organisation->memberships()->create(['user_id' => $user->id, 'role' => $role]);
+    $program = app(OrganisationContext::class)->run(
+        $organisation,
+        fn (): Program => Program::factory()->for($organisation)->create(),
+    );
+
+    if ($role === OrganisationRole::ProgramManager) {
+        app(OrganisationContext::class)->run($organisation, fn () => $membership->programs()->attach($program));
+    }
+
+    return compact('user', 'organisation', 'membership', 'program');
+}
+
+it('creates a tenant-local Party profile with separate roles programs interests and encrypted contacts', function () {
+    extract(partyProfileFixture());
+
+    $response = $this->actingAs($user)->post(route('parties.store', $organisation), [
+        'kind' => PartyKind::Person->value,
+        'display_name' => 'Amina Example',
+        'email' => 'amina@example.test',
+        'telephone' => '+1 202-555-0199',
+        'program_ids' => [$program->id],
+        'roles' => [PartyBusinessRole::Client->value, PartyBusinessRole::Volunteer->value],
+        'interests' => ['Housing', 'Food security'],
+    ]);
+
+    $party = app(OrganisationContext::class)->run(
+        $organisation,
+        fn (): Party => Party::query()->where('display_name', 'Amina Example')->firstOrFail(),
+    );
+    $response->assertRedirect(route('parties.show', [$organisation, $party]));
+
+    app(OrganisationContext::class)->run($organisation, function () use ($party, $program): void {
+        expect($party->businessRoles()->get()->map(fn (PartyRole $role): string => $role->role->value)->all())->toEqualCanonicalizing(['client', 'volunteer'])
+            ->and($party->programs()->pluck('programs.id')->all())->toBe([$program->id])
+            ->and($party->interests()->pluck('label')->all())->toEqualCanonicalizing(['Housing', 'Food security'])
+            ->and($party->timelineEvents()->pluck('summary')->all())->toBe(['Profile created']);
+    });
+
+    expect(DB::table('party_contact_points')->where('party_id', $party->id)->pluck('encrypted_value')->implode(' '))
+        ->not->toContain('amina@example.test')
+        ->not->toContain('202-555-0199');
+});
+
+it('preserves immutable consent grant and withdrawal history with exact provenance', function () {
+    extract(partyProfileFixture());
+    $party = app(OrganisationContext::class)->run($organisation, fn (): Party => Party::factory()->for($organisation)->create());
+    $base = [
+        'purpose' => ConsentPurpose::Referral->value,
+        'wording_version' => 'referral-v2',
+        'wording' => 'I agree that my details may be shared with the named partner.',
+        'source' => 'signed_form',
+        'occurred_at' => now()->subMinute()->toAtomString(),
+    ];
+
+    $this->actingAs($user)->post(route('parties.consents.store', [$organisation, $party]), [...$base, 'decision' => ConsentDecision::Granted->value])->assertRedirect();
+    $this->actingAs($user)->post(route('parties.consents.store', [$organisation, $party]), [...$base, 'decision' => ConsentDecision::Withdrawn->value, 'occurred_at' => now()->toAtomString()])->assertRedirect();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($party): void {
+        $history = PartyConsent::query()->where('party_id', $party->id)->oldest('occurred_at')->get();
+        expect($history)->toHaveCount(2)
+            ->and($history[1]->supersedes_id)->toBe($history[0]->id)
+            ->and($history[0]->wording)->toBe($history[1]->wording)
+            ->and(fn () => $history[0]->update(['source' => 'changed']))->toThrow(LogicException::class);
+    });
+});
+
+it('limits Party safe-contact content to assigned Program managers', function () {
+    extract(partyProfileFixture(OrganisationRole::ProgramManager));
+    $administrator = User::factory()->create();
+    $organisation->memberships()->create(['user_id' => $administrator->id, 'role' => OrganisationRole::OrganisationAdministrator]);
+    $party = app(OrganisationContext::class)->run($organisation, function () use ($organisation, $program): Party {
+        $party = Party::factory()->for($organisation)->create();
+        $party->programs()->attach($program);
+
+        return $party;
+    });
+
+    $this->actingAs($user)->post(route('parties.safe-contact-instructions.store', [$organisation, $party]), [
+        'instruction' => 'Never leave a voicemail.',
+        'source' => 'participant',
+        'effective_at' => now()->toAtomString(),
+    ])->assertRedirect();
+    $this->actingAs($administrator)->post(route('parties.safe-contact-instructions.store', [$organisation, $party]), [
+        'instruction' => 'Unsafe admin access',
+        'source' => 'admin',
+        'effective_at' => now()->toAtomString(),
+    ])->assertForbidden();
+
+    expect(DB::table('party_safe_contact_instructions')->value('encrypted_value'))->not->toContain('Never leave a voicemail');
+    app(OrganisationContext::class)->run($organisation, fn () => expect(PartySafeContactInstruction::query()->count())->toBe(1));
+});
+
+it('lets an Organisation-wide Program manager open an unassigned Party', function () {
+    extract(partyProfileFixture(OrganisationRole::ProgramManager));
+    $party = app(OrganisationContext::class)->run($organisation, fn (): Party => Party::factory()->for($organisation)->create());
+
+    $this->actingAs($user)
+        ->get(route('parties.show', [$organisation, $party]))
+        ->assertOk()
+        ->assertInertia(fn ($page) => $page->where('party.uuid', $party->uuid));
+});
+
+it('enforces consent history immutability and tenant-local supersession in the database', function () {
+    extract(partyProfileFixture());
+    $party = app(OrganisationContext::class)->run($organisation, fn (): Party => Party::factory()->for($organisation)->create());
+    $consent = app(OrganisationContext::class)->run($organisation, fn (): PartyConsent => PartyConsent::factory()->for($party)->create());
+    $otherOrganisation = Organisation::factory()->active()->create();
+    $otherParty = app(OrganisationContext::class)->run($otherOrganisation, fn (): Party => Party::factory()->for($otherOrganisation)->create());
+
+    expect(fn () => DB::table('party_consents')->where('id', $consent->id)->update(['source' => 'changed']))
+        ->toThrow(QueryException::class)
+        ->and(fn () => DB::table('party_consents')->insert([
+            'id' => (string) str()->ulid(),
+            'organisation_id' => $otherOrganisation->id,
+            'party_id' => $otherParty->id,
+            'purpose' => ConsentPurpose::Service->value,
+            'decision' => ConsentDecision::Withdrawn->value,
+            'wording_version' => 'v1',
+            'wording' => 'Wording',
+            'source' => 'test',
+            'occurred_at' => now(),
+            'supersedes_id' => $consent->id,
+        ]))->toThrow(QueryException::class);
+});
+
+it('returns not found for another tenant Party and rejects cross-tenant pivots', function () {
+    extract(partyProfileFixture());
+    $otherOrganisation = Organisation::factory()->active()->create();
+    $otherParty = app(OrganisationContext::class)->run($otherOrganisation, fn (): Party => Party::factory()->for($otherOrganisation)->create());
+
+    $this->actingAs($user)->get(route('parties.show', [$organisation, $otherParty]))->assertNotFound();
+
+    expect(fn () => DB::table('party_program')->insert([
+        'organisation_id' => $organisation->id,
+        'party_id' => $otherParty->id,
+        'program_id' => $program->id,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]))->toThrow(QueryException::class);
+});
+
+it('does not grant Party access through ownership alone', function () {
+    $owner = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    $organisation->memberships()->create(['user_id' => $owner->id, 'is_owner' => true]);
+
+    $this->actingAs($owner)->get(route('parties.index', $organisation))->assertForbidden();
+});

--- a/tests/Feature/ProgramConfigurationTest.php
+++ b/tests/Feature/ProgramConfigurationTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\Program;
+use App\Models\User;
+use App\OrganisationContext;
+use Inertia\Testing\AssertableInertia as Assert;
+
+it('lets an administrator change validated Program terminology and measurement configuration without code', function () {
+    $administrator = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    $organisation->memberships()->create(['user_id' => $administrator->id, 'role' => OrganisationRole::OrganisationAdministrator]);
+    $program = app(OrganisationContext::class)->run($organisation, fn (): Program => Program::factory()->for($organisation)->create());
+    $configuration = [
+        'labels' => ['request' => 'Support request', 'case' => 'Support journey'],
+        'stages' => [['key' => 'received', 'label' => 'Received'], ['key' => 'active', 'label' => 'Active']],
+        'outcome_measures' => [['key' => 'housing_stability', 'label' => 'Housing stability', 'unit' => 'score']],
+        'taxonomies' => [['key' => 'need', 'label' => 'Presenting need', 'values' => ['Housing', 'Food']]],
+    ];
+
+    $this->actingAs($administrator)
+        ->patchJson(route('organisations.programs.update', [$organisation, $program]), [
+            'name' => $program->name,
+            'slug' => $program->slug,
+            'configuration' => $configuration,
+        ])
+        ->assertOk()
+        ->assertJsonPath('configuration.labels.case', 'Support journey');
+
+    app(OrganisationContext::class)->run($organisation, fn () => expect($program->refresh()->configuration)->toBe($configuration));
+
+    $this->actingAs($administrator)
+        ->get(route('programs.index', $organisation))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('programs/index')
+            ->where('programs.0.configuration.labels.case', 'Support journey')
+            ->where('programs.0.canUpdate', true));
+});
+
+it('rejects malformed Program configuration', function () {
+    $administrator = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    $organisation->memberships()->create(['user_id' => $administrator->id, 'role' => OrganisationRole::OrganisationAdministrator]);
+    $program = app(OrganisationContext::class)->run($organisation, fn (): Program => Program::factory()->for($organisation)->create());
+
+    $this->actingAs($administrator)
+        ->patchJson(route('organisations.programs.update', [$organisation, $program]), [
+            'name' => $program->name,
+            'slug' => $program->slug,
+            'configuration' => [
+                'labels' => ['request' => 'Request', 'case' => 'Case'],
+                'stages' => [['key' => 'Not valid', 'label' => 'Invalid']],
+                'outcome_measures' => [],
+                'taxonomies' => [],
+            ],
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('configuration.stages.0.key');
+});


### PR DESCRIPTION
## Summary
- add tenant-local Party profiles with business roles, Program assignments, interests, encrypted contacts and addresses, relationships, and timelines
- preserve service, referral, and safe-contact consent history with database-enforced immutability and tenant-local supersession
- keep safe-contact instructions separately encrypted and restricted to assigned Program Managers
- add validated, editable Program labels, stages, outcome measures, and taxonomies
- extend deterministic HarbourKind and NeighbourLink scenarios with configured Programs and visible profile examples

## Review
Reviewed against `codex/issue-9-deterministic-scenarios`. Fixed Organisation-wide Program Manager access consistency, cross-tenant consent supersession, database-level history immutability, and missing profile summary/edit controls. No further actionable findings.

## Verification
- `composer ci:check` (267 tests, 1,109 assertions)
- `npm test`
- `npm run build`
- local PostgreSQL migration and deterministic scenario seed

Stacked on #50.

Closes #10