### PR TITLE
Accept, triage, and assign a service request

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ php artisan config:clear
 php artisan db:seed
 ```
 
-Scenario catalog version `2026.1` uses the fixed reporting instant
+Scenario catalog version `2026.2` uses the fixed reporting instant
 `2026-06-30 23:59:59` in each Organisation's local timezone: HarbourKind uses
 `Africa/Johannesburg` and ZAR, while NeighbourLink uses `Europe/London` and
 GBP. It can be seeded repeatedly without duplicating its records. All demo

--- a/app/Actions/Intake/AssignCaseWorker.php
+++ b/app/Actions/Intake/AssignCaseWorker.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Actions\Intake;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Enums\CaseAssignmentRole;
+use App\Enums\CaseAssignmentStatus;
+use App\Enums\OrganisationRole;
+use App\Enums\TenantAuditEventType;
+use App\Models\CaseAssignment;
+use App\Models\Membership;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class AssignCaseWorker
+{
+    public function __construct(
+        private readonly OrganisationContext $organisationContext,
+        private readonly RecordTenantAuditEvent $recordTenantAuditEvent,
+    ) {}
+
+    public function handle(ServiceCase $case, Membership $worker, User $actor, ?string $reason = null): CaseAssignment
+    {
+        $this->organisationContext->ensureOwns($case->organisation_id);
+        $this->organisationContext->ensureOwns($worker->organisation_id);
+
+        if (! $worker->user->hasOrganisationRole($case->organisation, OrganisationRole::CaseWorker, $case->program)
+            || ! $worker->user->hasProgramAccess($case->program)) {
+            throw new LogicException('The selected worker is not authorised for this Program.');
+        }
+
+        return DB::transaction(function () use ($case, $worker, $actor, $reason): CaseAssignment {
+            $lockedCase = ServiceCase::query()->lockForUpdate()->findOrFail($case->id);
+            $active = CaseAssignment::query()
+                ->where('service_case_id', $lockedCase->id)
+                ->where('role', CaseAssignmentRole::Primary)
+                ->where('status', CaseAssignmentStatus::Active)
+                ->lockForUpdate()
+                ->first();
+
+            if ($active?->membership_id === $worker->id) {
+                return $active;
+            }
+
+            if ($active !== null) {
+                $active->update([
+                    'status' => CaseAssignmentStatus::Ended,
+                    'active_primary_marker' => null,
+                    'ended_at' => now(),
+                    'ended_reason' => $reason,
+                    'ended_by_user_id' => $actor->id,
+                ]);
+            }
+
+            $assignment = CaseAssignment::query()->create([
+                'organisation_id' => $case->organisation_id,
+                'service_case_id' => $lockedCase->id,
+                'membership_id' => $worker->id,
+                'role' => CaseAssignmentRole::Primary,
+                'status' => CaseAssignmentStatus::Active,
+                'active_primary_marker' => true,
+                'started_at' => now(),
+                'assigned_reason' => $reason,
+                'assigned_by_user_id' => $actor->id,
+            ]);
+            $this->recordTenantAuditEvent->handle(
+                $case->organisation,
+                TenantAuditEventType::CaseAssigned,
+                'service_case',
+                $case->id,
+                ['case_id' => $case->id, 'membership_id' => $worker->id],
+                $actor,
+            );
+
+            return $assignment;
+        });
+    }
+}

--- a/app/Actions/Intake/CreateIntakeRequest.php
+++ b/app/Actions/Intake/CreateIntakeRequest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace App\Actions\Intake;
+
+use App\Actions\Parties\FindPartiesByContact;
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\IntakeStatus;
+use App\Enums\PartyContactType;
+use App\Models\IntakeRequest;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\PartyDuplicateReview;
+use App\Models\Program;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+
+class CreateIntakeRequest
+{
+    public function __construct(
+        private readonly OrganisationContext $organisationContext,
+        private readonly ClassifiedDataEncrypter $encrypter,
+        private readonly FindPartiesByContact $findPartiesByContact,
+    ) {}
+
+    /**
+     * @param  array{source: string, narrative: string, presenting_needs: string, intake_fields: array<string, mixed>, eligibility_context: array<string, mixed>, risk_flags: list<string>, email: string|null, telephone: string|null, idempotency_key: string|null, consent_granted: bool, consent_source: string}  $attributes
+     */
+    public function handle(Organisation $organisation, Program $program, Party $party, array $attributes, User $actor): IntakeRequest
+    {
+        $this->organisationContext->ensureOwns($organisation->id);
+        $this->organisationContext->ensureOwns($program->organisation_id);
+        $this->organisationContext->ensureOwns($party->organisation_id);
+
+        try {
+            return DB::transaction(function () use ($organisation, $program, $party, $attributes, $actor): IntakeRequest {
+                if ($attributes['idempotency_key'] !== null) {
+                    $existing = IntakeRequest::query()->where('idempotency_key', $attributes['idempotency_key'])->first();
+
+                    if ($existing !== null) {
+                        return $existing;
+                    }
+                }
+
+                $intake = new IntakeRequest;
+                $intake->forceFill([
+                    'id' => $intake->newUniqueId(),
+                    'organisation_id' => $organisation->id,
+                    'program_id' => $program->id,
+                    'party_id' => $party->id,
+                    'type' => 'content',
+                    'data_key_version' => $this->encrypter->currentVersion(),
+                    'eligibility_context' => $attributes['eligibility_context'],
+                    'risk_flags' => $attributes['risk_flags'],
+                    'status' => IntakeStatus::Draft,
+                    'source' => $attributes['source'],
+                    'idempotency_key' => $attributes['idempotency_key'],
+                    'created_by_user_id' => $actor->id,
+                ]);
+                $intake->encrypted_content = new ClassifiedValue(json_encode([
+                    'narrative' => $attributes['narrative'],
+                    'presenting_needs' => $attributes['presenting_needs'],
+                    'intake_fields' => $attributes['intake_fields'],
+                    'service_consent' => [
+                        'granted' => $attributes['consent_granted'],
+                        'source' => $attributes['consent_source'],
+                        'wording_version' => 'service-intake-v1',
+                        'captured_at' => now()->toAtomString(),
+                    ],
+                ], JSON_THROW_ON_ERROR));
+                $intake->save();
+                $intake->transitions()->create([
+                    'organisation_id' => $organisation->id,
+                    'from_status' => null,
+                    'to_status' => IntakeStatus::Draft,
+                    'effective_at' => now(),
+                    'recorded_at' => now(),
+                    'version' => 1,
+                    'actor_user_id' => $actor->id,
+                ]);
+                $this->recordDuplicateSuggestions($intake, $party, $attributes['email'], $attributes['telephone']);
+
+                return $intake;
+            });
+        } catch (QueryException $exception) {
+            if ($attributes['idempotency_key'] === null) {
+                throw $exception;
+            }
+
+            $existing = IntakeRequest::query()->where('idempotency_key', $attributes['idempotency_key'])->first();
+
+            if ($existing === null) {
+                throw $exception;
+            }
+
+            return $existing;
+        }
+    }
+
+    private function recordDuplicateSuggestions(IntakeRequest $intake, Party $submittedParty, ?string $email, ?string $telephone): void
+    {
+        /** @var array<int, array{candidate: Party, fields: list<string>}> $matches */
+        $matches = [];
+
+        foreach ([PartyContactType::Email->value => $email, PartyContactType::Telephone->value => $telephone] as $typeValue => $value) {
+            if (! is_string($value) || $value === '') {
+                continue;
+            }
+
+            $type = PartyContactType::from($typeValue);
+
+            foreach ($this->findPartiesByContact->handle($type, $value) as $candidate) {
+                if ($candidate->is($submittedParty)) {
+                    continue;
+                }
+
+                $matches[$candidate->id] ??= ['candidate' => $candidate, 'fields' => []];
+                $matches[$candidate->id]['fields'][] = $type->value;
+            }
+        }
+
+        foreach ($matches as $match) {
+            PartyDuplicateReview::query()->create([
+                'organisation_id' => $intake->organisation_id,
+                'intake_request_id' => $intake->id,
+                'submitted_party_id' => $submittedParty->id,
+                'candidate_party_id' => $match['candidate']->id,
+                'matched_fields' => array_values(array_unique($match['fields'])),
+            ]);
+        }
+    }
+}

--- a/app/Actions/Intake/ReversePartyMerge.php
+++ b/app/Actions/Intake/ReversePartyMerge.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Actions\Intake;
+
+use App\Enums\DuplicateReviewDecision;
+use App\Models\IntakeRequest;
+use App\Models\PartyDuplicateReview;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class ReversePartyMerge
+{
+    public function __construct(private readonly OrganisationContext $organisationContext) {}
+
+    public function handle(PartyDuplicateReview $review, User $actor): PartyDuplicateReview
+    {
+        $this->organisationContext->ensureOwns($review->organisation_id);
+
+        return DB::transaction(function () use ($review, $actor): PartyDuplicateReview {
+            $review = PartyDuplicateReview::query()->lockForUpdate()->findOrFail($review->id);
+
+            if ($review->decision !== DuplicateReviewDecision::Merged || $review->reversed_at !== null) {
+                throw new LogicException('Only an active logical Party merge can be reversed.');
+            }
+
+            $intake = IntakeRequest::query()->lockForUpdate()->findOrFail($review->intake_request_id);
+
+            if ($intake->party_id !== $review->canonical_party_id) {
+                throw new LogicException('The intake Party changed after the merge and cannot be reversed automatically.');
+            }
+
+            if ($intake->serviceCase()->exists()) {
+                throw new LogicException('A duplicate decision cannot be reversed after a Case has been created.');
+            }
+
+            $intake->update(['party_id' => $review->submitted_party_id]);
+            $review->forceFill([
+                'reversed_at' => now(),
+                'reversed_by_user_id' => $actor->id,
+            ])->save();
+
+            return $review->refresh();
+        });
+    }
+}

--- a/app/Actions/Intake/ReviewPartyDuplicate.php
+++ b/app/Actions/Intake/ReviewPartyDuplicate.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Actions\Intake;
+
+use App\Enums\DuplicateReviewDecision;
+use App\Models\IntakeRequest;
+use App\Models\PartyDuplicateReview;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class ReviewPartyDuplicate
+{
+    public function __construct(private readonly OrganisationContext $organisationContext) {}
+
+    public function handle(PartyDuplicateReview $review, DuplicateReviewDecision $decision, User $actor): PartyDuplicateReview
+    {
+        $this->organisationContext->ensureOwns($review->organisation_id);
+
+        if (! in_array($decision, [DuplicateReviewDecision::Dismissed, DuplicateReviewDecision::Merged], true)) {
+            throw new LogicException('A duplicate review must be dismissed or merged.');
+        }
+
+        return DB::transaction(function () use ($review, $decision, $actor): PartyDuplicateReview {
+            $review = PartyDuplicateReview::query()->lockForUpdate()->findOrFail($review->id);
+
+            if ($review->decision !== DuplicateReviewDecision::Pending) {
+                return $review;
+            }
+
+            $intake = IntakeRequest::query()->lockForUpdate()->findOrFail($review->intake_request_id);
+
+            if ($intake->serviceCase()->exists()) {
+                throw new LogicException('A duplicate decision cannot change the Party after a Case has been created.');
+            }
+
+            if ($decision === DuplicateReviewDecision::Merged && $intake->party_id !== $review->submitted_party_id) {
+                throw new LogicException('The intake is already linked to a different canonical Party.');
+            }
+
+            $canonicalPartyId = $decision === DuplicateReviewDecision::Merged ? $review->candidate_party_id : null;
+            $review->forceFill([
+                'decision' => $decision,
+                'canonical_party_id' => $canonicalPartyId,
+                'decided_at' => now(),
+                'decided_by_user_id' => $actor->id,
+            ])->save();
+
+            if ($canonicalPartyId !== null) {
+                $intake->update(['party_id' => $canonicalPartyId]);
+            }
+
+            return $review->refresh();
+        });
+    }
+}

--- a/app/Actions/Intake/TransitionIntakeRequest.php
+++ b/app/Actions/Intake/TransitionIntakeRequest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Actions\Intake;
+
+use App\Actions\Parties\RecordPartyConsent;
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use App\Enums\EligibilityStatus;
+use App\Enums\IntakeStatus;
+use App\Enums\IntakeUrgency;
+use App\Enums\ServiceCaseStatus;
+use App\Models\IntakeRequest;
+use App\Models\Membership;
+use App\Models\PartyConsent;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class TransitionIntakeRequest
+{
+    public function __construct(
+        private readonly OrganisationContext $organisationContext,
+        private readonly AssignCaseWorker $assignCaseWorker,
+        private readonly RecordPartyConsent $recordPartyConsent,
+    ) {}
+
+    /** @param array{urgency?: IntakeUrgency, eligibility_status?: EligibilityStatus, eligibility_context?: array<string, mixed>, risk_flags?: list<string>} $triage */
+    public function handle(
+        IntakeRequest $intake,
+        IntakeStatus $to,
+        int $expectedVersion,
+        User $actor,
+        ?string $reason = null,
+        array $triage = [],
+        ?Membership $worker = null,
+    ): IntakeRequest {
+        $this->organisationContext->ensureOwns($intake->organisation_id);
+
+        return DB::transaction(function () use ($intake, $to, $expectedVersion, $actor, $reason, $triage, $worker): IntakeRequest {
+            $locked = IntakeRequest::query()->lockForUpdate()->findOrFail($intake->id);
+
+            if ($locked->status === $to && $to === IntakeStatus::Accepted) {
+                return $locked;
+            }
+
+            if ($locked->version !== $expectedVersion) {
+                throw new LogicException('The intake changed while it was being reviewed.');
+            }
+
+            if (! in_array($to, $locked->status->allowedTransitions(), true)) {
+                throw new LogicException("Cannot transition intake from {$locked->status->value} to {$to->value}.");
+            }
+
+            if (in_array($to, [IntakeStatus::Redirected, IntakeStatus::Declined], true) && blank($reason)) {
+                throw new LogicException('A reason is required for this transition.');
+            }
+
+            if ($to === IntakeStatus::Accepted && ! $this->ensureServiceConsent($locked, $actor)) {
+                throw new LogicException('Service consent must be granted before accepting an intake.');
+            }
+
+            $from = $locked->status;
+            $nextVersion = $locked->version + 1;
+            $locked->forceFill([
+                'status' => $to,
+                'version' => $nextVersion,
+                'urgency' => $triage['urgency'] ?? $locked->urgency,
+                'eligibility_status' => $triage['eligibility_status'] ?? $locked->eligibility_status,
+                'eligibility_context' => $triage['eligibility_context'] ?? $locked->eligibility_context,
+                'risk_flags' => $triage['risk_flags'] ?? $locked->risk_flags,
+            ])->save();
+            $locked->transitions()->create([
+                'organisation_id' => $locked->organisation_id,
+                'from_status' => $from,
+                'to_status' => $to,
+                'reason' => $reason,
+                'effective_at' => now(),
+                'recorded_at' => now(),
+                'version' => $nextVersion,
+                'actor_user_id' => $actor->id,
+            ]);
+
+            if ($to === IntakeStatus::Accepted) {
+                $case = ServiceCase::query()->firstOrCreate(
+                    ['intake_request_id' => $locked->id],
+                    [
+                        'organisation_id' => $locked->organisation_id,
+                        'program_id' => $locked->program_id,
+                        'party_id' => $locked->party_id,
+                        'status' => ServiceCaseStatus::Open,
+                        'confidentiality' => 'confidential',
+                        'opened_at' => now(),
+                        'created_by_user_id' => $actor->id,
+                    ],
+                );
+
+                if ($worker !== null) {
+                    $this->assignCaseWorker->handle($case, $worker, $actor, $reason);
+                }
+            }
+
+            return $locked->refresh();
+        });
+    }
+
+    private function ensureServiceConsent(IntakeRequest $intake, User $actor): bool
+    {
+        $latest = PartyConsent::query()
+            ->where('party_id', $intake->party_id)
+            ->where('purpose', ConsentPurpose::Service)
+            ->latest('occurred_at')
+            ->latest('id')
+            ->first();
+
+        if ($latest !== null) {
+            return $latest->decision === ConsentDecision::Granted;
+        }
+
+        $content = json_decode($intake->encrypted_content->reveal(), true, flags: JSON_THROW_ON_ERROR);
+        $consent = $content['service_consent'] ?? null;
+
+        if (! is_array($consent) || ($consent['granted'] ?? false) !== true) {
+            return false;
+        }
+
+        $this->recordPartyConsent->handle($intake->party, [
+            'purpose' => ConsentPurpose::Service,
+            'decision' => ConsentDecision::Granted,
+            'wording_version' => 'service-intake-v1',
+            'wording' => 'I agree that my information may be used to assess and provide the requested service.',
+            'source' => is_string($consent['source'] ?? null) ? $consent['source'] : 'intake',
+            'occurred_at' => is_string($consent['captured_at'] ?? null) ? $consent['captured_at'] : now()->toAtomString(),
+        ], $actor);
+
+        return true;
+    }
+}

--- a/app/Data/Demo/ScenarioCatalog.php
+++ b/app/Data/Demo/ScenarioCatalog.php
@@ -9,7 +9,7 @@ use InvalidArgumentException;
 
 final class ScenarioCatalog
 {
-    public const VERSION = '2026.1';
+    public const VERSION = '2026.2';
 
     public const AS_OF = '2026-06-30 23:59:59';
 
@@ -153,7 +153,7 @@ final class ScenarioCatalog
 
     /**
      * @param  array<string, string>  $stages
-     * @return array{name: string, slug: string, configuration: array{labels: array{request: string, case: string}, stages: list<array{key: string, label: string}>, outcome_measures: list<array{key: string, label: string, unit: string}>, taxonomies: list<array{key: string, label: string, values: list<string>}>}}
+     * @return array{name: string, slug: string, configuration: array{labels: array{request: string, case: string}, stages: list<array{key: string, label: string}>, outcome_measures: list<array{key: string, label: string, unit: string}>, taxonomies: list<array{key: string, label: string, values: list<string>}>, intake_fields: list<array{key: string, label: string, type: string, required: bool}>, eligibility_fields: list<array{key: string, label: string}>, risk_flags: list<array{key: string, label: string}>}}
      */
     private static function program(string $name, string $slug, string $requestLabel, string $caseLabel, array $stages): array
     {
@@ -165,6 +165,18 @@ final class ScenarioCatalog
                 'stages' => array_values(collect($stages)->map(fn (string $label, string $key): array => compact('key', 'label'))->all()),
                 'outcome_measures' => [['key' => 'progress', 'label' => 'Progress', 'unit' => 'score']],
                 'taxonomies' => [['key' => 'need', 'label' => 'Presenting need', 'values' => ['Housing', 'Food', 'Employment', 'Connection']]],
+                'intake_fields' => [
+                    ['key' => 'preferred_contact_time', 'label' => 'Preferred contact time', 'type' => 'text', 'required' => false],
+                    ['key' => 'current_situation', 'label' => 'Current situation', 'type' => 'textarea', 'required' => true],
+                ],
+                'eligibility_fields' => [
+                    ['key' => 'service_area', 'label' => 'Lives in the service area'],
+                    ['key' => 'program_fit', 'label' => 'Request fits the Program remit'],
+                ],
+                'risk_flags' => [
+                    ['key' => 'immediate_safety', 'label' => 'Immediate safety concern'],
+                    ['key' => 'housing_loss', 'label' => 'At risk of losing housing'],
+                ],
             ],
         ];
     }

--- a/app/Enums/CaseAssignmentRole.php
+++ b/app/Enums/CaseAssignmentRole.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum CaseAssignmentRole: string
+{
+    case Primary = 'primary';
+    case Collaborator = 'collaborator';
+}

--- a/app/Enums/CaseAssignmentStatus.php
+++ b/app/Enums/CaseAssignmentStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum CaseAssignmentStatus: string
+{
+    case Active = 'active';
+    case Ended = 'ended';
+}

--- a/app/Enums/DuplicateReviewDecision.php
+++ b/app/Enums/DuplicateReviewDecision.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum DuplicateReviewDecision: string
+{
+    case Pending = 'pending';
+    case Dismissed = 'dismissed';
+    case Merged = 'merged';
+}

--- a/app/Enums/EligibilityStatus.php
+++ b/app/Enums/EligibilityStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum EligibilityStatus: string
+{
+    case NeedsReview = 'needs_review';
+    case Eligible = 'eligible';
+    case Ineligible = 'ineligible';
+}

--- a/app/Enums/IntakeStatus.php
+++ b/app/Enums/IntakeStatus.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Enums;
+
+enum IntakeStatus: string
+{
+    case Draft = 'draft';
+    case Submitted = 'submitted';
+    case UnderReview = 'under_review';
+    case Waitlisted = 'waitlisted';
+    case Accepted = 'accepted';
+    case Redirected = 'redirected';
+    case Declined = 'declined';
+    case Withdrawn = 'withdrawn';
+
+    /** @return list<self> */
+    public function allowedTransitions(): array
+    {
+        return match ($this) {
+            self::Draft => [self::Submitted, self::Withdrawn],
+            self::Submitted => [self::UnderReview, self::Withdrawn],
+            self::UnderReview => [self::Waitlisted, self::Accepted, self::Redirected, self::Declined, self::Withdrawn],
+            self::Waitlisted => [self::UnderReview, self::Accepted, self::Redirected, self::Withdrawn],
+            self::Accepted, self::Redirected, self::Declined, self::Withdrawn => [],
+        };
+    }
+}

--- a/app/Enums/IntakeUrgency.php
+++ b/app/Enums/IntakeUrgency.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum IntakeUrgency: string
+{
+    case Routine = 'routine';
+    case Priority = 'priority';
+    case Urgent = 'urgent';
+}

--- a/app/Enums/ServiceCaseStatus.php
+++ b/app/Enums/ServiceCaseStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum ServiceCaseStatus: string
+{
+    case Open = 'open';
+    case Active = 'active';
+    case OnHold = 'on_hold';
+    case Closed = 'closed';
+    case Cancelled = 'cancelled';
+}

--- a/app/Enums/TenantAuditEventType.php
+++ b/app/Enums/TenantAuditEventType.php
@@ -5,6 +5,7 @@ namespace App\Enums;
 enum TenantAuditEventType: string
 {
     case ProgramUpdated = 'program_updated';
+    case CaseAssigned = 'case_assigned';
 
     /** @return array<string, string> */
     public function payloadSchema(): array
@@ -13,6 +14,10 @@ enum TenantAuditEventType: string
             self::ProgramUpdated => [
                 'program_id' => 'integer',
                 'changed_fields' => 'string_list',
+            ],
+            self::CaseAssigned => [
+                'case_id' => 'string',
+                'membership_id' => 'integer',
             ],
         };
     }

--- a/app/Http/Controllers/Organisations/CaseAssignmentController.php
+++ b/app/Http/Controllers/Organisations/CaseAssignmentController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Intake\AssignCaseWorker;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\AssignCaseRequest;
+use App\Models\IntakeRequest;
+use App\Models\Membership;
+use App\Models\Organisation;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+use LogicException;
+
+class CaseAssignmentController extends Controller
+{
+    public function store(
+        AssignCaseRequest $request,
+        Organisation $currentOrganisation,
+        string $intake,
+        AssignCaseWorker $assignCaseWorker,
+    ): RedirectResponse {
+        $intakeRequest = IntakeRequest::query()->findOrFail($intake);
+        Gate::authorize('assign', $intakeRequest);
+        $case = $intakeRequest->serviceCase()->firstOrFail();
+        $worker = Membership::query()->findOrFail($request->integer('membership_id'));
+
+        try {
+            $assignCaseWorker->handle(
+                $case,
+                $worker,
+                $request->user(),
+                $request->filled('reason') ? $request->string('reason')->toString() : null,
+            );
+        } catch (LogicException $exception) {
+            throw ValidationException::withMessages(['membership_id' => $exception->getMessage()]);
+        }
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Organisations/IntakeRequestController.php
+++ b/app/Http/Controllers/Organisations/IntakeRequestController.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Intake\CreateIntakeRequest;
+use App\Enums\OrganisationRole;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\StoreIntakeRequestRequest;
+use App\Models\IntakeRequest;
+use App\Models\Membership;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\Program;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class IntakeRequestController extends Controller
+{
+    public function index(Request $request, Organisation $currentOrganisation): Response
+    {
+        Gate::authorize('viewAny', [IntakeRequest::class, $currentOrganisation]);
+        $programs = Program::query()->orderBy('name')->get()->filter(
+            fn (Program $program): bool => Gate::allows('create', [IntakeRequest::class, $program]),
+        )->values();
+        $managerProgramIds = $programs->filter(fn (Program $program): bool => $request->user()->hasOrganisationRole(
+            $currentOrganisation,
+            OrganisationRole::ProgramManager,
+            $program,
+        ) && $request->user()->hasProgramAccess($program))->modelKeys();
+        $caseWorkerProgramIds = $programs->whereNotIn('id', $managerProgramIds)->modelKeys();
+        $membershipId = $request->user()->organisationMembership($currentOrganisation)?->id;
+        $intakes = IntakeRequest::query()
+            ->with(['party:id,uuid,display_name', 'program:id,name,slug', 'serviceCase.assignments.membership.user'])
+            ->where(function (Builder $query) use ($managerProgramIds, $caseWorkerProgramIds, $membershipId): void {
+                $query->whereIn('program_id', $managerProgramIds)
+                    ->orWhere(function (Builder $query) use ($caseWorkerProgramIds, $membershipId): void {
+                        $query->whereIn('program_id', $caseWorkerProgramIds)
+                            ->whereHas('serviceCase.assignments', fn (Builder $query) => $query
+                                ->where('membership_id', $membershipId)
+                                ->where('status', 'active'));
+                    });
+            })
+            ->latest()
+            ->paginate(25)
+            ->through(fn (IntakeRequest $intake): array => $this->summary($intake));
+
+        return Inertia::render('intakes/index', [
+            'intakes' => $intakes,
+            'programs' => $programs->map(fn (Program $program): array => [
+                'id' => $program->id,
+                'name' => $program->name,
+                'configuration' => $program->configuration,
+            ]),
+            'parties' => Party::query()
+                ->whereHas('programs', fn (Builder $query) => $query->whereIn('programs.id', $programs->modelKeys()))
+                ->orderBy('display_name')
+                ->limit(250)
+                ->get(['uuid', 'display_name'])
+                ->map(fn (Party $party): array => ['uuid' => $party->uuid, 'displayName' => $party->display_name]),
+        ]);
+    }
+
+    public function store(
+        StoreIntakeRequestRequest $request,
+        Organisation $currentOrganisation,
+        CreateIntakeRequest $createIntakeRequest,
+    ): RedirectResponse {
+        $program = Program::query()->findOrFail($request->integer('program_id'));
+        $party = Party::query()->where('uuid', $request->string('party_uuid')->toString())->firstOrFail();
+        Gate::authorize('create', [IntakeRequest::class, $program]);
+        $intake = $createIntakeRequest->handle($currentOrganisation, $program, $party, [
+            'source' => $request->string('source')->toString(),
+            'narrative' => $request->string('narrative')->toString(),
+            'presenting_needs' => $request->string('presenting_needs')->toString(),
+            'intake_fields' => $request->array('intake_fields'),
+            'eligibility_context' => [],
+            'risk_flags' => array_values(array_map(strval(...), $request->array('risk_flags'))),
+            'email' => $request->filled('email') ? $request->string('email')->toString() : null,
+            'telephone' => $request->filled('telephone') ? $request->string('telephone')->toString() : null,
+            'idempotency_key' => $request->filled('idempotency_key') ? $request->string('idempotency_key')->toString() : null,
+            'consent_granted' => $request->boolean('consent_granted'),
+            'consent_source' => $request->string('consent_source')->toString(),
+        ], $request->user());
+
+        return Gate::allows('view', $intake)
+            ? to_route('intakes.show', [$currentOrganisation, $intake])
+            : to_route('intakes.index', $currentOrganisation);
+    }
+
+    public function show(Request $request, Organisation $currentOrganisation, string $intake): Response
+    {
+        $intakeRequest = IntakeRequest::query()->findOrFail($intake);
+        Gate::authorize('view', $intakeRequest);
+        $intakeRequest->load([
+            'party:id,uuid,display_name',
+            'program:id,organisation_id,name,slug,configuration',
+            'transitions' => fn ($query) => $query->orderBy('version'),
+            'duplicateReviews.candidateParty:id,uuid,display_name',
+            'serviceCase.assignments' => fn ($query) => $query->orderBy('started_at'),
+            'serviceCase.assignments.membership.user:id,name',
+        ]);
+        $content = json_decode($intakeRequest->encrypted_content->reveal(), true, flags: JSON_THROW_ON_ERROR);
+
+        return Inertia::render('intakes/show', [
+            'intake' => [
+                ...$this->summary($intakeRequest),
+                'version' => $intakeRequest->version,
+                'narrative' => $content['narrative'] ?? '',
+                'presentingNeeds' => $content['presenting_needs'] ?? '',
+                'intakeFields' => is_array($content['intake_fields'] ?? null) ? $content['intake_fields'] : [],
+                'eligibilityContext' => $intakeRequest->eligibility_context,
+                'riskFlags' => $intakeRequest->risk_flags,
+                'configuration' => $intakeRequest->program->configuration,
+                'transitions' => $intakeRequest->transitions->map(fn ($transition): array => [
+                    'id' => $transition->id,
+                    'from' => $transition->from_status?->value,
+                    'to' => $transition->to_status->value,
+                    'reason' => $transition->reason,
+                    'effectiveAt' => $transition->effective_at->toAtomString(),
+                    'version' => $transition->version,
+                ]),
+                'duplicateReviews' => $intakeRequest->duplicateReviews->map(fn ($review): array => [
+                    'id' => $review->id,
+                    'candidate' => ['uuid' => $review->candidateParty->uuid, 'displayName' => $review->candidateParty->display_name],
+                    'matchedFields' => $review->matched_fields,
+                    'decision' => $review->decision->value,
+                    'reversedAt' => $review->reversed_at?->toAtomString(),
+                ]),
+                'case' => $intakeRequest->serviceCase === null ? null : [
+                    'id' => $intakeRequest->serviceCase->id,
+                    'status' => $intakeRequest->serviceCase->status->value,
+                    'assignments' => $intakeRequest->serviceCase->assignments->map(fn ($assignment): array => [
+                        'id' => $assignment->id,
+                        'worker' => $assignment->membership->user->name,
+                        'status' => $assignment->status->value,
+                        'startedAt' => $assignment->started_at->toAtomString(),
+                        'endedAt' => $assignment->ended_at?->toAtomString(),
+                    ]),
+                ],
+            ],
+            'canTransition' => Gate::allows('transition', $intakeRequest),
+            'workers' => $this->eligibleWorkers($intakeRequest),
+        ]);
+    }
+
+    /** @return array<string, mixed> */
+    private function summary(IntakeRequest $intake): array
+    {
+        return [
+            'id' => $intake->id,
+            'party' => ['uuid' => $intake->party->uuid, 'displayName' => $intake->party->display_name],
+            'program' => ['id' => $intake->program->id, 'name' => $intake->program->name],
+            'status' => $intake->status->value,
+            'urgency' => $intake->urgency->value,
+            'eligibilityStatus' => $intake->eligibility_status->value,
+            'createdAt' => $intake->created_at?->toAtomString(),
+        ];
+    }
+
+    /** @return list<array{id: int, name: string}> */
+    private function eligibleWorkers(IntakeRequest $intake): array
+    {
+        return array_values(Membership::query()
+            ->with('user:id,name')
+            ->where('organisation_id', $intake->organisation_id)
+            ->whereNull('ended_at')
+            ->get()
+            ->filter(fn (Membership $membership): bool => $membership->user->hasOrganisationRole(
+                $intake->organisation,
+                OrganisationRole::CaseWorker,
+                $intake->program,
+            ) && $membership->user->hasProgramAccess($intake->program))
+            ->map(fn (Membership $membership): array => ['id' => $membership->id, 'name' => $membership->user->name])
+            ->values()
+            ->all());
+    }
+}

--- a/app/Http/Controllers/Organisations/IntakeTransitionController.php
+++ b/app/Http/Controllers/Organisations/IntakeTransitionController.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Intake\TransitionIntakeRequest;
+use App\Enums\EligibilityStatus;
+use App\Enums\IntakeStatus;
+use App\Enums\IntakeUrgency;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\TransitionIntakeRequestRequest;
+use App\Models\IntakeRequest;
+use App\Models\Membership;
+use App\Models\Organisation;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+use LogicException;
+
+class IntakeTransitionController extends Controller
+{
+    public function store(
+        TransitionIntakeRequestRequest $request,
+        Organisation $currentOrganisation,
+        string $intake,
+        TransitionIntakeRequest $transitionIntakeRequest,
+    ): RedirectResponse {
+        $intakeRequest = IntakeRequest::query()->findOrFail($intake);
+        Gate::authorize('transition', $intakeRequest);
+        $worker = $request->filled('worker_membership_id')
+            ? Membership::query()->findOrFail($request->integer('worker_membership_id'))
+            : null;
+
+        try {
+            $transitionIntakeRequest->handle(
+                $intakeRequest,
+                IntakeStatus::from($request->string('status')->toString()),
+                $request->integer('expected_version'),
+                $request->user(),
+                $request->filled('reason') ? $request->string('reason')->toString() : null,
+                array_filter([
+                    'urgency' => $request->filled('urgency') ? IntakeUrgency::from($request->string('urgency')->toString()) : null,
+                    'eligibility_status' => $request->filled('eligibility_status') ? EligibilityStatus::from($request->string('eligibility_status')->toString()) : null,
+                    'eligibility_context' => $request->has('eligibility_context') ? $request->array('eligibility_context') : null,
+                    'risk_flags' => $request->has('risk_flags') ? array_values(array_map(strval(...), $request->array('risk_flags'))) : null,
+                ], fn (mixed $value): bool => $value !== null),
+                $worker,
+            );
+        } catch (LogicException $exception) {
+            throw ValidationException::withMessages(['status' => $exception->getMessage()]);
+        }
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Organisations/PartyDuplicateReviewController.php
+++ b/app/Http/Controllers/Organisations/PartyDuplicateReviewController.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Intake\ReversePartyMerge;
+use App\Actions\Intake\ReviewPartyDuplicate;
+use App\Enums\DuplicateReviewDecision;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\ReviewPartyDuplicateRequest;
+use App\Models\Organisation;
+use App\Models\PartyDuplicateReview;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+use LogicException;
+
+class PartyDuplicateReviewController extends Controller
+{
+    public function store(
+        ReviewPartyDuplicateRequest $request,
+        Organisation $currentOrganisation,
+        string $duplicateReview,
+        ReviewPartyDuplicate $reviewPartyDuplicate,
+    ): RedirectResponse {
+        $partyDuplicateReview = PartyDuplicateReview::query()->findOrFail($duplicateReview);
+        Gate::authorize('reviewDuplicate', $partyDuplicateReview->intakeRequest);
+        try {
+            $reviewPartyDuplicate->handle(
+                $partyDuplicateReview,
+                DuplicateReviewDecision::from($request->string('decision')->toString()),
+                $request->user(),
+            );
+        } catch (LogicException $exception) {
+            throw ValidationException::withMessages(['duplicate' => $exception->getMessage()]);
+        }
+
+        return back();
+    }
+
+    public function destroy(
+        Request $request,
+        Organisation $currentOrganisation,
+        string $duplicateReview,
+        ReversePartyMerge $reversePartyMerge,
+    ): RedirectResponse {
+        $partyDuplicateReview = PartyDuplicateReview::query()->findOrFail($duplicateReview);
+        Gate::authorize('reviewDuplicate', $partyDuplicateReview->intakeRequest);
+
+        try {
+            $reversePartyMerge->handle($partyDuplicateReview, $request->user());
+        } catch (LogicException $exception) {
+            throw ValidationException::withMessages(['duplicate' => $exception->getMessage()]);
+        }
+
+        return back();
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\IntakeRequest;
 use App\Models\Organisation;
 use App\Models\Party;
 use App\Models\Program;
@@ -61,6 +62,8 @@ class HandleInertiaRequests extends Middleware
                 && Gate::allows('viewAny', [Party::class, $routeOrganisation]),
             'canViewPrograms' => fn (): bool => $routeOrganisation instanceof Organisation
                 && Gate::allows('viewAny', [Program::class, $routeOrganisation]),
+            'canViewIntakes' => fn (): bool => $routeOrganisation instanceof Organisation
+                && Gate::allows('viewAny', [IntakeRequest::class, $routeOrganisation]),
         ];
     }
 }

--- a/app/Http/Requests/Organisations/AssignCaseRequest.php
+++ b/app/Http/Requests/Organisations/AssignCaseRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Models\Organisation;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class AssignCaseRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $organisation = $this->route('current_organisation');
+        $organisationId = $organisation instanceof Organisation ? $organisation->id : 0;
+
+        return [
+            'membership_id' => ['required', 'integer', Rule::exists('organisation_members', 'id')->where('organisation_id', $organisationId)->whereNull('ended_at')],
+            'reason' => ['nullable', Rule::in(['initial_assignment', 'caseload_transfer', 'availability', 'program_rebalance', 'other'])],
+        ];
+    }
+}

--- a/app/Http/Requests/Organisations/ReviewPartyDuplicateRequest.php
+++ b/app/Http/Requests/Organisations/ReviewPartyDuplicateRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Enums\DuplicateReviewDecision;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class ReviewPartyDuplicateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return ['decision' => ['required', Rule::in([
+            DuplicateReviewDecision::Dismissed->value,
+            DuplicateReviewDecision::Merged->value,
+        ])]];
+    }
+}

--- a/app/Http/Requests/Organisations/StoreIntakeRequestRequest.php
+++ b/app/Http/Requests/Organisations/StoreIntakeRequestRequest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Models\Organisation;
+use App\Models\Program;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreIntakeRequestRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $organisation = $this->route('current_organisation');
+        $organisationId = $organisation instanceof Organisation ? $organisation->id : 0;
+        $program = Program::query()->whereKey($this->integer('program_id'))->first();
+        $fieldDefinitions = $program === null ? [] : $this->configuredFields($program, 'intake_fields');
+        $fieldKeys = $this->configuredFieldKeys($fieldDefinitions);
+        $riskKeys = $program === null ? [] : $this->configuredFieldKeys($this->configuredFields($program, 'risk_flags'));
+        $rules = [
+            'program_id' => ['required', 'integer', Rule::exists('programs', 'id')->where('organisation_id', $organisationId)],
+            'party_uuid' => ['required', 'uuid', Rule::exists('parties', 'uuid')->where('organisation_id', $organisationId)],
+            'source' => ['required', Rule::in(['staff_referral', 'self_referral', 'partner_referral', 'phone', 'walk_in', 'online'])],
+            'narrative' => ['required', 'string', 'max:10000'],
+            'presenting_needs' => ['required', 'string', 'max:10000'],
+            'email' => ['nullable', 'email:rfc', 'max:255'],
+            'telephone' => ['nullable', 'string', 'max:50'],
+            'intake_fields' => [$fieldKeys === [] ? 'array' : 'array:'.implode(',', $fieldKeys)],
+            'risk_flags' => ['present', 'array', 'max:20'],
+            'risk_flags.*' => ['string', 'distinct', Rule::in($riskKeys)],
+            'consent_granted' => ['required', 'boolean'],
+            'consent_source' => ['required_if:consent_granted,true', 'nullable', Rule::in(['verbal', 'written', 'online', 'referral'])],
+            'idempotency_key' => ['nullable', 'string', 'max:100'],
+        ];
+
+        foreach ($fieldDefinitions as $definition) {
+            $key = $definition['key'] ?? null;
+
+            if (! is_string($key)) {
+                continue;
+            }
+
+            $fieldRules = [($definition['required'] ?? false) === true ? 'required' : 'nullable'];
+            $fieldRules[] = match ($definition['type'] ?? 'text') {
+                'boolean' => 'boolean',
+                'date' => 'date',
+                default => 'string',
+            };
+            $fieldRules[] = 'max:'.(($definition['type'] ?? null) === 'textarea' ? '10000' : '255');
+            $rules['intake_fields.'.$key] = $fieldRules;
+        }
+
+        return $rules;
+    }
+
+    /** @return list<array<string, mixed>> */
+    private function configuredFields(Program $program, string $key): array
+    {
+        $value = $program->configuration[$key] ?? null;
+
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_filter($value, is_array(...)));
+    }
+
+    /** @param list<array<string, mixed>> $definitions
+     * @return list<string>
+     */
+    private function configuredFieldKeys(array $definitions): array
+    {
+        $keys = [];
+
+        foreach ($definitions as $definition) {
+            if (isset($definition['key']) && is_string($definition['key'])) {
+                $keys[] = $definition['key'];
+            }
+        }
+
+        return $keys;
+    }
+}

--- a/app/Http/Requests/Organisations/TransitionIntakeRequestRequest.php
+++ b/app/Http/Requests/Organisations/TransitionIntakeRequestRequest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Enums\EligibilityStatus;
+use App\Enums\IntakeStatus;
+use App\Enums\IntakeUrgency;
+use App\Models\IntakeRequest;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TransitionIntakeRequestRequest extends FormRequest
+{
+    protected function prepareForValidation(): void
+    {
+        if ($this->has('risk_flags')) {
+            $this->merge([
+                'risk_flags' => array_values(array_filter(
+                    $this->array('risk_flags'),
+                    fn (mixed $value): bool => is_string($value) && $value !== '',
+                )),
+            ]);
+        }
+    }
+
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $identifier = $this->route('intake');
+        $intake = is_string($identifier) ? IntakeRequest::query()->find($identifier) : null;
+        $eligibilityKeys = $intake instanceof IntakeRequest
+            ? $this->configuredFieldKeys($intake, 'eligibility_fields')
+            : [];
+        $riskKeys = $intake instanceof IntakeRequest
+            ? $this->configuredFieldKeys($intake, 'risk_flags')
+            : [];
+
+        return [
+            'status' => ['required', Rule::enum(IntakeStatus::class)],
+            'expected_version' => ['required', 'integer', 'min:1'],
+            'reason' => ['nullable', Rule::in(['client_request', 'eligibility', 'capacity', 'external_referral', 'duplicate', 'other'])],
+            'urgency' => ['nullable', Rule::enum(IntakeUrgency::class)],
+            'eligibility_status' => ['nullable', Rule::enum(EligibilityStatus::class)],
+            'eligibility_context' => [$eligibilityKeys === [] ? 'array' : 'array:'.implode(',', $eligibilityKeys)],
+            'eligibility_context.*' => ['boolean'],
+            'risk_flags' => ['nullable', 'array', 'max:20'],
+            'risk_flags.*' => ['string', 'distinct', Rule::in($riskKeys)],
+            'worker_membership_id' => ['nullable', 'integer'],
+        ];
+    }
+
+    /** @return list<string> */
+    private function configuredFieldKeys(IntakeRequest $intake, string $configurationKey): array
+    {
+        $definitions = $intake->program->configuration[$configurationKey] ?? null;
+
+        if (! is_array($definitions)) {
+            return [];
+        }
+
+        $keys = [];
+
+        foreach ($definitions as $definition) {
+            if (is_array($definition) && isset($definition['key']) && is_string($definition['key'])) {
+                $keys[] = $definition['key'];
+            }
+        }
+
+        return $keys;
+    }
+}

--- a/app/Http/Requests/Organisations/UpdateProgramRequest.php
+++ b/app/Http/Requests/Organisations/UpdateProgramRequest.php
@@ -42,7 +42,7 @@ class UpdateProgramRequest extends FormRequest
                     ->where('organisation_id', $organisation instanceof Organisation ? $organisation->id : 0)
                     ->ignore($program?->id),
             ],
-            'configuration' => ['sometimes', 'array:labels,stages,outcome_measures,taxonomies'],
+            'configuration' => ['sometimes', 'array:labels,stages,outcome_measures,taxonomies,intake_fields,eligibility_fields,risk_flags'],
             'configuration.labels' => ['required_with:configuration', 'array:request,case'],
             'configuration.labels.request' => ['required_with:configuration', 'string', 'max:100'],
             'configuration.labels.case' => ['required_with:configuration', 'string', 'max:100'],
@@ -61,6 +61,20 @@ class UpdateProgramRequest extends FormRequest
             'configuration.taxonomies.*.label' => ['required', 'string', 'max:100'],
             'configuration.taxonomies.*.values' => ['required', 'array', 'max:50'],
             'configuration.taxonomies.*.values.*' => ['required', 'string', 'max:100', 'distinct'],
+            'configuration.intake_fields' => ['sometimes', 'array', 'max:30'],
+            'configuration.intake_fields.*' => ['array:key,label,type,required'],
+            'configuration.intake_fields.*.key' => ['required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/', 'distinct'],
+            'configuration.intake_fields.*.label' => ['required', 'string', 'max:100'],
+            'configuration.intake_fields.*.type' => ['required', Rule::in(['text', 'textarea', 'boolean', 'date'])],
+            'configuration.intake_fields.*.required' => ['required', 'boolean'],
+            'configuration.eligibility_fields' => ['sometimes', 'array', 'max:20'],
+            'configuration.eligibility_fields.*' => ['array:key,label'],
+            'configuration.eligibility_fields.*.key' => ['required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/', 'distinct'],
+            'configuration.eligibility_fields.*.label' => ['required', 'string', 'max:100'],
+            'configuration.risk_flags' => ['sometimes', 'array', 'max:20'],
+            'configuration.risk_flags.*' => ['array:key,label'],
+            'configuration.risk_flags.*.key' => ['required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/', 'distinct'],
+            'configuration.risk_flags.*.label' => ['required', 'string', 'max:100'],
         ];
     }
 }

--- a/app/Models/CaseAssignment.php
+++ b/app/Models/CaseAssignment.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\CaseAssignmentRole;
+use App\Enums\CaseAssignmentStatus;
+use Database\Factories\CaseAssignmentFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $service_case_id
+ * @property int $membership_id
+ * @property CaseAssignmentRole $role
+ * @property CaseAssignmentStatus $status
+ * @property bool|null $active_primary_marker
+ * @property Carbon $started_at
+ * @property Carbon|null $ended_at
+ * @property string|null $assigned_reason
+ * @property string|null $ended_reason
+ * @property-read Membership $membership
+ * @property-read ServiceCase $serviceCase
+ */
+class CaseAssignment extends Model
+{
+    /** @use HasFactory<CaseAssignmentFactory> */
+    use BelongsToOrganisation, HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(function (CaseAssignment $assignment): void {
+            $allowedChanges = ['status', 'active_primary_marker', 'ended_at', 'ended_reason', 'ended_by_user_id'];
+
+            if ($assignment->getRawOriginal('status') !== CaseAssignmentStatus::Active->value
+                || $assignment->status !== CaseAssignmentStatus::Ended
+                || array_diff(array_keys($assignment->getDirty()), $allowedChanges) !== []) {
+                throw new LogicException('Case assignment history may only be ended.');
+            }
+        });
+        static::deleting(fn () => throw new LogicException('Case assignment history is append-only.'));
+    }
+
+    /** @return BelongsTo<ServiceCase, $this> */
+    public function serviceCase(): BelongsTo
+    {
+        return $this->belongsTo(ServiceCase::class);
+    }
+
+    /** @return BelongsTo<Membership, $this> */
+    public function membership(): BelongsTo
+    {
+        return $this->belongsTo(Membership::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'role' => CaseAssignmentRole::class,
+            'status' => CaseAssignmentStatus::class,
+            'active_primary_marker' => 'boolean',
+            'started_at' => 'datetime',
+            'ended_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/IntakeRequest.php
+++ b/app/Models/IntakeRequest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\ClassifiedValueCast;
+use App\Concerns\BelongsToOrganisation;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\EligibilityStatus;
+use App\Enums\IntakeStatus;
+use App\Enums\IntakeUrgency;
+use Database\Factories\IntakeRequestFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property int $program_id
+ * @property int $party_id
+ * @property ClassifiedValue $encrypted_content
+ * @property array<string, mixed> $eligibility_context
+ * @property EligibilityStatus $eligibility_status
+ * @property IntakeStatus $status
+ * @property IntakeUrgency $urgency
+ * @property list<string> $risk_flags
+ * @property int $version
+ * @property int|null $created_by_user_id
+ * @property Carbon|null $created_at
+ * @property-read Organisation $organisation
+ * @property-read Program $program
+ * @property-read Party $party
+ * @property-read ServiceCase|null $serviceCase
+ */
+class IntakeRequest extends Model
+{
+    /** @use HasFactory<IntakeRequestFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected $guarded = ['organisation_id'];
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return BelongsTo<Program, $this> */
+    public function program(): BelongsTo
+    {
+        return $this->belongsTo(Program::class);
+    }
+
+    /** @return BelongsTo<Party, $this> */
+    public function party(): BelongsTo
+    {
+        return $this->belongsTo(Party::class);
+    }
+
+    /** @return HasMany<IntakeTransition, $this> */
+    public function transitions(): HasMany
+    {
+        return $this->hasMany(IntakeTransition::class);
+    }
+
+    /** @return HasOne<ServiceCase, $this> */
+    public function serviceCase(): HasOne
+    {
+        return $this->hasOne(ServiceCase::class);
+    }
+
+    /** @return HasMany<PartyDuplicateReview, $this> */
+    public function duplicateReviews(): HasMany
+    {
+        return $this->hasMany(PartyDuplicateReview::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'encrypted_content' => ClassifiedValueCast::class.':intake_request',
+            'eligibility_context' => 'array',
+            'eligibility_status' => EligibilityStatus::class,
+            'status' => IntakeStatus::class,
+            'urgency' => IntakeUrgency::class,
+            'risk_flags' => 'array',
+        ];
+    }
+}

--- a/app/Models/IntakeTransition.php
+++ b/app/Models/IntakeTransition.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\IntakeStatus;
+use Database\Factories\IntakeTransitionFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $intake_request_id
+ * @property IntakeStatus|null $from_status
+ * @property IntakeStatus $to_status
+ * @property string|null $reason
+ * @property Carbon $effective_at
+ * @property Carbon $recorded_at
+ * @property int $version
+ */
+class IntakeTransition extends Model
+{
+    /** @use HasFactory<IntakeTransitionFactory> */
+    use BelongsToOrganisation, HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Intake transitions are append-only.'));
+        static::deleting(fn () => throw new LogicException('Intake transitions are append-only.'));
+    }
+
+    /** @return BelongsTo<IntakeRequest, $this> */
+    public function intakeRequest(): BelongsTo
+    {
+        return $this->belongsTo(IntakeRequest::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'from_status' => IntakeStatus::class,
+            'to_status' => IntakeStatus::class,
+            'effective_at' => 'datetime',
+            'recorded_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/PartyDuplicateReview.php
+++ b/app/Models/PartyDuplicateReview.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\DuplicateReviewDecision;
+use Database\Factories\PartyDuplicateReviewFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $intake_request_id
+ * @property int $submitted_party_id
+ * @property int $candidate_party_id
+ * @property list<string> $matched_fields
+ * @property DuplicateReviewDecision $decision
+ * @property int|null $canonical_party_id
+ * @property Carbon|null $decided_at
+ * @property Carbon|null $reversed_at
+ * @property int|null $decided_by_user_id
+ * @property int|null $reversed_by_user_id
+ * @property-read IntakeRequest $intakeRequest
+ * @property-read Party $submittedParty
+ * @property-read Party $candidateParty
+ */
+class PartyDuplicateReview extends Model
+{
+    /** @use HasFactory<PartyDuplicateReviewFactory> */
+    use BelongsToOrganisation, HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    protected $guarded = ['organisation_id'];
+
+    /** @return BelongsTo<IntakeRequest, $this> */
+    public function intakeRequest(): BelongsTo
+    {
+        return $this->belongsTo(IntakeRequest::class);
+    }
+
+    /** @return BelongsTo<Party, $this> */
+    public function submittedParty(): BelongsTo
+    {
+        return $this->belongsTo(Party::class, 'submitted_party_id');
+    }
+
+    /** @return BelongsTo<Party, $this> */
+    public function candidateParty(): BelongsTo
+    {
+        return $this->belongsTo(Party::class, 'candidate_party_id');
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'matched_fields' => 'array',
+            'decision' => DuplicateReviewDecision::class,
+            'decided_at' => 'datetime',
+            'reversed_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/Program.php
+++ b/app/Models/Program.php
@@ -18,6 +18,7 @@ use Laravel\Scout\Searchable;
  * @property int $organisation_id
  * @property string $name
  * @property string $slug
+ * @property array<string, mixed> $configuration
  * @property-read Organisation $organisation
  */
 #[Fillable(['organisation_id', 'name', 'slug', 'configuration'])]

--- a/app/Models/ServiceCase.php
+++ b/app/Models/ServiceCase.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\ServiceCaseStatus;
+use Database\Factories\ServiceCaseFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $intake_request_id
+ * @property int $program_id
+ * @property int $party_id
+ * @property ServiceCaseStatus $status
+ * @property string $confidentiality
+ * @property Carbon $opened_at
+ * @property-read Organisation $organisation
+ * @property-read Program $program
+ * @property-read Party $party
+ */
+class ServiceCase extends Model
+{
+    /** @use HasFactory<ServiceCaseFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected $guarded = ['organisation_id'];
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return BelongsTo<IntakeRequest, $this> */
+    public function intakeRequest(): BelongsTo
+    {
+        return $this->belongsTo(IntakeRequest::class);
+    }
+
+    /** @return BelongsTo<Program, $this> */
+    public function program(): BelongsTo
+    {
+        return $this->belongsTo(Program::class);
+    }
+
+    /** @return BelongsTo<Party, $this> */
+    public function party(): BelongsTo
+    {
+        return $this->belongsTo(Party::class);
+    }
+
+    /** @return HasMany<CaseAssignment, $this> */
+    public function assignments(): HasMany
+    {
+        return $this->hasMany(CaseAssignment::class);
+    }
+
+    protected function casts(): array
+    {
+        return ['status' => ServiceCaseStatus::class, 'opened_at' => 'datetime'];
+    }
+}

--- a/app/Policies/IntakeRequestPolicy.php
+++ b/app/Policies/IntakeRequestPolicy.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\OrganisationRole;
+use App\Models\IntakeRequest;
+use App\Models\Organisation;
+use App\Models\Program;
+use App\Models\User;
+
+class IntakeRequestPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user, Organisation $organisation): bool
+    {
+        return $this->hasOperationalRole($user, $organisation);
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, IntakeRequest $intakeRequest): bool
+    {
+        if ($this->canManageProgram($user, $intakeRequest->program)) {
+            return true;
+        }
+
+        $membership = $user->organisationMembership($intakeRequest->organisation);
+
+        return $membership !== null
+            && $user->hasOrganisationRole($intakeRequest->organisation, OrganisationRole::CaseWorker, $intakeRequest->program)
+            && $user->hasProgramAccess($intakeRequest->program)
+            && $intakeRequest->serviceCase?->assignments()
+                ->where('membership_id', $membership->id)
+                ->where('status', 'active')
+                ->exists() === true;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user, Program $program): bool
+    {
+        return $this->canManageProgram($user, $program)
+            || ($user->hasOrganisationRole($program->organisation, OrganisationRole::CaseWorker, $program)
+                && $user->hasProgramAccess($program));
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, IntakeRequest $intakeRequest): bool
+    {
+        return $this->canManageProgram($user, $intakeRequest->program);
+    }
+
+    public function transition(User $user, IntakeRequest $intakeRequest): bool
+    {
+        return $this->update($user, $intakeRequest);
+    }
+
+    public function reviewDuplicate(User $user, IntakeRequest $intakeRequest): bool
+    {
+        return $this->update($user, $intakeRequest);
+    }
+
+    public function assign(User $user, IntakeRequest $intakeRequest): bool
+    {
+        return $this->update($user, $intakeRequest);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, IntakeRequest $intakeRequest): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, IntakeRequest $intakeRequest): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, IntakeRequest $intakeRequest): bool
+    {
+        return false;
+    }
+
+    private function hasOperationalRole(User $user, Organisation $organisation): bool
+    {
+        $membership = $user->organisationMembership($organisation);
+
+        return $membership !== null
+            && ! $membership->isHeld()
+            && $membership->roleAssignments()
+                ->whereNull('ended_at')
+                ->whereIn('role', [OrganisationRole::ProgramManager, OrganisationRole::CaseWorker])
+                ->exists();
+    }
+
+    private function canManageProgram(User $user, Program $program): bool
+    {
+        return $user->hasOrganisationRole($program->organisation, OrganisationRole::ProgramManager, $program)
+            && $user->hasProgramAccess($program);
+    }
+}

--- a/database/factories/CaseAssignmentFactory.php
+++ b/database/factories/CaseAssignmentFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\CaseAssignmentRole;
+use App\Enums\CaseAssignmentStatus;
+use App\Models\CaseAssignment;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CaseAssignment>
+ */
+class CaseAssignmentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'service_case_id' => ServiceCase::factory(),
+            'membership_id' => fn (): int => app(OrganisationContext::class)->organisation()
+                ->memberships()->create(['user_id' => User::factory()->create()->id])->id,
+            'role' => CaseAssignmentRole::Primary,
+            'status' => CaseAssignmentStatus::Active,
+            'active_primary_marker' => true,
+            'started_at' => now(),
+        ];
+    }
+}

--- a/database/factories/IntakeRequestFactory.php
+++ b/database/factories/IntakeRequestFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\EligibilityStatus;
+use App\Enums\IntakeStatus;
+use App\Enums\IntakeUrgency;
+use App\Models\IntakeRequest;
+use App\Models\Party;
+use App\Models\Program;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<IntakeRequest>
+ */
+class IntakeRequestFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'program_id' => Program::factory()->state(['organisation_id' => app(OrganisationContext::class)->id()]),
+            'party_id' => Party::factory()->state(['organisation_id' => app(OrganisationContext::class)->id()]),
+            'type' => 'content',
+            'encrypted_content' => new ClassifiedValue(json_encode([
+                'narrative' => fake()->paragraph(),
+                'presenting_needs' => fake()->sentence(),
+                'intake_fields' => [],
+            ], JSON_THROW_ON_ERROR)),
+            'data_key_version' => app(ClassifiedDataEncrypter::class)->currentVersion(),
+            'eligibility_context' => [],
+            'eligibility_status' => EligibilityStatus::NeedsReview,
+            'status' => IntakeStatus::Draft,
+            'urgency' => IntakeUrgency::Routine,
+            'risk_flags' => [],
+            'version' => 1,
+            'source' => 'factory',
+        ];
+    }
+}

--- a/database/factories/IntakeTransitionFactory.php
+++ b/database/factories/IntakeTransitionFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\IntakeStatus;
+use App\Models\IntakeRequest;
+use App\Models\IntakeTransition;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<IntakeTransition>
+ */
+class IntakeTransitionFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'intake_request_id' => IntakeRequest::factory(),
+            'from_status' => null,
+            'to_status' => IntakeStatus::Draft,
+            'effective_at' => now(),
+            'recorded_at' => now(),
+            'version' => 1,
+        ];
+    }
+}

--- a/database/factories/PartyDuplicateReviewFactory.php
+++ b/database/factories/PartyDuplicateReviewFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\DuplicateReviewDecision;
+use App\Models\IntakeRequest;
+use App\Models\Party;
+use App\Models\PartyDuplicateReview;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PartyDuplicateReview>
+ */
+class PartyDuplicateReviewFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'intake_request_id' => IntakeRequest::factory(),
+            'submitted_party_id' => fn (array $attributes): int => IntakeRequest::query()->where('id', $attributes['intake_request_id'])->firstOrFail()->party_id,
+            'candidate_party_id' => Party::factory()->state(['organisation_id' => app(OrganisationContext::class)->id()]),
+            'matched_fields' => ['email'],
+            'decision' => DuplicateReviewDecision::Pending,
+        ];
+    }
+}

--- a/database/factories/ServiceCaseFactory.php
+++ b/database/factories/ServiceCaseFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ServiceCaseStatus;
+use App\Models\IntakeRequest;
+use App\Models\ServiceCase;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ServiceCase>
+ */
+class ServiceCaseFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'intake_request_id' => IntakeRequest::factory(),
+            'program_id' => fn (array $attributes): int => IntakeRequest::query()->where('id', $attributes['intake_request_id'])->firstOrFail()->program_id,
+            'party_id' => fn (array $attributes): int => IntakeRequest::query()->where('id', $attributes['intake_request_id'])->firstOrFail()->party_id,
+            'status' => ServiceCaseStatus::Open,
+            'confidentiality' => 'confidential',
+            'opened_at' => now(),
+        ];
+    }
+}

--- a/database/migrations/2026_08_31_051834_create_intake_requests_table.php
+++ b/database/migrations/2026_08_31_051834_create_intake_requests_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('intake_requests', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('program_id');
+            $table->foreignId('party_id');
+            $table->string('type', 32)->default('content');
+            $table->text('encrypted_content');
+            $table->string('data_key_version', 64);
+            $table->json('eligibility_context')->default('{}');
+            $table->string('eligibility_status', 32)->default('needs_review');
+            $table->string('status', 32)->default('draft');
+            $table->string('urgency', 32)->default('routine');
+            $table->json('risk_flags')->default('[]');
+            $table->unsignedInteger('version')->default(1);
+            $table->string('source', 100);
+            $table->string('idempotency_key', 100)->nullable();
+            $table->foreignId('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->foreign(['organisation_id', 'program_id'])
+                ->references(['organisation_id', 'id'])->on('programs')->restrictOnDelete();
+            $table->foreign(['organisation_id', 'party_id'])
+                ->references(['organisation_id', 'id'])->on('parties')->restrictOnDelete();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'idempotency_key']);
+            $table->index(['organisation_id', 'program_id', 'status', 'urgency']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('intake_requests');
+    }
+};

--- a/database/migrations/2026_08_31_051835_create_intake_transitions_table.php
+++ b/database/migrations/2026_08_31_051835_create_intake_transitions_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('intake_transitions', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->uuid('intake_request_id');
+            $table->string('from_status', 32)->nullable();
+            $table->string('to_status', 32);
+            $table->string('reason', 64)->nullable();
+            $table->timestamp('effective_at');
+            $table->timestamp('recorded_at');
+            $table->unsignedInteger('version');
+            $table->unsignedBigInteger('actor_user_id')->nullable()->index();
+
+            $table->foreign(['organisation_id', 'intake_request_id'])
+                ->references(['organisation_id', 'id'])->on('intake_requests')->cascadeOnDelete();
+            $table->unique(['organisation_id', 'intake_request_id', 'version']);
+            $table->index(['organisation_id', 'intake_request_id', 'effective_at']);
+        });
+
+        if (DB::getDriverName() === 'pgsql') {
+            DB::unprepared('CREATE TRIGGER intake_transitions_append_only BEFORE UPDATE OR DELETE OR TRUNCATE ON intake_transitions FOR EACH STATEMENT EXECUTE FUNCTION prevent_append_only_mutation()');
+        } elseif (DB::getDriverName() === 'sqlite') {
+            DB::unprepared("CREATE TRIGGER intake_transitions_append_only_update BEFORE UPDATE ON intake_transitions BEGIN SELECT RAISE(ABORT, 'append-only table'); END");
+            DB::unprepared("CREATE TRIGGER intake_transitions_append_only_delete BEFORE DELETE ON intake_transitions BEGIN SELECT RAISE(ABORT, 'append-only table'); END");
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('intake_transitions');
+    }
+};

--- a/database/migrations/2026_08_31_051836_create_service_cases_table.php
+++ b/database/migrations/2026_08_31_051836_create_service_cases_table.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('service_cases', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->uuid('intake_request_id');
+            $table->foreignId('program_id');
+            $table->foreignId('party_id');
+            $table->string('status', 32)->default('open');
+            $table->string('confidentiality', 32)->default('confidential');
+            $table->unsignedInteger('version')->default(1);
+            $table->timestamp('opened_at');
+            $table->foreignId('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->foreign(['organisation_id', 'intake_request_id'])
+                ->references(['organisation_id', 'id'])->on('intake_requests')->restrictOnDelete();
+            $table->foreign(['organisation_id', 'program_id'])
+                ->references(['organisation_id', 'id'])->on('programs')->restrictOnDelete();
+            $table->foreign(['organisation_id', 'party_id'])
+                ->references(['organisation_id', 'id'])->on('parties')->restrictOnDelete();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'intake_request_id']);
+            $table->index(['organisation_id', 'program_id', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('service_cases');
+    }
+};

--- a/database/migrations/2026_08_31_051837_create_case_assignments_table.php
+++ b/database/migrations/2026_08_31_051837_create_case_assignments_table.php
@@ -1,0 +1,87 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('case_assignments', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->uuid('service_case_id');
+            $table->foreignId('membership_id');
+            $table->string('role', 32)->default('primary');
+            $table->string('status', 32)->default('active');
+            $table->boolean('active_primary_marker')->nullable();
+            $table->timestamp('started_at');
+            $table->timestamp('ended_at')->nullable();
+            $table->string('assigned_reason', 64)->nullable();
+            $table->string('ended_reason', 64)->nullable();
+            $table->unsignedBigInteger('assigned_by_user_id')->nullable()->index();
+            $table->unsignedBigInteger('ended_by_user_id')->nullable()->index();
+
+            $table->foreign(['organisation_id', 'service_case_id'])
+                ->references(['organisation_id', 'id'])->on('service_cases')->cascadeOnDelete();
+            $table->foreign(['organisation_id', 'membership_id'])
+                ->references(['organisation_id', 'id'])->on('organisation_members')->restrictOnDelete();
+            $table->unique(['organisation_id', 'service_case_id', 'active_primary_marker']);
+            $table->index(['organisation_id', 'membership_id', 'status']);
+        });
+
+        if (DB::getDriverName() === 'pgsql') {
+            DB::unprepared(<<<'SQL'
+                CREATE OR REPLACE FUNCTION guard_case_assignment_history() RETURNS trigger AS $$
+                BEGIN
+                    IF TG_OP = 'DELETE' THEN
+                        RAISE EXCEPTION 'Case assignment history is append-only.';
+                    END IF;
+
+                    IF OLD.status <> 'active'
+                        OR NEW.status <> 'ended'
+                        OR NEW.active_primary_marker IS NOT NULL
+                        OR OLD.ended_at IS NOT NULL
+                        OR NEW.ended_at IS NULL
+                        OR NEW.id IS DISTINCT FROM OLD.id
+                        OR NEW.organisation_id IS DISTINCT FROM OLD.organisation_id
+                        OR NEW.service_case_id IS DISTINCT FROM OLD.service_case_id
+                        OR NEW.membership_id IS DISTINCT FROM OLD.membership_id
+                        OR NEW.role IS DISTINCT FROM OLD.role
+                        OR NEW.started_at IS DISTINCT FROM OLD.started_at
+                        OR NEW.assigned_reason IS DISTINCT FROM OLD.assigned_reason
+                        OR NEW.assigned_by_user_id IS DISTINCT FROM OLD.assigned_by_user_id
+                    THEN
+                        RAISE EXCEPTION 'Case assignment history may only be ended.';
+                    END IF;
+
+                    RETURN NEW;
+                END;
+                $$ LANGUAGE plpgsql;
+
+                CREATE TRIGGER case_assignments_history_guard
+                BEFORE UPDATE OR DELETE ON case_assignments
+                FOR EACH ROW EXECUTE FUNCTION guard_case_assignment_history();
+                SQL);
+        } elseif (DB::getDriverName() === 'sqlite') {
+            DB::unprepared("CREATE TRIGGER case_assignments_append_only_delete BEFORE DELETE ON case_assignments BEGIN SELECT RAISE(ABORT, 'Case assignment history is append-only.'); END");
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::unprepared('DROP FUNCTION IF EXISTS guard_case_assignment_history() CASCADE');
+        }
+
+        Schema::dropIfExists('case_assignments');
+    }
+};

--- a/database/migrations/2026_08_31_051838_create_party_duplicate_reviews_table.php
+++ b/database/migrations/2026_08_31_051838_create_party_duplicate_reviews_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('party_duplicate_reviews', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->uuid('intake_request_id');
+            $table->foreignId('submitted_party_id');
+            $table->foreignId('candidate_party_id');
+            $table->json('matched_fields');
+            $table->string('decision', 32)->default('pending');
+            $table->foreignId('canonical_party_id')->nullable();
+            $table->timestamp('decided_at')->nullable();
+            $table->timestamp('reversed_at')->nullable();
+            $table->unsignedBigInteger('decided_by_user_id')->nullable()->index();
+            $table->unsignedBigInteger('reversed_by_user_id')->nullable()->index();
+
+            $table->foreign(['organisation_id', 'intake_request_id'])
+                ->references(['organisation_id', 'id'])->on('intake_requests')->cascadeOnDelete();
+            $table->foreign(['organisation_id', 'submitted_party_id'], 'duplicate_reviews_submitted_party_foreign')
+                ->references(['organisation_id', 'id'])->on('parties')->restrictOnDelete();
+            $table->foreign(['organisation_id', 'candidate_party_id'], 'duplicate_reviews_candidate_party_foreign')
+                ->references(['organisation_id', 'id'])->on('parties')->restrictOnDelete();
+            $table->foreign(['organisation_id', 'canonical_party_id'], 'duplicate_reviews_canonical_party_foreign')
+                ->references(['organisation_id', 'id'])->on('parties')->restrictOnDelete();
+            $table->unique(['organisation_id', 'intake_request_id', 'candidate_party_id']);
+            $table->index(['organisation_id', 'decision']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('party_duplicate_reviews');
+    }
+};

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -1,5 +1,6 @@
 import { Link, usePage } from '@inertiajs/react';
 import {
+    ClipboardList,
     FolderGit2,
     LayoutGrid,
     Scale,
@@ -21,6 +22,7 @@ import {
     SidebarMenuItem,
 } from '@/components/ui/sidebar';
 import { dashboard } from '@/routes';
+import { index as intakesIndex } from '@/routes/intakes';
 import { index as partiesIndex } from '@/routes/parties';
 import { index as programsIndex } from '@/routes/programs';
 import type { NavItem } from '@/types';
@@ -43,6 +45,15 @@ export function AppSidebar() {
                       title: 'Party profiles',
                       href: partiesIndex(page.props.currentOrganisation.slug),
                       icon: UsersRound,
+                  },
+              ]
+            : []),
+        ...(page.props.canViewIntakes && page.props.currentOrganisation
+            ? [
+                  {
+                      title: 'Service requests',
+                      href: intakesIndex(page.props.currentOrganisation.slug),
+                      icon: ClipboardList,
                   },
               ]
             : []),

--- a/resources/js/pages/intakes/index.tsx
+++ b/resources/js/pages/intakes/index.tsx
@@ -1,0 +1,416 @@
+import { Head, Link, useForm, usePage } from '@inertiajs/react';
+import { FormEvent } from 'react';
+import Heading from '@/components/heading';
+import InputError from '@/components/input-error';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { index, show, store } from '@/routes/intakes';
+
+type FieldDefinition = {
+    key: string;
+    label: string;
+    type: 'text' | 'textarea' | 'boolean' | 'date';
+    required: boolean;
+};
+type Program = {
+    id: number;
+    name: string;
+    configuration: {
+        intake_fields?: FieldDefinition[];
+        risk_flags?: { key: string; label: string }[];
+    };
+};
+type Party = { uuid: string; displayName: string };
+type Intake = {
+    id: string;
+    party: Party;
+    program: { id: number; name: string };
+    status: string;
+    urgency: string;
+};
+type Props = {
+    intakes: {
+        data: Intake[];
+        links: { url: string | null; label: string; active: boolean }[];
+    };
+    programs: Program[];
+    parties: Party[];
+};
+
+export default function IntakesIndex({ intakes, programs, parties }: Props) {
+    const organisation = usePage().props.currentOrganisation!;
+    const form = useForm({
+        program_id: programs[0]?.id ?? 0,
+        party_uuid: parties[0]?.uuid ?? '',
+        source: 'staff_referral',
+        narrative: '',
+        presenting_needs: '',
+        email: '',
+        telephone: '',
+        intake_fields: {} as Record<string, string | boolean>,
+        risk_flags: [] as string[],
+        consent_granted: false,
+        consent_source: 'verbal',
+        idempotency_key: crypto.randomUUID(),
+    });
+    const program = programs.find(
+        (candidate) => candidate.id === Number(form.data.program_id),
+    );
+    const fields = program?.configuration.intake_fields ?? [];
+    const risks = program?.configuration.risk_flags ?? [];
+    const submit = (event: FormEvent) => {
+        event.preventDefault();
+        form.post(store.url(organisation.slug));
+    };
+
+    return (
+        <>
+            <Head title="Service requests" />
+            <div className="space-y-8 p-4">
+                <Heading
+                    title="Service requests"
+                    description="Record referrals, review likely duplicates, triage requests, and assign accepted cases."
+                />
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Record a request</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <form
+                            onSubmit={submit}
+                            className="grid gap-4 md:grid-cols-2"
+                        >
+                            <div>
+                                <Label htmlFor="program_id">Program</Label>
+                                <select
+                                    id="program_id"
+                                    className="h-9 w-full rounded-md border bg-transparent px-3"
+                                    value={form.data.program_id}
+                                    onChange={(event) => {
+                                        form.setData(
+                                            'program_id',
+                                            Number(event.target.value),
+                                        );
+                                        form.setData('intake_fields', {});
+                                        form.setData('risk_flags', []);
+                                    }}
+                                >
+                                    {programs.map((option) => (
+                                        <option
+                                            key={option.id}
+                                            value={option.id}
+                                        >
+                                            {option.name}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={form.errors.program_id} />
+                            </div>
+                            <div>
+                                <Label htmlFor="party_uuid">Party</Label>
+                                <select
+                                    id="party_uuid"
+                                    className="h-9 w-full rounded-md border bg-transparent px-3"
+                                    value={form.data.party_uuid}
+                                    onChange={(event) =>
+                                        form.setData(
+                                            'party_uuid',
+                                            event.target.value,
+                                        )
+                                    }
+                                >
+                                    {parties.map((party) => (
+                                        <option
+                                            key={party.uuid}
+                                            value={party.uuid}
+                                        >
+                                            {party.displayName}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError message={form.errors.party_uuid} />
+                            </div>
+                            <div>
+                                <Label htmlFor="source">Referral source</Label>
+                                <select
+                                    id="source"
+                                    className="h-9 w-full rounded-md border bg-transparent px-3"
+                                    value={form.data.source}
+                                    onChange={(event) =>
+                                        form.setData(
+                                            'source',
+                                            event.target.value,
+                                        )
+                                    }
+                                >
+                                    <option value="staff_referral">
+                                        Staff referral
+                                    </option>
+                                    <option value="self_referral">
+                                        Self-referral
+                                    </option>
+                                    <option value="partner_referral">
+                                        Partner referral
+                                    </option>
+                                    <option value="phone">Phone</option>
+                                    <option value="walk_in">Walk-in</option>
+                                    <option value="online">Online</option>
+                                </select>
+                            </div>
+                            <div className="grid grid-cols-2 gap-3">
+                                <div>
+                                    <Label htmlFor="email">
+                                        Submitted email
+                                    </Label>
+                                    <Input
+                                        id="email"
+                                        type="email"
+                                        value={form.data.email}
+                                        onChange={(event) =>
+                                            form.setData(
+                                                'email',
+                                                event.target.value,
+                                            )
+                                        }
+                                    />
+                                </div>
+                                <div>
+                                    <Label htmlFor="telephone">
+                                        Submitted telephone
+                                    </Label>
+                                    <Input
+                                        id="telephone"
+                                        value={form.data.telephone}
+                                        onChange={(event) =>
+                                            form.setData(
+                                                'telephone',
+                                                event.target.value,
+                                            )
+                                        }
+                                    />
+                                </div>
+                            </div>
+                            <div className="md:col-span-2">
+                                <Label htmlFor="presenting_needs">
+                                    Presenting needs
+                                </Label>
+                                <Textarea
+                                    id="presenting_needs"
+                                    value={form.data.presenting_needs}
+                                    onChange={(event) =>
+                                        form.setData(
+                                            'presenting_needs',
+                                            event.target.value,
+                                        )
+                                    }
+                                    required
+                                />
+                                <InputError
+                                    message={form.errors.presenting_needs}
+                                />
+                            </div>
+                            <div className="md:col-span-2">
+                                <Label htmlFor="narrative">
+                                    Intake narrative
+                                </Label>
+                                <Textarea
+                                    id="narrative"
+                                    value={form.data.narrative}
+                                    onChange={(event) =>
+                                        form.setData(
+                                            'narrative',
+                                            event.target.value,
+                                        )
+                                    }
+                                    required
+                                />
+                                <InputError message={form.errors.narrative} />
+                            </div>
+                            {fields.map((field) => (
+                                <div
+                                    key={field.key}
+                                    className={
+                                        field.type === 'textarea'
+                                            ? 'md:col-span-2'
+                                            : ''
+                                    }
+                                >
+                                    <Label htmlFor={`field-${field.key}`}>
+                                        {field.label}
+                                    </Label>
+                                    {field.type === 'textarea' ? (
+                                        <Textarea
+                                            id={`field-${field.key}`}
+                                            value={String(
+                                                form.data.intake_fields[
+                                                    field.key
+                                                ] ?? '',
+                                            )}
+                                            onChange={(event) =>
+                                                form.setData('intake_fields', {
+                                                    ...form.data.intake_fields,
+                                                    [field.key]:
+                                                        event.target.value,
+                                                })
+                                            }
+                                            required={field.required}
+                                        />
+                                    ) : field.type === 'boolean' ? (
+                                        <input
+                                            id={`field-${field.key}`}
+                                            className="ml-3 size-4"
+                                            type="checkbox"
+                                            checked={Boolean(
+                                                form.data.intake_fields[
+                                                    field.key
+                                                ],
+                                            )}
+                                            onChange={(event) =>
+                                                form.setData('intake_fields', {
+                                                    ...form.data.intake_fields,
+                                                    [field.key]:
+                                                        event.target.checked,
+                                                })
+                                            }
+                                        />
+                                    ) : (
+                                        <Input
+                                            id={`field-${field.key}`}
+                                            type={field.type}
+                                            value={String(
+                                                form.data.intake_fields[
+                                                    field.key
+                                                ] ?? '',
+                                            )}
+                                            onChange={(event) =>
+                                                form.setData('intake_fields', {
+                                                    ...form.data.intake_fields,
+                                                    [field.key]:
+                                                        event.target.value,
+                                                })
+                                            }
+                                            required={field.required}
+                                        />
+                                    )}
+                                </div>
+                            ))}
+                            {risks.length > 0 ? (
+                                <fieldset className="md:col-span-2">
+                                    <legend className="text-sm font-medium">
+                                        Risk indicators reported at intake
+                                    </legend>
+                                    <div className="mt-2 flex flex-wrap gap-4">
+                                        {risks.map((risk) => (
+                                            <label
+                                                key={risk.key}
+                                                className="flex items-center gap-2 text-sm"
+                                            >
+                                                <input
+                                                    type="checkbox"
+                                                    checked={form.data.risk_flags.includes(
+                                                        risk.key,
+                                                    )}
+                                                    onChange={(event) =>
+                                                        form.setData(
+                                                            'risk_flags',
+                                                            event.target.checked
+                                                                ? [
+                                                                      ...form
+                                                                          .data
+                                                                          .risk_flags,
+                                                                      risk.key,
+                                                                  ]
+                                                                : form.data.risk_flags.filter(
+                                                                      (key) =>
+                                                                          key !==
+                                                                          risk.key,
+                                                                  ),
+                                                        )
+                                                    }
+                                                />
+                                                {risk.label}
+                                            </label>
+                                        ))}
+                                    </div>
+                                </fieldset>
+                            ) : null}
+                            <label className="flex items-center gap-2 text-sm md:col-span-2">
+                                <input
+                                    type="checkbox"
+                                    checked={form.data.consent_granted}
+                                    onChange={(event) =>
+                                        form.setData(
+                                            'consent_granted',
+                                            event.target.checked,
+                                        )
+                                    }
+                                />
+                                Service consent was granted using wording
+                                version service-intake-v1
+                            </label>
+                            <InputError message={form.errors.consent_granted} />
+                            <div className="md:col-span-2">
+                                <Button
+                                    disabled={
+                                        form.processing ||
+                                        programs.length === 0 ||
+                                        parties.length === 0
+                                    }
+                                >
+                                    Record draft request
+                                </Button>
+                            </div>
+                        </form>
+                    </CardContent>
+                </Card>
+                <div className="space-y-3">
+                    {intakes.data.map((intake) => (
+                        <Link
+                            key={intake.id}
+                            href={show.url([organisation.slug, intake.id])}
+                            className="hover:bg-muted/40 block rounded-lg border p-4"
+                        >
+                            <div className="flex flex-wrap items-center justify-between gap-2">
+                                <div>
+                                    <p className="font-medium">
+                                        {intake.party.displayName}
+                                    </p>
+                                    <p className="text-muted-foreground text-sm">
+                                        {intake.program.name}
+                                    </p>
+                                </div>
+                                <div className="flex gap-2">
+                                    <Badge variant="outline">
+                                        {intake.urgency.replace('_', ' ')}
+                                    </Badge>
+                                    <Badge>
+                                        {intake.status.replace('_', ' ')}
+                                    </Badge>
+                                </div>
+                            </div>
+                        </Link>
+                    ))}
+                    {intakes.data.length === 0 ? (
+                        <p className="text-muted-foreground text-sm">
+                            No service requests are visible in your Programs
+                            yet.
+                        </p>
+                    ) : null}
+                </div>
+            </div>
+        </>
+    );
+}
+
+IntakesIndex.layout = (props: { currentOrganisation: { slug: string } }) => ({
+    breadcrumbs: [
+        {
+            title: 'Service requests',
+            href: index(props.currentOrganisation.slug),
+        },
+    ],
+});

--- a/resources/js/pages/intakes/show.tsx
+++ b/resources/js/pages/intakes/show.tsx
@@ -1,0 +1,477 @@
+import { Form, Head, Link, router, usePage } from '@inertiajs/react';
+import Heading from '@/components/heading';
+import InputError from '@/components/input-error';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { index } from '@/routes/intakes';
+import { store as assign } from '@/routes/intakes/assignments';
+import { store as transition } from '@/routes/intakes/transitions';
+import {
+    destroy as reverseDuplicate,
+    store as reviewDuplicate,
+} from '@/routes/duplicate-reviews';
+
+const transitions: Record<string, string[]> = {
+    draft: ['submitted', 'withdrawn'],
+    submitted: ['under_review', 'withdrawn'],
+    under_review: [
+        'waitlisted',
+        'accepted',
+        'redirected',
+        'declined',
+        'withdrawn',
+    ],
+    waitlisted: ['under_review', 'accepted', 'redirected', 'withdrawn'],
+};
+
+export default function IntakeShow({ intake, canTransition, workers }: any) {
+    const organisation = usePage().props.currentOrganisation!;
+    const args = [organisation.slug, intake.id] as [string, string];
+    const availableTransitions = transitions[intake.status] ?? [];
+
+    return (
+        <>
+            <Head title={`${intake.party.displayName} service request`} />
+            <div className="space-y-8 p-4">
+                <div>
+                    <Link
+                        className="text-muted-foreground text-sm"
+                        href={index.url(organisation.slug)}
+                    >
+                        ← Service requests
+                    </Link>
+                    <Heading
+                        title={intake.party.displayName}
+                        description={intake.program.name}
+                    />
+                    <div className="flex gap-2">
+                        <Badge>{intake.status.replace('_', ' ')}</Badge>
+                        <Badge variant="outline">{intake.urgency}</Badge>
+                        <Badge variant="outline">
+                            {intake.eligibilityStatus.replace('_', ' ')}
+                        </Badge>
+                    </div>
+                </div>
+                <div className="grid gap-6 lg:grid-cols-2">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Presenting needs</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-4 text-sm">
+                            <p className="whitespace-pre-wrap">
+                                {intake.presentingNeeds}
+                            </p>
+                            <p className="text-muted-foreground whitespace-pre-wrap">
+                                {intake.narrative}
+                            </p>
+                            {Object.entries(intake.intakeFields).map(
+                                ([key, value]) => (
+                                    <p key={key}>
+                                        <strong>
+                                            {key.replaceAll('_', ' ')}:
+                                        </strong>{' '}
+                                        {String(value)}
+                                    </p>
+                                ),
+                            )}
+                            <div className="flex flex-wrap gap-2">
+                                {intake.riskFlags.map((risk: string) => (
+                                    <Badge key={risk} variant="destructive">
+                                        {risk.replaceAll('_', ' ')}
+                                    </Badge>
+                                ))}
+                            </div>
+                        </CardContent>
+                    </Card>
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Triage and decision</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            {canTransition &&
+                            availableTransitions.length > 0 ? (
+                                <Form
+                                    action={transition.url(args)}
+                                    method="post"
+                                    className="space-y-4"
+                                    resetOnSuccess={false}
+                                >
+                                    {({ errors, processing }) => (
+                                        <>
+                                            <input
+                                                type="hidden"
+                                                name="expected_version"
+                                                value={intake.version}
+                                            />
+                                            <div>
+                                                <Label htmlFor="status">
+                                                    Next status
+                                                </Label>
+                                                <select
+                                                    id="status"
+                                                    name="status"
+                                                    className="h-9 w-full rounded-md border bg-transparent px-3"
+                                                >
+                                                    {availableTransitions.map(
+                                                        (status) => (
+                                                            <option
+                                                                key={status}
+                                                                value={status}
+                                                            >
+                                                                {status.replace(
+                                                                    '_',
+                                                                    ' ',
+                                                                )}
+                                                            </option>
+                                                        ),
+                                                    )}
+                                                </select>
+                                                <InputError
+                                                    message={errors.status}
+                                                />
+                                            </div>
+                                            <div>
+                                                <Label htmlFor="urgency">
+                                                    Urgency
+                                                </Label>
+                                                <select
+                                                    id="urgency"
+                                                    name="urgency"
+                                                    defaultValue={
+                                                        intake.urgency
+                                                    }
+                                                    className="h-9 w-full rounded-md border bg-transparent px-3"
+                                                >
+                                                    <option value="routine">
+                                                        Routine
+                                                    </option>
+                                                    <option value="priority">
+                                                        Priority
+                                                    </option>
+                                                    <option value="urgent">
+                                                        Urgent
+                                                    </option>
+                                                </select>
+                                                <p className="text-muted-foreground mt-1 text-xs">
+                                                    Urgent prioritises work; it
+                                                    is not an emergency-dispatch
+                                                    service.
+                                                </p>
+                                            </div>
+                                            <div>
+                                                <Label htmlFor="eligibility_status">
+                                                    Eligibility
+                                                </Label>
+                                                <select
+                                                    id="eligibility_status"
+                                                    name="eligibility_status"
+                                                    defaultValue={
+                                                        intake.eligibilityStatus
+                                                    }
+                                                    className="h-9 w-full rounded-md border bg-transparent px-3"
+                                                >
+                                                    <option value="needs_review">
+                                                        Needs review
+                                                    </option>
+                                                    <option value="eligible">
+                                                        Eligible
+                                                    </option>
+                                                    <option value="ineligible">
+                                                        Ineligible
+                                                    </option>
+                                                </select>
+                                            </div>
+                                            {(
+                                                intake.configuration
+                                                    .eligibility_fields ?? []
+                                            ).map((field: any) => (
+                                                <label
+                                                    key={field.key}
+                                                    className="flex items-center gap-2 text-sm"
+                                                >
+                                                    <input
+                                                        type="hidden"
+                                                        name={`eligibility_context[${field.key}]`}
+                                                        value="0"
+                                                    />
+                                                    <input
+                                                        type="checkbox"
+                                                        name={`eligibility_context[${field.key}]`}
+                                                        value="1"
+                                                        defaultChecked={Boolean(
+                                                            intake
+                                                                .eligibilityContext[
+                                                                field.key
+                                                            ],
+                                                        )}
+                                                    />
+                                                    {field.label}
+                                                </label>
+                                            ))}
+                                            {(
+                                                intake.configuration
+                                                    .risk_flags ?? []
+                                            ).map((risk: any) => (
+                                                <label
+                                                    key={risk.key}
+                                                    className="flex items-center gap-2 text-sm"
+                                                >
+                                                    <input
+                                                        type="checkbox"
+                                                        name="risk_flags[]"
+                                                        value={risk.key}
+                                                        defaultChecked={intake.riskFlags.includes(
+                                                            risk.key,
+                                                        )}
+                                                    />
+                                                    {risk.label}
+                                                </label>
+                                            ))}
+                                            <input
+                                                type="hidden"
+                                                name="risk_flags[]"
+                                                value=""
+                                            />
+                                            <div>
+                                                <Label htmlFor="worker_membership_id">
+                                                    Assign worker when accepted
+                                                </Label>
+                                                <select
+                                                    id="worker_membership_id"
+                                                    name="worker_membership_id"
+                                                    className="h-9 w-full rounded-md border bg-transparent px-3"
+                                                >
+                                                    <option value="">
+                                                        Leave in Program queue
+                                                    </option>
+                                                    {workers.map(
+                                                        (worker: any) => (
+                                                            <option
+                                                                key={worker.id}
+                                                                value={
+                                                                    worker.id
+                                                                }
+                                                            >
+                                                                {worker.name}
+                                                            </option>
+                                                        ),
+                                                    )}
+                                                </select>
+                                            </div>
+                                            <div>
+                                                <Label htmlFor="reason">
+                                                    Decision reason code
+                                                </Label>
+                                                <select
+                                                    id="reason"
+                                                    name="reason"
+                                                    className="h-9 w-full rounded-md border bg-transparent px-3"
+                                                >
+                                                    <option value="">
+                                                        Not required
+                                                    </option>
+                                                    <option value="client_request">
+                                                        Client request
+                                                    </option>
+                                                    <option value="eligibility">
+                                                        Eligibility
+                                                    </option>
+                                                    <option value="capacity">
+                                                        Program capacity
+                                                    </option>
+                                                    <option value="external_referral">
+                                                        External referral
+                                                    </option>
+                                                    <option value="duplicate">
+                                                        Duplicate request
+                                                    </option>
+                                                    <option value="other">
+                                                        Other coded reason
+                                                    </option>
+                                                </select>
+                                            </div>
+                                            <Button disabled={processing}>
+                                                Apply transition
+                                            </Button>
+                                        </>
+                                    )}
+                                </Form>
+                            ) : (
+                                <p className="text-muted-foreground text-sm">
+                                    No further transition is available to your
+                                    role.
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+                </div>
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Duplicate review</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        {intake.duplicateReviews.map((review: any) => (
+                            <div
+                                key={review.id}
+                                className="flex flex-wrap items-center justify-between gap-3 rounded-md border p-3 text-sm"
+                            >
+                                <div>
+                                    <strong>
+                                        {review.candidate.displayName}
+                                    </strong>
+                                    <p className="text-muted-foreground">
+                                        Exact tenant-local match:{' '}
+                                        {review.matchedFields.join(', ')}
+                                    </p>
+                                    <Badge variant="outline">
+                                        {review.reversedAt
+                                            ? 'reversed'
+                                            : review.decision}
+                                    </Badge>
+                                </div>
+                                {canTransition &&
+                                review.decision === 'pending' ? (
+                                    <div className="flex gap-2">
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            onClick={() =>
+                                                router.post(
+                                                    reviewDuplicate.url([
+                                                        organisation.slug,
+                                                        review.id,
+                                                    ]),
+                                                    { decision: 'dismissed' },
+                                                )
+                                            }
+                                        >
+                                            Keep separate
+                                        </Button>
+                                        <Button
+                                            size="sm"
+                                            onClick={() =>
+                                                router.post(
+                                                    reviewDuplicate.url([
+                                                        organisation.slug,
+                                                        review.id,
+                                                    ]),
+                                                    { decision: 'merged' },
+                                                )
+                                            }
+                                        >
+                                            Use existing Party
+                                        </Button>
+                                    </div>
+                                ) : null}
+                                {canTransition &&
+                                review.decision === 'merged' &&
+                                !review.reversedAt ? (
+                                    <Button
+                                        size="sm"
+                                        variant="outline"
+                                        onClick={() =>
+                                            router.delete(
+                                                reverseDuplicate.url([
+                                                    organisation.slug,
+                                                    review.id,
+                                                ]),
+                                            )
+                                        }
+                                    >
+                                        Reverse
+                                    </Button>
+                                ) : null}
+                            </div>
+                        ))}
+                        {intake.duplicateReviews.length === 0 ? (
+                            <p className="text-muted-foreground text-sm">
+                                No exact contact match was found in this
+                                Organisation.
+                            </p>
+                        ) : null}
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Case assignment history</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        {intake.case?.assignments.map((assignment: any) => (
+                            <div key={assignment.id} className="text-sm">
+                                <strong>{assignment.worker}</strong> ·{' '}
+                                {assignment.status} ·{' '}
+                                {new Date(
+                                    assignment.startedAt,
+                                ).toLocaleString()}
+                            </div>
+                        ))}
+                        {intake.case && canTransition ? (
+                            <Form
+                                action={assign.url(args)}
+                                method="post"
+                                className="flex flex-wrap gap-2"
+                            >
+                                <select
+                                    name="membership_id"
+                                    className="h-9 rounded-md border bg-transparent px-3"
+                                >
+                                    {workers.map((worker: any) => (
+                                        <option
+                                            key={worker.id}
+                                            value={worker.id}
+                                        >
+                                            {worker.name}
+                                        </option>
+                                    ))}
+                                </select>
+                                <select
+                                    name="reason"
+                                    className="h-9 flex-1 rounded-md border bg-transparent px-3"
+                                >
+                                    <option value="initial_assignment">
+                                        Initial assignment
+                                    </option>
+                                    <option value="caseload_transfer">
+                                        Caseload transfer
+                                    </option>
+                                    <option value="availability">
+                                        Worker availability
+                                    </option>
+                                    <option value="program_rebalance">
+                                        Program rebalance
+                                    </option>
+                                    <option value="other">
+                                        Other coded reason
+                                    </option>
+                                </select>
+                                <Button>Assign or transfer</Button>
+                            </Form>
+                        ) : null}
+                        {!intake.case ? (
+                            <p className="text-muted-foreground text-sm">
+                                A case is created atomically when this request
+                                is accepted.
+                            </p>
+                        ) : null}
+                    </CardContent>
+                </Card>
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Immutable transition history</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-2 text-sm">
+                        {intake.transitions.map((item: any) => (
+                            <p key={item.id}>
+                                v{item.version}: {item.from ?? 'created'} →{' '}
+                                {item.to}
+                                {item.reason ? ` — ${item.reason}` : ''}
+                            </p>
+                        ))}
+                    </CardContent>
+                </Card>
+            </div>
+        </>
+    );
+}

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -16,6 +16,7 @@ declare module '@inertiajs/core' {
             canCreateOrganisation: boolean;
             canViewParties: boolean;
             canViewPrograms: boolean;
+            canViewIntakes: boolean;
             currentOrganisation: Organisation | null;
             organisations: Organisation[];
             [key: string]: unknown;

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,10 +1,14 @@
 <?php
 
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\Organisations\CaseAssignmentController;
+use App\Http\Controllers\Organisations\IntakeRequestController;
+use App\Http\Controllers\Organisations\IntakeTransitionController;
 use App\Http\Controllers\Organisations\OrganisationInvitationController;
 use App\Http\Controllers\Organisations\PartyAddressController;
 use App\Http\Controllers\Organisations\PartyConsentController;
 use App\Http\Controllers\Organisations\PartyController;
+use App\Http\Controllers\Organisations\PartyDuplicateReviewController;
 use App\Http\Controllers\Organisations\PartyRelationshipController;
 use App\Http\Controllers\Organisations\PartySafeContactInstructionController;
 use App\Http\Controllers\Organisations\ProgramController;
@@ -76,6 +80,13 @@ Route::prefix('{current_organisation}')
         Route::get('dashboard', DashboardController::class)->name('dashboard');
         Route::get('programs', [ProgramController::class, 'index'])->name('programs.index');
         Route::resource('parties', PartyController::class)->only(['index', 'store', 'show', 'update']);
+        Route::resource('intakes', IntakeRequestController::class)
+            ->parameters(['intakes' => 'intake'])
+            ->only(['index', 'store', 'show']);
+        Route::post('intakes/{intake}/transitions', [IntakeTransitionController::class, 'store'])->name('intakes.transitions.store');
+        Route::post('intakes/{intake}/assignments', [CaseAssignmentController::class, 'store'])->name('intakes.assignments.store');
+        Route::post('duplicate-reviews/{duplicate_review}', [PartyDuplicateReviewController::class, 'store'])->name('duplicate-reviews.store');
+        Route::delete('duplicate-reviews/{duplicate_review}', [PartyDuplicateReviewController::class, 'destroy'])->name('duplicate-reviews.destroy');
         Route::post('parties/{party}/consents', [PartyConsentController::class, 'store'])->name('parties.consents.store');
         Route::post('parties/{party}/addresses', [PartyAddressController::class, 'store'])->name('parties.addresses.store');
         Route::post('parties/{party}/relationships', [PartyRelationshipController::class, 'store'])->name('parties.relationships.store');

--- a/tests/Feature/CommunityKindScenarioSeederTest.php
+++ b/tests/Feature/CommunityKindScenarioSeederTest.php
@@ -56,7 +56,7 @@ it('seeds the versioned synthetic scenarios deterministically', function () {
         ->map(fn (int|string $count): int => (int) $count)
         ->all();
 
-    expect(ScenarioCatalog::VERSION)->toBe('2026.1')
+    expect(ScenarioCatalog::VERSION)->toBe('2026.2')
         ->and(ScenarioCatalog::AS_OF)->toBe('2026-06-30 23:59:59')
         ->and(Date::getTestNow())->toBeNull()
         ->and(Organisation::query()->count())->toBe(2)

--- a/tests/Feature/IntakeRequestWorkflowTest.php
+++ b/tests/Feature/IntakeRequestWorkflowTest.php
@@ -1,0 +1,319 @@
+<?php
+
+use App\Actions\Intake\ReversePartyMerge;
+use App\Actions\Intake\ReviewPartyDuplicate;
+use App\Actions\Intake\TransitionIntakeRequest;
+use App\Actions\Parties\StorePartyContact;
+use App\Enums\CaseAssignmentStatus;
+use App\Enums\ConsentPurpose;
+use App\Enums\DuplicateReviewDecision;
+use App\Enums\IntakeStatus;
+use App\Enums\OrganisationRole;
+use App\Enums\PartyContactType;
+use App\Models\CaseAssignment;
+use App\Models\IntakeRequest;
+use App\Models\Membership;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\PartyDuplicateReview;
+use App\Models\Program;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/** @return array{manager: User, managerMembership: Membership, worker: User, workerMembership: Membership, organisation: Organisation, program: Program, party: Party} */
+function intakeWorkflowFixture(): array
+{
+    $manager = User::factory()->create();
+    $worker = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    $managerMembership = $organisation->memberships()->create(['user_id' => $manager->id, 'role' => OrganisationRole::ProgramManager]);
+    $workerMembership = $organisation->memberships()->create(['user_id' => $worker->id, 'role' => OrganisationRole::CaseWorker]);
+    [$program, $party] = app(OrganisationContext::class)->run($organisation, function () use ($organisation, $managerMembership, $workerMembership): array {
+        $program = Program::factory()->for($organisation)->create(['configuration' => [
+            'labels' => ['request' => 'Housing request', 'case' => 'Housing journey'],
+            'stages' => [['key' => 'received', 'label' => 'Received']],
+            'outcome_measures' => [['key' => 'housing_stability', 'label' => 'Housing stability', 'unit' => 'score']],
+            'taxonomies' => [['key' => 'need', 'label' => 'Need', 'values' => ['Housing']]],
+            'intake_fields' => [['key' => 'current_situation', 'label' => 'Current situation', 'type' => 'textarea', 'required' => true]],
+            'eligibility_fields' => [['key' => 'service_area', 'label' => 'Lives in service area']],
+            'risk_flags' => [['key' => 'housing_loss', 'label' => 'At risk of losing housing']],
+        ]]);
+        $managerMembership->programs()->attach($program);
+        $workerMembership->programs()->attach($program);
+        $party = Party::factory()->for($organisation)->create(['display_name' => 'Amina Example']);
+        $party->programs()->attach($program);
+
+        return [$program, $party];
+    });
+
+    return compact('manager', 'managerMembership', 'worker', 'workerMembership', 'organisation', 'program', 'party');
+}
+
+/** @param array<string, mixed> $overrides
+ * @return array<string, mixed>
+ */
+function intakeRequestPayload(Program $program, Party $party, array $overrides = []): array
+{
+    return [
+        'program_id' => $program->id,
+        'party_uuid' => $party->uuid,
+        'source' => 'staff_referral',
+        'narrative' => 'A fictional referral from a community partner.',
+        'presenting_needs' => 'Amina needs stable housing and tenancy advice.',
+        'email' => 'amina@example.test',
+        'telephone' => '+27 82 555 0101',
+        'intake_fields' => ['current_situation' => 'Temporarily staying with friends.'],
+        'risk_flags' => ['housing_loss'],
+        'consent_granted' => true,
+        'consent_source' => 'verbal',
+        'idempotency_key' => 'housing-referral-001',
+        ...$overrides,
+    ];
+}
+
+function createIntakeThroughHttp(object $test, array $fixture, array $overrides = []): IntakeRequest
+{
+    $test->actingAs($fixture['manager'])
+        ->post(route('intakes.store', $fixture['organisation']), intakeRequestPayload($fixture['program'], $fixture['party'], $overrides))
+        ->assertRedirect();
+
+    return app(OrganisationContext::class)->run(
+        $fixture['organisation'],
+        fn (): IntakeRequest => IntakeRequest::query()->where('idempotency_key', $overrides['idempotency_key'] ?? 'housing-referral-001')->firstOrFail(),
+    );
+}
+
+it('records encrypted Program-defined intake content, service consent, and tenant-local duplicate suggestions', function () {
+    $fixture = intakeWorkflowFixture();
+    $candidate = app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): Party {
+        $candidate = Party::factory()->for($fixture['organisation'])->create(['display_name' => 'Existing Amina']);
+        app(StorePartyContact::class)->handle($candidate, PartyContactType::Email, 'amina@example.test');
+
+        return $candidate;
+    });
+    $otherOrganisation = Organisation::factory()->active()->create();
+    app(OrganisationContext::class)->run($otherOrganisation, function () use ($otherOrganisation): void {
+        $otherParty = Party::factory()->for($otherOrganisation)->create(['display_name' => 'Other tenant record']);
+        app(StorePartyContact::class)->handle($otherParty, PartyContactType::Email, 'amina@example.test');
+    });
+
+    $intake = createIntakeThroughHttp($this, $fixture);
+    $this->actingAs($fixture['manager'])
+        ->post(route('intakes.store', $fixture['organisation']), intakeRequestPayload($fixture['program'], $fixture['party']))
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    expect(DB::table('intake_requests')->where('id', $intake->id)->value('encrypted_content'))
+        ->not->toContain('stable housing')
+        ->not->toContain('Temporarily staying with friends');
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($intake, $candidate, $fixture): void {
+        expect(IntakeRequest::query()->where('idempotency_key', 'housing-referral-001')->count())->toBe(1)
+            ->and($intake->transitions()->count())->toBe(1)
+            ->and($intake->duplicateReviews()->count())->toBe(1)
+            ->and($intake->duplicateReviews()->firstOrFail()->candidate_party_id)->toBe($candidate->id)
+            ->and($fixture['party']->consents()->where('purpose', ConsentPurpose::Service)->count())->toBe(0);
+    });
+    $this->actingAs($fixture['manager'])
+        ->get(route('intakes.show', [$fixture['organisation'], $intake]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('intakes/show')
+            ->where('intake.presentingNeeds', 'Amina needs stable housing and tenancy advice.')
+            ->where('intake.duplicateReviews.0.candidate.displayName', 'Existing Amina')
+            ->missing('intake.duplicateReviews.0.candidate.services'));
+});
+
+it('validates fields and risk flags against the selected Program configuration', function () {
+    $fixture = intakeWorkflowFixture();
+
+    $this->actingAs($fixture['manager'])
+        ->post(route('intakes.store', $fixture['organisation']), intakeRequestPayload($fixture['program'], $fixture['party'], [
+            'intake_fields' => ['unexpected' => 'not allowed'],
+            'risk_flags' => ['unconfigured_risk'],
+        ]))
+        ->assertSessionHasErrors(['intake_fields', 'intake_fields.current_situation', 'risk_flags.0']);
+});
+
+it('accepts an intake exactly once and atomically creates and assigns one open case', function () {
+    $fixture = intakeWorkflowFixture();
+    $intake = createIntakeThroughHttp($this, $fixture);
+
+    foreach ([IntakeStatus::Submitted, IntakeStatus::UnderReview] as $status) {
+        $this->actingAs($fixture['manager'])->post(route('intakes.transitions.store', [$fixture['organisation'], $intake]), [
+            'status' => $status->value,
+            'expected_version' => $intake->version,
+        ])->assertRedirect()->assertSessionHasNoErrors();
+        $intake->refresh();
+    }
+    $this->actingAs($fixture['manager'])->post(route('intakes.transitions.store', [$fixture['organisation'], $intake]), [
+        'status' => IntakeStatus::Accepted->value,
+        'expected_version' => $intake->version,
+        'urgency' => 'priority',
+        'eligibility_status' => 'eligible',
+        'eligibility_context' => ['service_area' => true],
+        'risk_flags' => ['housing_loss'],
+        'worker_membership_id' => $fixture['workerMembership']->id,
+    ])->assertRedirect()->assertSessionHasNoErrors();
+    $intake->refresh();
+    $case = app(OrganisationContext::class)->run($fixture['organisation'], fn (): ServiceCase => $intake->serviceCase()->firstOrFail());
+
+    expect($intake->status)->toBe(IntakeStatus::Accepted);
+    app(OrganisationContext::class)->run($fixture['organisation'], fn () => expect($intake->transitions()->count())->toBe(4)
+        ->and($case->assignments()->where('status', CaseAssignmentStatus::Active)->count())->toBe(1)
+        ->and($intake->party->consents()->where('purpose', ConsentPurpose::Service)->count())->toBe(1));
+    $this->actingAs($fixture['worker'])
+        ->get(route('intakes.show', [$fixture['organisation'], $intake]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page->where('canTransition', false));
+
+    $this->actingAs($fixture['manager'])->post(route('intakes.transitions.store', [$fixture['organisation'], $intake]), [
+        'status' => IntakeStatus::Accepted->value,
+        'expected_version' => 3,
+        'worker_membership_id' => $fixture['workerMembership']->id,
+    ])->assertRedirect();
+    app(OrganisationContext::class)->run($fixture['organisation'], fn () => expect(ServiceCase::query()->where('intake_request_id', $intake->id)->count())->toBe(1)
+        ->and(CaseAssignment::query()->where('service_case_id', $case->id)->count())->toBe(1));
+});
+
+it('rejects stale or invalid decisions and preserves immutable transition history', function () {
+    $fixture = intakeWorkflowFixture();
+    $intake = createIntakeThroughHttp($this, $fixture);
+
+    $this->actingAs($fixture['manager'])->post(route('intakes.transitions.store', [$fixture['organisation'], $intake]), [
+        'status' => IntakeStatus::Accepted->value,
+        'expected_version' => 1,
+    ])->assertSessionHasErrors('status');
+    $this->actingAs($fixture['manager'])->post(route('intakes.transitions.store', [$fixture['organisation'], $intake]), [
+        'status' => IntakeStatus::Submitted->value,
+        'expected_version' => 99,
+    ])->assertSessionHasErrors('status');
+    expect(fn () => DB::transaction(fn () => DB::table('intake_transitions')->where('intake_request_id', $intake->id)->update(['reason' => 'rewritten'])))
+        ->toThrow(QueryException::class);
+});
+
+it('requires consent before acceptance and reasons for redirect or decline', function () {
+    $fixture = intakeWorkflowFixture();
+    $intake = createIntakeThroughHttp($this, $fixture, [
+        'consent_granted' => false,
+        'consent_source' => null,
+        'idempotency_key' => 'without-consent',
+    ]);
+    foreach ([IntakeStatus::Submitted, IntakeStatus::UnderReview] as $status) {
+        $this->actingAs($fixture['manager'])->post(route('intakes.transitions.store', [$fixture['organisation'], $intake]), [
+            'status' => $status->value,
+            'expected_version' => $intake->version,
+        ])->assertRedirect()->assertSessionHasNoErrors();
+        $intake->refresh();
+    }
+
+    $this->actingAs($fixture['manager'])->post(route('intakes.transitions.store', [$fixture['organisation'], $intake]), [
+        'status' => IntakeStatus::Accepted->value,
+        'expected_version' => $intake->version,
+    ])->assertSessionHasErrors('status');
+    $this->actingAs($fixture['manager'])->post(route('intakes.transitions.store', [$fixture['organisation'], $intake]), [
+        'status' => IntakeStatus::Redirected->value,
+        'expected_version' => $intake->version,
+    ])->assertSessionHasErrors('status');
+});
+
+it('transfers primary responsibility atomically and prevents assignment history rewrites', function () {
+    $fixture = intakeWorkflowFixture();
+    $replacement = User::factory()->create();
+    $replacementMembership = $fixture['organisation']->memberships()->create(['user_id' => $replacement->id, 'role' => OrganisationRole::CaseWorker]);
+    app(OrganisationContext::class)->run($fixture['organisation'], fn () => $replacementMembership->programs()->attach($fixture['program']));
+    $intake = createIntakeThroughHttp($this, $fixture);
+    foreach ([IntakeStatus::Submitted, IntakeStatus::UnderReview, IntakeStatus::Accepted] as $status) {
+        $this->actingAs($fixture['manager'])->post(route('intakes.transitions.store', [$fixture['organisation'], $intake]), [
+            'status' => $status->value,
+            'expected_version' => $intake->version,
+            'worker_membership_id' => $status === IntakeStatus::Accepted ? $fixture['workerMembership']->id : null,
+        ])->assertRedirect()->assertSessionHasNoErrors();
+        $intake->refresh();
+    }
+
+    $unauthorisedWorker = User::factory()->create();
+    $unauthorisedMembership = $fixture['organisation']->memberships()->create(['user_id' => $unauthorisedWorker->id, 'role' => OrganisationRole::CaseWorker]);
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture, $unauthorisedMembership): void {
+        $otherProgram = Program::factory()->for($fixture['organisation'])->create();
+        $unauthorisedMembership->programs()->attach($otherProgram);
+    });
+    $this->actingAs($fixture['manager'])->post(route('intakes.assignments.store', [$fixture['organisation'], $intake]), [
+        'membership_id' => $unauthorisedMembership->id,
+    ])->assertSessionHasErrors('membership_id');
+
+    $this->actingAs($fixture['manager'])->post(route('intakes.assignments.store', [$fixture['organisation'], $intake]), [
+        'membership_id' => $replacementMembership->id,
+        'reason' => 'caseload_transfer',
+    ])->assertRedirect()->assertSessionHasNoErrors();
+    $assignments = app(OrganisationContext::class)->run($fixture['organisation'], fn () => $intake->serviceCase->assignments()->orderBy('started_at')->get());
+    expect($assignments)->toHaveCount(2)
+        ->and($assignments[0]->status)->toBe(CaseAssignmentStatus::Ended)
+        ->and($assignments[0]->ended_reason)->toBe('caseload_transfer')
+        ->and($assignments[1]->membership_id)->toBe($replacementMembership->id);
+    expect(fn () => DB::transaction(fn () => DB::table('case_assignments')->where('id', $assignments[0]->id)->update(['membership_id' => $replacementMembership->id])))
+        ->toThrow(QueryException::class);
+});
+
+it('keeps duplicate decisions controlled, idempotent, and reversible before acceptance', function () {
+    $fixture = intakeWorkflowFixture();
+    $candidate = app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): Party {
+        $candidate = Party::factory()->for($fixture['organisation'])->create();
+        app(StorePartyContact::class)->handle($candidate, PartyContactType::Email, 'amina@example.test');
+
+        return $candidate;
+    });
+    $intake = createIntakeThroughHttp($this, $fixture);
+    $review = app(OrganisationContext::class)->run($fixture['organisation'], fn (): PartyDuplicateReview => $intake->duplicateReviews()->firstOrFail());
+
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($review, $fixture, $candidate, $intake): void {
+        app(ReviewPartyDuplicate::class)->handle($review, DuplicateReviewDecision::Merged, $fixture['manager']);
+        app(ReviewPartyDuplicate::class)->handle($review->refresh(), DuplicateReviewDecision::Merged, $fixture['manager']);
+        expect($intake->refresh()->party_id)->toBe($candidate->id);
+
+        $secondCandidate = Party::factory()->for($fixture['organisation'])->create();
+        $secondReview = PartyDuplicateReview::query()->create([
+            'organisation_id' => $fixture['organisation']->id,
+            'intake_request_id' => $intake->id,
+            'submitted_party_id' => $fixture['party']->id,
+            'candidate_party_id' => $secondCandidate->id,
+            'matched_fields' => ['email'],
+        ]);
+        expect(fn () => app(ReviewPartyDuplicate::class)->handle($secondReview, DuplicateReviewDecision::Merged, $fixture['manager']))
+            ->toThrow(LogicException::class, 'already linked to a different canonical Party');
+
+        $decidedBy = $review->refresh()->decided_by_user_id;
+        app(ReversePartyMerge::class)->handle($review->refresh(), $fixture['manager']);
+        expect($intake->refresh()->party_id)->toBe($fixture['party']->id)
+            ->and($review->refresh()->decided_by_user_id)->toBe($decidedBy)
+            ->and($review->reversed_by_user_id)->toBe($fixture['manager']->id)
+            ->and($candidate->trashed())->toBeFalse();
+
+        app(ReviewPartyDuplicate::class)->handle($secondReview, DuplicateReviewDecision::Merged, $fixture['manager']);
+        app(TransitionIntakeRequest::class)->handle($intake->refresh(), IntakeStatus::Submitted, 1, $fixture['manager']);
+        app(TransitionIntakeRequest::class)->handle($intake->refresh(), IntakeStatus::UnderReview, 2, $fixture['manager']);
+        app(TransitionIntakeRequest::class)->handle($intake->refresh(), IntakeStatus::Accepted, 3, $fixture['manager']);
+        expect(fn () => app(ReversePartyMerge::class)->handle($secondReview->refresh(), $fixture['manager']))
+            ->toThrow(LogicException::class, 'cannot be reversed after a Case has been created');
+    });
+});
+
+it('enforces role, Program, assignment, and cross-Organisation boundaries', function () {
+    $fixture = intakeWorkflowFixture();
+    $administrator = User::factory()->create();
+    $fixture['organisation']->memberships()->create(['user_id' => $administrator->id, 'role' => OrganisationRole::OrganisationAdministrator]);
+    $intake = createIntakeThroughHttp($this, $fixture);
+    $otherOrganisation = Organisation::factory()->active()->create();
+    $otherManager = User::factory()->create();
+    $otherOrganisation->memberships()->create(['user_id' => $otherManager->id, 'role' => OrganisationRole::ProgramManager]);
+
+    $this->actingAs($administrator)->get(route('intakes.show', [$fixture['organisation'], $intake]))->assertForbidden();
+    $this->actingAs($fixture['worker'])->get(route('intakes.show', [$fixture['organisation'], $intake]))->assertForbidden();
+    $this->actingAs($fixture['worker'])
+        ->post(route('intakes.store', $fixture['organisation']), intakeRequestPayload($fixture['program'], $fixture['party'], ['idempotency_key' => 'worker-created']))
+        ->assertRedirect(route('intakes.index', $fixture['organisation']));
+    $this->actingAs($otherManager)->get(route('intakes.show', [$otherOrganisation, $intake]))->assertNotFound();
+});


### PR DESCRIPTION
## Summary
- add encrypted, Program-configured service request intake with deterministic duplicate suggestions
- add append-only triage transitions, consent-gated acceptance, Case creation, and assignment history
- add tenant-scoped Inertia intake and triage screens with role and Program boundaries
- extend deterministic scenarios to cover the intake configuration

## Review
- reviewed the complete change against `codex/issue-10-party-profiles`
- fixed duplicate-decision and reversal races by serializing on the intake
- fixed classified intake-field storage, consent materialization, assignment serialization, and case-worker visibility

## Verification
- `DB_CONNECTION=pgsql DB_DATABASE=community_kind DB_USERNAME=marlinf DB_PASSWORD= composer ci:check` (275 tests, 1,206 assertions)
- `npm test`
- `npm run build`

## Stack
This PR is stacked on #51 and should be reviewed after it.

Closes #11