### PR TITLE
Deliver and close a case through explicit state transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ php artisan config:clear
 php artisan db:seed
 ```
 
-Scenario catalog version `2026.2` uses the fixed reporting instant
+Scenario catalog version `2026.3` uses the fixed reporting instant
 `2026-06-30 23:59:59` in each Organisation's local timezone: HarbourKind uses
 `Africa/Johannesburg` and ZAR, while NeighbourLink uses `Europe/London` and
 GBP. It can be seeded repeatedly without duplicating its records. All demo

--- a/app/Actions/CaseDelivery/CarryForwardExternalReferral.php
+++ b/app/Actions/CaseDelivery/CarryForwardExternalReferral.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Enums\ExternalReferralStatus;
+use App\Models\ExternalReferral;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class CarryForwardExternalReferral
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly EnsureCanManageCase $access, private readonly CorrectCaseWorkflowRecord $correctRecord) {}
+
+    public function handle(ExternalReferral $referral, int $expectedVersion, string $reason, CarbonInterface $effectiveAt, User $actor): ExternalReferral
+    {
+        $this->context->ensureOwns($referral->organisation_id);
+
+        return DB::transaction(function () use ($referral, $expectedVersion, $reason, $effectiveAt, $actor): ExternalReferral {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($referral->service_case_id);
+            $this->access->handle($case, $actor);
+            if ($case->status->isTerminal()) {
+                throw new LogicException('A terminal Case cannot transition its work.');
+            }
+            $locked = ExternalReferral::query()->lockForUpdate()->findOrFail($referral->id);
+
+            if (! in_array($locked->status, [ExternalReferralStatus::Sent, ExternalReferralStatus::Acknowledged], true)) {
+                throw new LogicException('Only a pending referral can be carried forward.');
+            }
+            if ($locked->version !== $expectedVersion) {
+                throw new LogicException('The referral changed while it was being reviewed.');
+            }
+            if (blank($reason)) {
+                throw new LogicException('A carry-forward reason code is required.');
+            }
+
+            $locked->forceFill(['version' => $locked->version + 1, 'carried_forward_at' => $effectiveAt, 'carry_forward_reason' => $reason])->save();
+            $this->correctRecord->handle($case, $locked->id, 'referral', 'carry_forward', $reason, ['status' => $locked->status->value], $effectiveAt, $actor);
+
+            return $locked->refresh();
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/CorrectCaseWorkflowRecord.php
+++ b/app/Actions/CaseDelivery/CorrectCaseWorkflowRecord.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Enums\CaseMetricCode;
+use App\Enums\CaseWorkflowSubject;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\Models\WorkflowCorrection;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class CorrectCaseWorkflowRecord
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly EnsureCanManageCase $access, private readonly RecordCaseMetric $recordMetric) {}
+
+    /** @param array<string, bool|int|float|string|null> $replacementValues */
+    public function handle(ServiceCase $case, string $subjectId, string $subjectType, string $correctionType, string $reason, array $replacementValues, CarbonInterface $effectiveAt, User $actor, ?CaseMetricCode $metricCode = null): WorkflowCorrection
+    {
+        $this->context->ensureOwns($case->organisation_id);
+
+        if (! in_array($correctionType, ['correction', 'reversal', 'carry_forward'], true) || blank($reason)) {
+            throw new LogicException('A supported correction type and reason code are required.');
+        }
+        if (array_diff(array_keys($replacementValues), ['effective_at', 'status', 'metric_value', 'service_code']) !== []) {
+            throw new LogicException('Correction values may only contain approved non-sensitive fields.');
+        }
+
+        return DB::transaction(function () use ($case, $subjectId, $subjectType, $correctionType, $reason, $replacementValues, $effectiveAt, $actor, $metricCode): WorkflowCorrection {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($case->id);
+            $this->access->handle($case, $actor);
+            $subjectExists = match ($subjectType) {
+                'case' => hash_equals($case->id, $subjectId),
+                'goal' => $case->goals()->whereKey($subjectId)->exists(),
+                'service' => $case->services()->whereKey($subjectId)->exists(),
+                'referral' => $case->referrals()->whereKey($subjectId)->exists(),
+                'task' => $case->tasks()->whereKey($subjectId)->exists(),
+                'appointment' => $case->appointments()->whereKey($subjectId)->exists(),
+                'note' => $case->notes()->whereKey($subjectId)->exists(),
+                default => false,
+            };
+            if (! $subjectExists) {
+                throw new LogicException('The correction subject does not belong to this Case.');
+            }
+            $correction = WorkflowCorrection::query()->create([
+                'organisation_id' => $case->organisation_id,
+                'service_case_id' => $case->id,
+                'subject_type' => CaseWorkflowSubject::from($subjectType),
+                'subject_id' => $subjectId,
+                'correction_type' => $correctionType,
+                'reason' => $reason,
+                'replacement_values' => $replacementValues,
+                'effective_at' => $effectiveAt,
+                'recorded_at' => now(),
+                'actor_user_id' => $actor->id,
+            ]);
+
+            if ($metricCode !== null && $correctionType === 'reversal') {
+                $this->recordMetric->handle($case, $metricCode, $effectiveAt, "correction:{$correction->id}", ['correction' => true], -1);
+            }
+
+            return $correction;
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/CreateCaseAppointment.php
+++ b/app/Actions/CaseDelivery/CreateCaseAppointment.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseAppointmentStatus;
+use App\Enums\CaseWorkflowSubject;
+use App\Models\CaseAppointment;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class CreateCaseAppointment
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly EnsureCanManageCase $access, private readonly ClassifiedDataEncrypter $encrypter, private readonly RecordCaseWorkflowTransition $recordTransition) {}
+
+    public function handle(ServiceCase $case, string $summary, string $location, CarbonInterface $scheduledAt, User $actor): CaseAppointment
+    {
+        $this->context->ensureOwns($case->organisation_id);
+
+        return DB::transaction(function () use ($case, $summary, $location, $scheduledAt, $actor): CaseAppointment {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($case->id);
+            $this->access->handle($case, $actor);
+            if ($case->status->isTerminal()) {
+                throw new LogicException('A terminal Case cannot accept new work.');
+            }
+            $appointment = new CaseAppointment;
+            $appointment->forceFill(['id' => $appointment->newUniqueId(), 'organisation_id' => $case->organisation_id, 'service_case_id' => $case->id, 'type' => 'content', 'data_key_version' => $this->encrypter->currentVersion(), 'status' => CaseAppointmentStatus::Scheduled, 'scheduled_at' => $scheduledAt, 'created_by_user_id' => $actor->id]);
+            $appointment->encrypted_content = new ClassifiedValue(json_encode(compact('summary', 'location'), JSON_THROW_ON_ERROR));
+            $appointment->save();
+            $this->recordTransition->handle($case, CaseWorkflowSubject::Appointment, $appointment->id, null, $appointment->status->value, 1, now(), $actor);
+
+            return $appointment;
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/CreateCaseGoal.php
+++ b/app/Actions/CaseDelivery/CreateCaseGoal.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseGoalStatus;
+use App\Enums\CaseWorkflowSubject;
+use App\Models\CaseGoal;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class CreateCaseGoal
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly EnsureCanManageCase $access, private readonly ClassifiedDataEncrypter $encrypter, private readonly RecordCaseWorkflowTransition $recordTransition) {}
+
+    public function handle(ServiceCase $case, string $title, string $description, ?CarbonInterface $targetAt, User $actor): CaseGoal
+    {
+        $this->context->ensureOwns($case->organisation_id);
+
+        return DB::transaction(function () use ($case, $title, $description, $targetAt, $actor): CaseGoal {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($case->id);
+            $this->access->handle($case, $actor);
+            if ($case->status->isTerminal()) {
+                throw new LogicException('A terminal Case cannot accept new work.');
+            }
+            $goal = new CaseGoal;
+            $goal->forceFill(['id' => $goal->newUniqueId(), 'organisation_id' => $case->organisation_id, 'service_case_id' => $case->id, 'type' => 'content', 'data_key_version' => $this->encrypter->currentVersion(), 'status' => CaseGoalStatus::Draft, 'target_at' => $targetAt, 'created_by_user_id' => $actor->id]);
+            $goal->encrypted_content = new ClassifiedValue(json_encode(compact('title', 'description'), JSON_THROW_ON_ERROR));
+            $goal->save();
+            $this->recordTransition->handle($case, CaseWorkflowSubject::Goal, $goal->id, null, $goal->status->value, 1, now(), $actor);
+
+            return $goal;
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/CreateCaseService.php
+++ b/app/Actions/CaseDelivery/CreateCaseService.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseServiceStatus;
+use App\Enums\CaseWorkflowSubject;
+use App\Models\CaseService;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class CreateCaseService
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly EnsureCanManageCase $access, private readonly ClassifiedDataEncrypter $encrypter, private readonly RecordCaseWorkflowTransition $recordTransition) {}
+
+    public function handle(ServiceCase $case, string $serviceCode, string $summary, ?CarbonInterface $scheduledFor, User $actor): CaseService
+    {
+        $this->context->ensureOwns($case->organisation_id);
+
+        return DB::transaction(function () use ($case, $serviceCode, $summary, $scheduledFor, $actor): CaseService {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($case->id);
+            $this->access->handle($case, $actor);
+            if ($case->status->isTerminal()) {
+                throw new LogicException('A terminal Case cannot accept new work.');
+            }
+            $service = new CaseService;
+            $service->forceFill(['id' => $service->newUniqueId(), 'organisation_id' => $case->organisation_id, 'service_case_id' => $case->id, 'type' => 'content', 'data_key_version' => $this->encrypter->currentVersion(), 'service_code' => $serviceCode, 'status' => CaseServiceStatus::Planned, 'scheduled_for' => $scheduledFor, 'created_by_user_id' => $actor->id]);
+            $service->encrypted_content = new ClassifiedValue(json_encode(compact('summary'), JSON_THROW_ON_ERROR));
+            $service->save();
+            $this->recordTransition->handle($case, CaseWorkflowSubject::Service, $service->id, null, $service->status->value, 1, now(), $actor);
+
+            return $service;
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/CreateCaseTask.php
+++ b/app/Actions/CaseDelivery/CreateCaseTask.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseTaskStatus;
+use App\Enums\CaseWorkflowSubject;
+use App\Models\CaseTask;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class CreateCaseTask
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly EnsureCanManageCase $access, private readonly ClassifiedDataEncrypter $encrypter, private readonly RecordCaseWorkflowTransition $recordTransition) {}
+
+    public function handle(ServiceCase $case, string $title, string $details, ?CarbonInterface $dueAt, User $actor): CaseTask
+    {
+        $this->context->ensureOwns($case->organisation_id);
+
+        return DB::transaction(function () use ($case, $title, $details, $dueAt, $actor): CaseTask {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($case->id);
+            $this->access->handle($case, $actor);
+            if ($case->status->isTerminal()) {
+                throw new LogicException('A terminal Case cannot accept new work.');
+            }
+            $task = new CaseTask;
+            $task->forceFill(['id' => $task->newUniqueId(), 'organisation_id' => $case->organisation_id, 'service_case_id' => $case->id, 'type' => 'content', 'data_key_version' => $this->encrypter->currentVersion(), 'status' => CaseTaskStatus::Open, 'due_at' => $dueAt, 'created_by_user_id' => $actor->id]);
+            $task->encrypted_content = new ClassifiedValue(json_encode(compact('title', 'details'), JSON_THROW_ON_ERROR));
+            $task->save();
+            $this->recordTransition->handle($case, CaseWorkflowSubject::Task, $task->id, null, $task->status->value, 1, now(), $actor);
+
+            return $task;
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/CreateExternalReferral.php
+++ b/app/Actions/CaseDelivery/CreateExternalReferral.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseWorkflowSubject;
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use App\Enums\ExternalReferralStatus;
+use App\Models\ExternalReferral;
+use App\Models\Party;
+use App\Models\PartyConsent;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class CreateExternalReferral
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly EnsureCanManageCase $access, private readonly ClassifiedDataEncrypter $encrypter, private readonly RecordCaseWorkflowTransition $recordTransition) {}
+
+    public function handle(ServiceCase $case, string $destination, string $purpose, string $minimumNecessary, string $sharingAuthority, User $actor): ExternalReferral
+    {
+        $this->context->ensureOwns($case->organisation_id);
+
+        return DB::transaction(function () use ($case, $destination, $purpose, $minimumNecessary, $sharingAuthority, $actor): ExternalReferral {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($case->id);
+            $this->access->handle($case, $actor);
+            if ($case->status->isTerminal()) {
+                throw new LogicException('A terminal Case cannot accept new work.');
+            }
+            Party::query()->lockForUpdate()->findOrFail($case->party_id);
+            $consent = PartyConsent::query()->where('party_id', $case->party_id)->where('purpose', ConsentPurpose::Service)->latest('occurred_at')->latest('id')->first();
+            if ($sharingAuthority !== 'service_consent' || $consent?->decision !== ConsentDecision::Granted) {
+                throw new LogicException('A current service-consent sharing authority is required.');
+            }
+            $referral = new ExternalReferral;
+            $referral->forceFill(['id' => $referral->newUniqueId(), 'organisation_id' => $case->organisation_id, 'service_case_id' => $case->id, 'type' => 'content', 'data_key_version' => $this->encrypter->currentVersion(), 'status' => ExternalReferralStatus::Draft, 'sharing_authority' => $sharingAuthority, 'created_by_user_id' => $actor->id]);
+            $referral->encrypted_content = new ClassifiedValue(json_encode(['destination' => $destination, 'purpose' => $purpose, 'minimum_necessary' => $minimumNecessary], JSON_THROW_ON_ERROR));
+            $referral->save();
+            $this->recordTransition->handle($case, CaseWorkflowSubject::Referral, $referral->id, null, $referral->status->value, 1, now(), $actor);
+
+            return $referral;
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/EnsureCanManageCase.php
+++ b/app/Actions/CaseDelivery/EnsureCanManageCase.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Enums\OrganisationRole;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use LogicException;
+
+class EnsureCanManageCase
+{
+    public function __construct(private readonly OrganisationContext $context) {}
+
+    public function handle(ServiceCase $case, User $actor): void
+    {
+        $this->context->ensureOwns($case->organisation_id);
+
+        if ($actor->hasOrganisationRole($case->organisation, OrganisationRole::ProgramManager, $case->program)
+            && $actor->hasProgramAccess($case->program)) {
+            return;
+        }
+
+        $membership = $actor->organisationMembership($case->organisation);
+        if ($membership !== null
+            && ! $membership->isHeld()
+            && $actor->hasOrganisationRole($case->organisation, OrganisationRole::CaseWorker, $case->program)
+            && $actor->hasProgramAccess($case->program)
+            && $case->assignments()->where('membership_id', $membership->id)->where('status', 'active')->exists()) {
+            return;
+        }
+
+        throw new LogicException('The actor is not authorised to manage this Case.');
+    }
+}

--- a/app/Actions/CaseDelivery/FinalizeCaseNote.php
+++ b/app/Actions/CaseDelivery/FinalizeCaseNote.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Enums\CaseNoteStatus;
+use App\Enums\CaseWorkflowSubject;
+use App\Models\CaseNote;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class FinalizeCaseNote
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly EnsureCanManageCase $access, private readonly RecordCaseWorkflowTransition $recordTransition) {}
+
+    public function handle(CaseNote $note, int $expectedVersion, User $actor): CaseNote
+    {
+        $this->context->ensureOwns($note->organisation_id);
+
+        return DB::transaction(function () use ($note, $expectedVersion, $actor): CaseNote {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($note->service_case_id);
+            $this->access->handle($case, $actor);
+            if ($case->status->isTerminal()) {
+                throw new LogicException('A terminal Case cannot transition its work.');
+            }
+            $locked = CaseNote::query()->lockForUpdate()->findOrFail($note->id);
+            if ($locked->status === CaseNoteStatus::Finalized) {
+                return $locked;
+            }
+            if ($locked->version !== $expectedVersion) {
+                throw new LogicException('The note changed while it was being reviewed.');
+            }
+
+            $locked->forceFill(['status' => CaseNoteStatus::Finalized, 'version' => $locked->version + 1, 'finalized_at' => now()])->save();
+            $this->recordTransition->handle($case, CaseWorkflowSubject::Note, $locked->id, CaseNoteStatus::Draft->value, CaseNoteStatus::Finalized->value, $locked->version, $locked->finalized_at, $actor);
+
+            return $locked->refresh();
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/RecordCaseInteraction.php
+++ b/app/Actions/CaseDelivery/RecordCaseInteraction.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Models\CaseInteraction;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class RecordCaseInteraction
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly EnsureCanManageCase $access, private readonly ClassifiedDataEncrypter $encrypter) {}
+
+    public function handle(ServiceCase $case, string $type, string $summary, CarbonInterface $occurredAt, User $actor): CaseInteraction
+    {
+        $this->context->ensureOwns($case->organisation_id);
+
+        return DB::transaction(function () use ($case, $type, $summary, $occurredAt, $actor): CaseInteraction {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($case->id);
+            $this->access->handle($case, $actor);
+            if ($case->status->isTerminal()) {
+                throw new LogicException('A terminal Case cannot accept new work.');
+            }
+            $interaction = new CaseInteraction;
+            $interaction->forceFill(['id' => $interaction->newUniqueId(), 'organisation_id' => $case->organisation_id, 'service_case_id' => $case->id, 'interaction_type' => $type, 'type' => 'content', 'data_key_version' => $this->encrypter->currentVersion(), 'occurred_at' => $occurredAt, 'recorded_at' => now(), 'recorded_by_user_id' => $actor->id]);
+            $interaction->encrypted_content = new ClassifiedValue(json_encode(compact('summary'), JSON_THROW_ON_ERROR));
+            $interaction->save();
+
+            return $interaction;
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/RecordCaseMetric.php
+++ b/app/Actions/CaseDelivery/RecordCaseMetric.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Enums\CaseMetricCode;
+use App\Models\MetricEvent;
+use App\Models\ServiceCase;
+use Carbon\CarbonInterface;
+
+class RecordCaseMetric
+{
+    /** @param array<string, bool|int|float|string|null> $dimensions */
+    public function handle(ServiceCase $case, CaseMetricCode $code, CarbonInterface $occurredAt, string $sourceKey, array $dimensions = [], float $value = 1): MetricEvent
+    {
+        return MetricEvent::query()->firstOrCreate(
+            ['deduplication_key' => hash('sha256', implode('|', [$case->organisation_id, $code->value, $sourceKey]))],
+            [
+                'organisation_id' => $case->organisation_id,
+                'program_id' => $case->program_id,
+                'code' => $code,
+                'value' => $value,
+                'dimensions' => $dimensions,
+                'occurred_at' => $occurredAt,
+                'recorded_at' => now(),
+            ],
+        );
+    }
+}

--- a/app/Actions/CaseDelivery/RecordCaseWorkflowTransition.php
+++ b/app/Actions/CaseDelivery/RecordCaseWorkflowTransition.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Enums\CaseWorkflowSubject;
+use App\Models\CaseWorkflowTransition;
+use App\Models\ServiceCase;
+use App\Models\User;
+use Carbon\CarbonInterface;
+
+class RecordCaseWorkflowTransition
+{
+    public function handle(
+        ServiceCase $case,
+        CaseWorkflowSubject $subjectType,
+        string $subjectId,
+        ?string $from,
+        string $to,
+        int $version,
+        CarbonInterface $effectiveAt,
+        User $actor,
+        ?string $reason = null,
+    ): CaseWorkflowTransition {
+        return CaseWorkflowTransition::query()->create([
+            'organisation_id' => $case->organisation_id,
+            'service_case_id' => $case->id,
+            'subject_type' => $subjectType,
+            'subject_id' => $subjectId,
+            'from_status' => $from,
+            'to_status' => $to,
+            'reason' => $reason,
+            'effective_at' => $effectiveAt,
+            'recorded_at' => now(),
+            'version' => $version,
+            'actor_user_id' => $actor->id,
+        ]);
+    }
+}

--- a/app/Actions/CaseDelivery/SaveCaseNote.php
+++ b/app/Actions/CaseDelivery/SaveCaseNote.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseNoteStatus;
+use App\Enums\CaseWorkflowSubject;
+use App\Models\CaseNote;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class SaveCaseNote
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly EnsureCanManageCase $access, private readonly ClassifiedDataEncrypter $encrypter, private readonly RecordCaseWorkflowTransition $recordTransition) {}
+
+    public function handle(ServiceCase $case, string $content, User $actor, ?CaseNote $corrects = null): CaseNote
+    {
+        $this->context->ensureOwns($case->organisation_id);
+
+        if ($corrects !== null) {
+            $this->context->ensureOwns($corrects->organisation_id);
+            if ($corrects->service_case_id !== $case->id || $corrects->status !== CaseNoteStatus::Finalized) {
+                throw new LogicException('A correction must reference a finalized note from the same Case.');
+            }
+        }
+
+        return DB::transaction(function () use ($case, $content, $actor, $corrects): CaseNote {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($case->id);
+            $this->access->handle($case, $actor);
+            if ($case->status->isTerminal()) {
+                throw new LogicException('A terminal Case cannot accept new work.');
+            }
+            $note = new CaseNote;
+            $note->forceFill(['id' => $note->newUniqueId(), 'organisation_id' => $case->organisation_id, 'service_case_id' => $case->id, 'type' => 'content', 'data_key_version' => $this->encrypter->currentVersion(), 'status' => CaseNoteStatus::Draft, 'corrects_note_id' => $corrects?->id, 'authored_by_user_id' => $actor->id]);
+            $note->encrypted_content = new ClassifiedValue($content);
+            $note->save();
+            $this->recordTransition->handle($case, CaseWorkflowSubject::Note, $note->id, null, $note->status->value, 1, now(), $actor, $corrects === null ? null : 'correction');
+
+            return $note;
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/TransitionCaseAppointment.php
+++ b/app/Actions/CaseDelivery/TransitionCaseAppointment.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Enums\CaseAppointmentStatus;
+use App\Enums\CaseServiceStatus;
+use App\Enums\CaseWorkflowSubject;
+use App\Models\CaseAppointment;
+use App\Models\CaseService;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class TransitionCaseAppointment
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly EnsureCanManageCase $access, private readonly RecordCaseWorkflowTransition $recordTransition) {}
+
+    public function handle(CaseAppointment $appointment, CaseAppointmentStatus $to, int $expectedVersion, CarbonInterface $effectiveAt, User $actor, ?string $reason = null, ?CaseService $completedService = null): CaseAppointment
+    {
+        $this->context->ensureOwns($appointment->organisation_id);
+
+        return DB::transaction(function () use ($appointment, $to, $expectedVersion, $effectiveAt, $actor, $reason, $completedService): CaseAppointment {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($appointment->service_case_id);
+            $this->access->handle($case, $actor);
+            if ($case->status->isTerminal()) {
+                throw new LogicException('A terminal Case cannot transition its work.');
+            }
+            $locked = CaseAppointment::query()->lockForUpdate()->findOrFail($appointment->id);
+
+            if ($locked->status === $to) {
+                return $locked;
+            }
+            if ($locked->version !== $expectedVersion) {
+                throw new LogicException('The appointment changed while it was being reviewed.');
+            }
+            if (! in_array($to, $locked->status->allowedTransitions(), true)) {
+                throw new LogicException("Cannot transition appointment from {$locked->status->value} to {$to->value}.");
+            }
+            if (in_array($to, [CaseAppointmentStatus::Cancelled, CaseAppointmentStatus::NoShow], true) && blank($reason)) {
+                throw new LogicException('A cancelled or no-show appointment requires a reason code.');
+            }
+            if ($completedService !== null && ($to !== CaseAppointmentStatus::Completed || $completedService->service_case_id !== $locked->service_case_id || $completedService->status !== CaseServiceStatus::Completed)) {
+                throw new LogicException('A completed appointment may only link a completed service from the same Case.');
+            }
+
+            $from = $locked->status;
+            $locked->forceFill(['status' => $to, 'version' => $locked->version + 1, 'effective_at' => $effectiveAt, 'terminal_reason' => $reason, 'completed_service_id' => $completedService?->id])->save();
+            $this->recordTransition->handle($case, CaseWorkflowSubject::Appointment, $locked->id, $from->value, $to->value, $locked->version, $effectiveAt, $actor, $reason);
+
+            return $locked->refresh();
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/TransitionCaseGoal.php
+++ b/app/Actions/CaseDelivery/TransitionCaseGoal.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Enums\CaseGoalStatus;
+use App\Enums\CaseMetricCode;
+use App\Enums\CaseWorkflowSubject;
+use App\Models\CaseGoal;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class TransitionCaseGoal
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly EnsureCanManageCase $access, private readonly RecordCaseWorkflowTransition $recordTransition, private readonly RecordCaseMetric $recordMetric) {}
+
+    public function handle(CaseGoal $goal, CaseGoalStatus $to, int $expectedVersion, CarbonInterface $effectiveAt, User $actor, ?string $reason = null): CaseGoal
+    {
+        $this->context->ensureOwns($goal->organisation_id);
+
+        return DB::transaction(function () use ($goal, $to, $expectedVersion, $effectiveAt, $actor, $reason): CaseGoal {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($goal->service_case_id);
+            $this->access->handle($case, $actor);
+            if ($case->status->isTerminal()) {
+                throw new LogicException('A terminal Case cannot transition its work.');
+            }
+            $locked = CaseGoal::query()->lockForUpdate()->findOrFail($goal->id);
+
+            if ($locked->status === $to) {
+                return $locked;
+            }
+            if ($locked->version !== $expectedVersion) {
+                throw new LogicException('The goal changed while it was being reviewed.');
+            }
+            if (! in_array($to, $locked->status->allowedTransitions(), true)) {
+                throw new LogicException("Cannot transition goal from {$locked->status->value} to {$to->value}.");
+            }
+            if ($to->isTerminal() && blank($reason)) {
+                throw new LogicException('A terminal goal requires an outcome or reason code.');
+            }
+
+            $from = $locked->status;
+            $locked->forceFill(['status' => $to, 'version' => $locked->version + 1, 'effective_at' => $to->isTerminal() ? $effectiveAt : null, 'terminal_reason' => $to->isTerminal() ? $reason : null])->save();
+            $this->recordTransition->handle($case, CaseWorkflowSubject::Goal, $locked->id, $from->value, $to->value, $locked->version, $effectiveAt, $actor, $reason);
+
+            $code = match ($to) {
+                CaseGoalStatus::Achieved => CaseMetricCode::GoalAchieved, CaseGoalStatus::NotAchieved => CaseMetricCode::GoalNotAchieved, default => null
+            };
+            if ($code !== null) {
+                $this->recordMetric->handle($case, $code, $effectiveAt, "goal:{$locked->id}:{$locked->version}");
+            }
+
+            return $locked->refresh();
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/TransitionCaseService.php
+++ b/app/Actions/CaseDelivery/TransitionCaseService.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Enums\CaseMetricCode;
+use App\Enums\CaseServiceStatus;
+use App\Enums\CaseWorkflowSubject;
+use App\Models\CaseService;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class TransitionCaseService
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly EnsureCanManageCase $access, private readonly RecordCaseWorkflowTransition $recordTransition, private readonly RecordCaseMetric $recordMetric) {}
+
+    public function handle(CaseService $service, CaseServiceStatus $to, int $expectedVersion, CarbonInterface $effectiveAt, User $actor, ?string $reason = null): CaseService
+    {
+        $this->context->ensureOwns($service->organisation_id);
+
+        return DB::transaction(function () use ($service, $to, $expectedVersion, $effectiveAt, $actor, $reason): CaseService {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($service->service_case_id);
+            $this->access->handle($case, $actor);
+            if ($case->status->isTerminal()) {
+                throw new LogicException('A terminal Case cannot transition its work.');
+            }
+            $locked = CaseService::query()->lockForUpdate()->findOrFail($service->id);
+
+            if ($locked->status === $to) {
+                return $locked;
+            }
+            if ($locked->version !== $expectedVersion) {
+                throw new LogicException('The service changed while it was being reviewed.');
+            }
+            if (! in_array($to, $locked->status->allowedTransitions(), true)) {
+                throw new LogicException("Cannot transition service from {$locked->status->value} to {$to->value}.");
+            }
+            if (in_array($to, [CaseServiceStatus::Cancelled, CaseServiceStatus::NotDelivered], true) && blank($reason)) {
+                throw new LogicException('Cancelled or not-delivered services require a reason code.');
+            }
+
+            $from = $locked->status;
+            $locked->forceFill(['status' => $to, 'version' => $locked->version + 1, 'delivered_at' => $to === CaseServiceStatus::Completed ? $effectiveAt : null, 'terminal_reason' => $to->isTerminal() && $to !== CaseServiceStatus::Completed ? $reason : null])->save();
+            $this->recordTransition->handle($case, CaseWorkflowSubject::Service, $locked->id, $from->value, $to->value, $locked->version, $effectiveAt, $actor, $reason);
+
+            if ($to === CaseServiceStatus::Completed) {
+                $this->recordMetric->handle($case, CaseMetricCode::ServiceDelivered, $effectiveAt, "service:{$locked->id}:{$locked->version}", ['service_code' => $locked->service_code]);
+            }
+
+            return $locked->refresh();
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/TransitionCaseTask.php
+++ b/app/Actions/CaseDelivery/TransitionCaseTask.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Enums\CaseTaskStatus;
+use App\Enums\CaseWorkflowSubject;
+use App\Models\CaseTask;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class TransitionCaseTask
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly EnsureCanManageCase $access, private readonly RecordCaseWorkflowTransition $recordTransition) {}
+
+    public function handle(CaseTask $task, CaseTaskStatus $to, int $expectedVersion, CarbonInterface $effectiveAt, User $actor, ?string $reason = null): CaseTask
+    {
+        $this->context->ensureOwns($task->organisation_id);
+
+        return DB::transaction(function () use ($task, $to, $expectedVersion, $effectiveAt, $actor, $reason): CaseTask {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($task->service_case_id);
+            $this->access->handle($case, $actor);
+            if ($case->status->isTerminal()) {
+                throw new LogicException('A terminal Case cannot transition its work.');
+            }
+            $locked = CaseTask::query()->lockForUpdate()->findOrFail($task->id);
+
+            if ($locked->status === $to) {
+                return $locked;
+            }
+            if ($locked->version !== $expectedVersion) {
+                throw new LogicException('The task changed while it was being reviewed.');
+            }
+            if (! in_array($to, $locked->status->allowedTransitions(), true)) {
+                throw new LogicException("Cannot transition task from {$locked->status->value} to {$to->value}.");
+            }
+            if ($to === CaseTaskStatus::Cancelled && blank($reason)) {
+                throw new LogicException('A cancelled task requires a reason code.');
+            }
+
+            $from = $locked->status;
+            $locked->forceFill(['status' => $to, 'version' => $locked->version + 1, 'effective_at' => $effectiveAt, 'terminal_reason' => $reason])->save();
+            $this->recordTransition->handle($case, CaseWorkflowSubject::Task, $locked->id, $from->value, $to->value, $locked->version, $effectiveAt, $actor, $reason);
+
+            return $locked->refresh();
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/TransitionExternalReferral.php
+++ b/app/Actions/CaseDelivery/TransitionExternalReferral.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Enums\CaseMetricCode;
+use App\Enums\CaseWorkflowSubject;
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use App\Enums\ExternalReferralStatus;
+use App\Models\ExternalReferral;
+use App\Models\Party;
+use App\Models\PartyConsent;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class TransitionExternalReferral
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly EnsureCanManageCase $access, private readonly RecordCaseWorkflowTransition $recordTransition, private readonly RecordCaseMetric $recordMetric) {}
+
+    public function handle(ExternalReferral $referral, ExternalReferralStatus $to, int $expectedVersion, CarbonInterface $effectiveAt, User $actor, ?string $reason = null): ExternalReferral
+    {
+        $this->context->ensureOwns($referral->organisation_id);
+
+        return DB::transaction(function () use ($referral, $to, $expectedVersion, $effectiveAt, $actor, $reason): ExternalReferral {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($referral->service_case_id);
+            $this->access->handle($case, $actor);
+            if ($case->status->isTerminal()) {
+                throw new LogicException('A terminal Case cannot transition its work.');
+            }
+            $locked = ExternalReferral::query()->lockForUpdate()->findOrFail($referral->id);
+
+            if ($locked->status === $to) {
+                return $locked;
+            }
+            if ($locked->version !== $expectedVersion) {
+                throw new LogicException('The referral changed while it was being reviewed.');
+            }
+            if (! in_array($to, $locked->status->allowedTransitions(), true)) {
+                throw new LogicException("Cannot transition referral from {$locked->status->value} to {$to->value}.");
+            }
+            if (in_array($to, [ExternalReferralStatus::NotConnected, ExternalReferralStatus::Cancelled], true) && blank($reason)) {
+                throw new LogicException('Not-connected or cancelled referrals require a reason code.');
+            }
+            if ($to === ExternalReferralStatus::Sent) {
+                $content = json_decode($locked->encrypted_content->reveal(), true, flags: JSON_THROW_ON_ERROR);
+                if (! is_array($content) || blank($content['destination'] ?? null) || blank($content['purpose'] ?? null) || blank($content['minimum_necessary'] ?? null)) {
+                    throw new LogicException('Sending a referral requires destination, purpose, and minimum necessary information.');
+                }
+                Party::query()->lockForUpdate()->findOrFail($case->party_id);
+                $consent = PartyConsent::query()->where('party_id', $case->party_id)->where('purpose', ConsentPurpose::Service)->latest('occurred_at')->latest('id')->first();
+                if ($locked->sharing_authority !== 'service_consent' || $consent?->decision !== ConsentDecision::Granted) {
+                    throw new LogicException('A current service-consent sharing authority is required when sending a referral.');
+                }
+            }
+
+            $from = $locked->status;
+            $locked->forceFill(['status' => $to, 'version' => $locked->version + 1, 'sent_at' => $to === ExternalReferralStatus::Sent ? $effectiveAt : $locked->sent_at, 'effective_at' => $to->isTerminal() ? $effectiveAt : null, 'terminal_reason' => $to->isTerminal() && $to !== ExternalReferralStatus::Connected ? $reason : null])->save();
+            $this->recordTransition->handle($case, CaseWorkflowSubject::Referral, $locked->id, $from->value, $to->value, $locked->version, $effectiveAt, $actor, $reason);
+
+            $code = match ($to) {
+                ExternalReferralStatus::Connected => CaseMetricCode::ReferralConnected, ExternalReferralStatus::NotConnected => CaseMetricCode::ReferralNotConnected, default => null
+            };
+            if ($code !== null) {
+                $this->recordMetric->handle($case, $code, $effectiveAt, "referral:{$locked->id}:{$locked->version}");
+            }
+
+            return $locked->refresh();
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/TransitionServiceCase.php
+++ b/app/Actions/CaseDelivery/TransitionServiceCase.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Actions\CaseDelivery;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseAssignmentRole;
+use App\Enums\CaseAssignmentStatus;
+use App\Enums\CaseMetricCode;
+use App\Enums\CaseWorkflowSubject;
+use App\Enums\ServiceCaseStatus;
+use App\Models\CaseOutcome;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class TransitionServiceCase
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly EnsureCanManageCase $access,
+        private readonly ClassifiedDataEncrypter $encrypter,
+        private readonly RecordCaseWorkflowTransition $recordTransition,
+        private readonly RecordCaseMetric $recordMetric,
+    ) {}
+
+    /** @param array{reason?: string, narrative?: string, measures?: array<string, int|float|string>, follow_up_at?: CarbonInterface|null} $closure */
+    public function handle(ServiceCase $case, ServiceCaseStatus $to, int $expectedVersion, CarbonInterface $effectiveAt, User $actor, array $closure = []): ServiceCase
+    {
+        $this->context->ensureOwns($case->organisation_id);
+
+        return DB::transaction(function () use ($case, $to, $expectedVersion, $effectiveAt, $actor, $closure): ServiceCase {
+            $locked = ServiceCase::query()->lockForUpdate()->findOrFail($case->id);
+            $this->access->handle($locked, $actor);
+
+            if ($locked->status === $to) {
+                return $locked;
+            }
+            if ($locked->version !== $expectedVersion) {
+                throw new LogicException('The Case changed while it was being reviewed.');
+            }
+            if (! in_array($to, $locked->status->allowedTransitions(), true)) {
+                throw new LogicException("Cannot transition Case from {$locked->status->value} to {$to->value}.");
+            }
+
+            if (in_array($to, [ServiceCaseStatus::Active, ServiceCaseStatus::OnHold], true) && ! $this->hasPrimaryAssignment($locked)) {
+                throw new LogicException('An active primary case-worker assignment is required.');
+            }
+
+            if ($to === ServiceCaseStatus::Cancelled) {
+                if (blank($closure['reason'] ?? null)) {
+                    throw new LogicException('Cancelling a Case requires a reason code.');
+                }
+                if ($locked->services()->where('status', 'completed')->exists() || $locked->interactions()->exists()) {
+                    throw new LogicException('A Case with substantive service must be closed, not cancelled.');
+                }
+                if ($locked->goals()->whereIn('status', ['draft', 'active'])->exists()
+                    || $locked->services()->whereIn('status', ['planned', 'scheduled'])->exists()
+                    || $locked->referrals()->whereIn('status', ['draft', 'sent', 'acknowledged'])->exists()
+                    || $locked->tasks()->where('status', 'open')->exists()
+                    || $locked->appointments()->where('status', 'scheduled')->exists()) {
+                    throw new LogicException('Resolve every open Case item before cancellation.');
+                }
+            }
+
+            $checklist = null;
+            if ($to === ServiceCaseStatus::Closed) {
+                $checklist = $this->closeCase($locked, $closure, $effectiveAt, $actor);
+            }
+
+            $from = $locked->status;
+            $locked->forceFill([
+                'status' => $to,
+                'version' => $locked->version + 1,
+                'closed_at' => $to->isTerminal() ? $effectiveAt : null,
+                'closure_reason' => $to->isTerminal() ? ($closure['reason'] ?? null) : null,
+                'follow_up_at' => $to === ServiceCaseStatus::Closed ? ($closure['follow_up_at'] ?? null) : null,
+                'closure_checklist' => $checklist,
+            ])->save();
+            $this->recordTransition->handle($locked, CaseWorkflowSubject::CaseRecord, $locked->id, $from->value, $to->value, $locked->version, $effectiveAt, $actor, $closure['reason'] ?? null);
+
+            if ($to === ServiceCaseStatus::Closed) {
+                $this->recordMetric->handle($locked, CaseMetricCode::CaseClosed, $effectiveAt, "case:{$locked->id}:{$locked->version}", ['closure_reason' => $locked->closure_reason]);
+            }
+
+            return $locked->refresh();
+        });
+    }
+
+    /**
+     * @param  array{reason?: string, narrative?: string, measures?: array<string, int|float|string>, follow_up_at?: CarbonInterface|null}  $closure
+     * @return array{goals_terminal: bool, services_terminal: bool, appointments_terminal: bool, tasks_terminal: bool, referrals_resolved_or_carried: bool}
+     */
+    private function closeCase(ServiceCase $case, array $closure, CarbonInterface $effectiveAt, User $actor): array
+    {
+        if (blank($closure['reason'] ?? null) || blank($closure['narrative'] ?? null) || ! is_array($closure['measures'] ?? null)) {
+            throw new LogicException('Case closure requires a reason and structured outcome.');
+        }
+
+        $requiredMeasures = [];
+        foreach ($case->program->configuration['outcome_measures'] ?? [] as $measure) {
+            if (is_array($measure) && is_string($measure['key'] ?? null)) {
+                $requiredMeasures[] = $measure['key'];
+            }
+        }
+        $providedMeasures = array_keys($closure['measures']);
+        sort($requiredMeasures);
+        sort($providedMeasures);
+        if ($requiredMeasures !== $providedMeasures || collect($closure['measures'])->contains(fn (mixed $value): bool => ! is_numeric($value))) {
+            throw new LogicException('Every configured outcome measure is required.');
+        }
+        if (($closure['follow_up_at'] ?? null) instanceof CarbonInterface && $closure['follow_up_at']->lessThanOrEqualTo($effectiveAt)) {
+            throw new LogicException('A follow-up date must be after Case closure.');
+        }
+
+        $checks = [
+            'goals_terminal' => ! $case->goals()->whereIn('status', ['draft', 'active'])->exists(),
+            'services_terminal' => ! $case->services()->whereIn('status', ['planned', 'scheduled'])->exists(),
+            'appointments_terminal' => ! $case->appointments()->where('status', 'scheduled')->exists(),
+            'tasks_terminal' => ! $case->tasks()->where('status', 'open')->exists(),
+            'referrals_resolved_or_carried' => ! $case->referrals()->whereIn('status', ['draft', 'sent', 'acknowledged'])->whereNull('carried_forward_at')->exists(),
+        ];
+
+        if (in_array(false, $checks, true)) {
+            throw new LogicException('Complete, cancel, resolve, or carry forward every open Case item before closure.');
+        }
+
+        $outcome = new CaseOutcome;
+        $measures = array_map(fn (int|float|string $value): int|float => is_int($value) || is_float($value) ? $value : (float) $value, $closure['measures']);
+        $outcome->forceFill(['id' => $outcome->newUniqueId(), 'organisation_id' => $case->organisation_id, 'service_case_id' => $case->id, 'measures' => $measures, 'type' => 'content', 'data_key_version' => $this->encrypter->currentVersion(), 'effective_at' => $effectiveAt, 'recorded_at' => now(), 'recorded_by_user_id' => $actor->id]);
+        $outcome->encrypted_content = new ClassifiedValue($closure['narrative']);
+        $outcome->save();
+
+        return $checks;
+    }
+
+    private function hasPrimaryAssignment(ServiceCase $case): bool
+    {
+        return $case->assignments()->where('role', CaseAssignmentRole::Primary)->where('status', CaseAssignmentStatus::Active)->exists();
+    }
+}

--- a/app/Actions/Demo/BuildOrganisationScenario.php
+++ b/app/Actions/Demo/BuildOrganisationScenario.php
@@ -36,6 +36,7 @@ final class BuildOrganisationScenario
     public function __construct(
         private readonly OrganisationContext $organisationContext,
         private readonly StorePartyContact $storePartyContact,
+        private readonly BuildRequestToOutcomeScenario $buildRequestToOutcomeScenario,
     ) {}
 
     /** @param ScenarioDefinition $scenario */
@@ -77,6 +78,16 @@ final class BuildOrganisationScenario
                 }
 
                 $this->upsertPartyPopulation($organisation, $scenario);
+
+                if ($scenario['slug'] === 'harbourkind') {
+                    $this->buildRequestToOutcomeScenario->handle(
+                        $organisation,
+                        Program::query()->where('slug', 'housing-support')->firstOrFail(),
+                        Party::query()->where('uuid', '12000000-0000-4000-8000-000000000001')->firstOrFail(),
+                        User::query()->where('email', 'manager@harbourkind.example.test')->firstOrFail(),
+                        Membership::query()->whereHas('user', fn ($query) => $query->where('email', 'caseworker@harbourkind.example.test'))->firstOrFail(),
+                    );
+                }
             });
 
             return $organisation;

--- a/app/Actions/Demo/BuildRequestToOutcomeScenario.php
+++ b/app/Actions/Demo/BuildRequestToOutcomeScenario.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Actions\Demo;
+
+use App\Actions\CaseDelivery\CreateCaseAppointment;
+use App\Actions\CaseDelivery\CreateCaseGoal;
+use App\Actions\CaseDelivery\CreateCaseService;
+use App\Actions\CaseDelivery\CreateCaseTask;
+use App\Actions\CaseDelivery\CreateExternalReferral;
+use App\Actions\CaseDelivery\FinalizeCaseNote;
+use App\Actions\CaseDelivery\RecordCaseInteraction;
+use App\Actions\CaseDelivery\SaveCaseNote;
+use App\Actions\CaseDelivery\TransitionCaseAppointment;
+use App\Actions\CaseDelivery\TransitionCaseGoal;
+use App\Actions\CaseDelivery\TransitionCaseService;
+use App\Actions\CaseDelivery\TransitionCaseTask;
+use App\Actions\CaseDelivery\TransitionExternalReferral;
+use App\Actions\CaseDelivery\TransitionServiceCase;
+use App\Actions\Intake\CreateIntakeRequest;
+use App\Actions\Intake\TransitionIntakeRequest;
+use App\Enums\CaseAppointmentStatus;
+use App\Enums\CaseGoalStatus;
+use App\Enums\CaseServiceStatus;
+use App\Enums\CaseTaskStatus;
+use App\Enums\EligibilityStatus;
+use App\Enums\ExternalReferralStatus;
+use App\Enums\IntakeStatus;
+use App\Enums\IntakeUrgency;
+use App\Enums\ServiceCaseStatus;
+use App\Models\IntakeRequest;
+use App\Models\Membership;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\Program;
+use App\Models\ServiceCase;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Date;
+
+class BuildRequestToOutcomeScenario
+{
+    public function __construct(
+        private readonly CreateIntakeRequest $createIntake,
+        private readonly TransitionIntakeRequest $transitionIntake,
+        private readonly TransitionServiceCase $transitionCase,
+        private readonly CreateCaseGoal $createGoal,
+        private readonly TransitionCaseGoal $transitionGoal,
+        private readonly CreateCaseService $createService,
+        private readonly TransitionCaseService $transitionService,
+        private readonly CreateExternalReferral $createReferral,
+        private readonly TransitionExternalReferral $transitionReferral,
+        private readonly CreateCaseTask $createTask,
+        private readonly TransitionCaseTask $transitionTask,
+        private readonly CreateCaseAppointment $createAppointment,
+        private readonly TransitionCaseAppointment $transitionAppointment,
+        private readonly RecordCaseInteraction $recordInteraction,
+        private readonly SaveCaseNote $saveNote,
+        private readonly FinalizeCaseNote $finalizeNote,
+    ) {}
+
+    public function handle(Organisation $organisation, Program $program, Party $party, User $manager, Membership $workerMembership): ServiceCase
+    {
+        $existing = IntakeRequest::query()->where('idempotency_key', 'scenario-request-to-outcome-v1')->first();
+        if ($existing?->serviceCase !== null) {
+            return $existing->serviceCase;
+        }
+
+        $reportingNow = Date::getTestNow();
+
+        try {
+            $worker = $workerMembership->user;
+            Date::setTestNow($this->at('2026-06-02 08:00'));
+            $intake = $this->createIntake->handle($organisation, $program, $party, [
+                'source' => 'partner_referral',
+                'narrative' => 'Synthetic referral from a fictional neighbourhood advice partner.',
+                'presenting_needs' => 'Amina needs tenancy advice and stable housing support.',
+                'intake_fields' => ['preferred_contact_time' => 'Weekday mornings', 'current_situation' => 'Temporarily staying with fictional friends.'],
+                'eligibility_context' => ['service_area' => true, 'program_fit' => true],
+                'risk_flags' => ['housing_loss'],
+                'email' => 'amina.client@harbourkind.example.test',
+                'telephone' => '+1 202-555-0111',
+                'idempotency_key' => 'scenario-request-to-outcome-v1',
+                'consent_granted' => true,
+                'consent_source' => 'verbal',
+            ], $manager);
+            $this->transitionIntake->handle($intake, IntakeStatus::Submitted, 1, $manager);
+            $this->transitionIntake->handle($intake->refresh(), IntakeStatus::UnderReview, 2, $manager, triage: [
+                'urgency' => IntakeUrgency::Priority,
+                'eligibility_status' => EligibilityStatus::Eligible,
+                'eligibility_context' => ['service_area' => true, 'program_fit' => true],
+                'risk_flags' => ['housing_loss'],
+            ]);
+            $this->transitionIntake->handle($intake->refresh(), IntakeStatus::Accepted, 3, $manager, worker: $workerMembership);
+            $case = $intake->refresh()->serviceCase()->firstOrFail();
+
+            Date::setTestNow($this->at('2026-06-03 09:00'));
+            $this->transitionCase->handle($case, ServiceCaseStatus::Active, 1, now(), $manager);
+            $goal = $this->createGoal->handle($case, 'Secure stable housing', 'Find a sustainable fictional tenancy.', $this->at('2026-06-25 17:00'), $worker);
+            $this->transitionGoal->handle($goal, CaseGoalStatus::Active, 1, now(), $worker);
+            Date::setTestNow($this->at('2026-06-04 09:00'));
+            $this->recordInteraction->handle($case, 'telephone', 'Confirmed fictional appointment details.', now(), $worker);
+            $service = $this->createService->handle($case, 'housing_advice', 'Fictional tenancy advice session.', $this->at('2026-06-10 11:00'), $worker);
+            $this->transitionService->handle($service, CaseServiceStatus::Scheduled, 1, now(), $worker);
+            Date::setTestNow($this->at('2026-06-05 09:00'));
+            $referral = $this->createReferral->handle($case, 'Synthetic Housing Partner', 'Tenancy placement', 'Name and safe contact preference only', 'service_consent', $worker);
+            $this->transitionReferral->handle($referral, ExternalReferralStatus::Sent, 1, now(), $worker);
+            Date::setTestNow($this->at('2026-06-06 09:00'));
+            $this->transitionReferral->handle($referral->refresh(), ExternalReferralStatus::Acknowledged, 2, now(), $worker);
+            Date::setTestNow($this->at('2026-06-07 09:00'));
+            $task = $this->createTask->handle($case, 'Confirm tenancy', 'Check the fictional signed agreement.', $this->at('2026-06-20 17:00'), $worker);
+            Date::setTestNow($this->at('2026-06-08 09:00'));
+            $appointment = $this->createAppointment->handle($case, 'Housing review', 'HarbourKind office', $this->at('2026-06-10 11:00'), $worker);
+            Date::setTestNow($this->at('2026-06-10 12:00'));
+            $this->transitionService->handle($service->refresh(), CaseServiceStatus::Completed, 2, now(), $worker);
+            $this->transitionAppointment->handle($appointment, CaseAppointmentStatus::Completed, 1, now(), $worker, completedService: $service->refresh());
+            Date::setTestNow($this->at('2026-06-12 09:00'));
+            $this->transitionReferral->handle($referral->refresh(), ExternalReferralStatus::Connected, 3, now(), $worker);
+            Date::setTestNow($this->at('2026-06-18 10:00'));
+            $this->transitionTask->handle($task, CaseTaskStatus::Completed, 1, now(), $worker);
+            Date::setTestNow($this->at('2026-06-27 14:00'));
+            $this->transitionGoal->handle($goal->refresh(), CaseGoalStatus::Achieved, 2, now(), $worker, 'stable_tenancy');
+            $note = $this->saveNote->handle($case, 'Synthetic confidential note: tenancy options reviewed.', $worker);
+            $this->finalizeNote->handle($note, 1, $worker);
+            Date::setTestNow($this->at('2026-06-28 15:00'));
+            $this->transitionCase->handle($case->refresh(), ServiceCaseStatus::Closed, 2, now(), $manager, [
+                'reason' => 'goals_completed',
+                'narrative' => 'Stable fictional housing was secured and follow-up agreed.',
+                'measures' => ['progress' => 4],
+                'follow_up_at' => $this->at('2026-07-28 09:00'),
+            ]);
+
+            return $case->refresh();
+        } finally {
+            Date::setTestNow($reportingNow);
+        }
+    }
+
+    private function at(string $localTime): CarbonImmutable
+    {
+        return CarbonImmutable::parse($localTime, 'Africa/Johannesburg')->utc();
+    }
+}

--- a/app/Actions/Intake/TransitionIntakeRequest.php
+++ b/app/Actions/Intake/TransitionIntakeRequest.php
@@ -2,7 +2,11 @@
 
 namespace App\Actions\Intake;
 
+use App\Actions\CaseDelivery\RecordCaseMetric;
+use App\Actions\CaseDelivery\RecordCaseWorkflowTransition;
 use App\Actions\Parties\RecordPartyConsent;
+use App\Enums\CaseMetricCode;
+use App\Enums\CaseWorkflowSubject;
 use App\Enums\ConsentDecision;
 use App\Enums\ConsentPurpose;
 use App\Enums\EligibilityStatus;
@@ -24,6 +28,8 @@ class TransitionIntakeRequest
         private readonly OrganisationContext $organisationContext,
         private readonly AssignCaseWorker $assignCaseWorker,
         private readonly RecordPartyConsent $recordPartyConsent,
+        private readonly RecordCaseWorkflowTransition $recordCaseWorkflowTransition,
+        private readonly RecordCaseMetric $recordCaseMetric,
     ) {}
 
     /** @param array{urgency?: IntakeUrgency, eligibility_status?: EligibilityStatus, eligibility_context?: array<string, mixed>, risk_flags?: list<string>} $triage */
@@ -95,6 +101,11 @@ class TransitionIntakeRequest
                         'created_by_user_id' => $actor->id,
                     ],
                 );
+
+                if ($case->wasRecentlyCreated) {
+                    $this->recordCaseWorkflowTransition->handle($case, CaseWorkflowSubject::CaseRecord, $case->id, null, ServiceCaseStatus::Open->value, 1, $case->opened_at, $actor);
+                    $this->recordCaseMetric->handle($case, CaseMetricCode::CaseOpened, $case->opened_at, "case:{$case->id}:opened");
+                }
 
                 if ($worker !== null) {
                     $this->assignCaseWorker->handle($case, $worker, $actor, $reason);

--- a/app/Actions/Parties/RecordPartyConsent.php
+++ b/app/Actions/Parties/RecordPartyConsent.php
@@ -25,6 +25,7 @@ final class RecordPartyConsent
         $this->organisationContext->ensureOwns($party->organisation_id);
 
         return DB::transaction(function () use ($party, $attributes, $actor): PartyConsent {
+            $party = Party::query()->lockForUpdate()->findOrFail($party->id);
             $latest = PartyConsent::query()
                 ->where('party_id', $party->id)
                 ->where('purpose', $attributes['purpose'])

--- a/app/Data/Demo/ScenarioCatalog.php
+++ b/app/Data/Demo/ScenarioCatalog.php
@@ -9,7 +9,7 @@ use InvalidArgumentException;
 
 final class ScenarioCatalog
 {
-    public const VERSION = '2026.2';
+    public const VERSION = '2026.3';
 
     public const AS_OF = '2026-06-30 23:59:59';
 

--- a/app/Enums/CaseAppointmentStatus.php
+++ b/app/Enums/CaseAppointmentStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Enums;
+
+enum CaseAppointmentStatus: string
+{
+    case Scheduled = 'scheduled';
+    case Completed = 'completed';
+    case Cancelled = 'cancelled';
+    case NoShow = 'no_show';
+
+    /** @return list<self> */
+    public function allowedTransitions(): array
+    {
+        return $this === self::Scheduled ? [self::Completed, self::Cancelled, self::NoShow] : [];
+    }
+
+    public function isTerminal(): bool
+    {
+        return $this !== self::Scheduled;
+    }
+}

--- a/app/Enums/CaseGoalStatus.php
+++ b/app/Enums/CaseGoalStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Enums;
+
+enum CaseGoalStatus: string
+{
+    case Draft = 'draft';
+    case Active = 'active';
+    case Achieved = 'achieved';
+    case NotAchieved = 'not_achieved';
+    case Cancelled = 'cancelled';
+    case Withdrawn = 'withdrawn';
+
+    /** @return list<self> */
+    public function allowedTransitions(): array
+    {
+        return match ($this) {
+            self::Draft => [self::Active, self::Cancelled],
+            self::Active => [self::Achieved, self::NotAchieved, self::Cancelled, self::Withdrawn],
+            default => [],
+        };
+    }
+
+    public function isTerminal(): bool
+    {
+        return $this->allowedTransitions() === [];
+    }
+}

--- a/app/Enums/CaseMetricCode.php
+++ b/app/Enums/CaseMetricCode.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums;
+
+enum CaseMetricCode: string
+{
+    case CaseOpened = 'case_opened';
+    case CaseClosed = 'case_closed';
+    case ServiceDelivered = 'service_delivered';
+    case GoalAchieved = 'goal_achieved';
+    case GoalNotAchieved = 'goal_not_achieved';
+    case ReferralConnected = 'referral_connected';
+    case ReferralNotConnected = 'referral_not_connected';
+}

--- a/app/Enums/CaseNoteStatus.php
+++ b/app/Enums/CaseNoteStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum CaseNoteStatus: string
+{
+    case Draft = 'draft';
+    case Finalized = 'finalized';
+}

--- a/app/Enums/CaseServiceStatus.php
+++ b/app/Enums/CaseServiceStatus.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Enums;
+
+enum CaseServiceStatus: string
+{
+    case Planned = 'planned';
+    case Scheduled = 'scheduled';
+    case Completed = 'completed';
+    case Cancelled = 'cancelled';
+    case NotDelivered = 'not_delivered';
+
+    /** @return list<self> */
+    public function allowedTransitions(): array
+    {
+        return match ($this) {
+            self::Planned => [self::Scheduled, self::Completed, self::Cancelled],
+            self::Scheduled => [self::Completed, self::Cancelled, self::NotDelivered],
+            default => [],
+        };
+    }
+
+    public function isTerminal(): bool
+    {
+        return $this->allowedTransitions() === [];
+    }
+}

--- a/app/Enums/CaseTaskStatus.php
+++ b/app/Enums/CaseTaskStatus.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+enum CaseTaskStatus: string
+{
+    case Open = 'open';
+    case Completed = 'completed';
+    case Cancelled = 'cancelled';
+
+    /** @return list<self> */
+    public function allowedTransitions(): array
+    {
+        return $this === self::Open ? [self::Completed, self::Cancelled] : [];
+    }
+
+    public function isTerminal(): bool
+    {
+        return $this !== self::Open;
+    }
+}

--- a/app/Enums/CaseWorkflowSubject.php
+++ b/app/Enums/CaseWorkflowSubject.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums;
+
+enum CaseWorkflowSubject: string
+{
+    case CaseRecord = 'case';
+    case Goal = 'goal';
+    case Service = 'service';
+    case Referral = 'referral';
+    case Task = 'task';
+    case Appointment = 'appointment';
+    case Note = 'note';
+}

--- a/app/Enums/ExternalReferralStatus.php
+++ b/app/Enums/ExternalReferralStatus.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Enums;
+
+enum ExternalReferralStatus: string
+{
+    case Draft = 'draft';
+    case Sent = 'sent';
+    case Acknowledged = 'acknowledged';
+    case Connected = 'connected';
+    case NotConnected = 'not_connected';
+    case Cancelled = 'cancelled';
+
+    /** @return list<self> */
+    public function allowedTransitions(): array
+    {
+        return match ($this) {
+            self::Draft => [self::Sent, self::Cancelled],
+            self::Sent => [self::Acknowledged, self::Connected, self::NotConnected, self::Cancelled],
+            self::Acknowledged => [self::Connected, self::NotConnected, self::Cancelled],
+            default => [],
+        };
+    }
+
+    public function isTerminal(): bool
+    {
+        return $this->allowedTransitions() === [];
+    }
+}

--- a/app/Enums/ServiceCaseStatus.php
+++ b/app/Enums/ServiceCaseStatus.php
@@ -9,4 +9,20 @@ enum ServiceCaseStatus: string
     case OnHold = 'on_hold';
     case Closed = 'closed';
     case Cancelled = 'cancelled';
+
+    /** @return list<self> */
+    public function allowedTransitions(): array
+    {
+        return match ($this) {
+            self::Open => [self::Active, self::OnHold, self::Closed, self::Cancelled],
+            self::Active => [self::OnHold, self::Closed],
+            self::OnHold => [self::Active, self::Closed],
+            self::Closed, self::Cancelled => [],
+        };
+    }
+
+    public function isTerminal(): bool
+    {
+        return in_array($this, [self::Closed, self::Cancelled], true);
+    }
 }

--- a/app/Http/Controllers/Organisations/CaseItemController.php
+++ b/app/Http/Controllers/Organisations/CaseItemController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\CaseDelivery\CreateCaseAppointment;
+use App\Actions\CaseDelivery\CreateCaseGoal;
+use App\Actions\CaseDelivery\CreateCaseService;
+use App\Actions\CaseDelivery\CreateCaseTask;
+use App\Actions\CaseDelivery\CreateExternalReferral;
+use App\Actions\CaseDelivery\RecordCaseInteraction;
+use App\Actions\CaseDelivery\SaveCaseNote;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\StoreCaseItemRequest;
+use App\Models\CaseNote;
+use App\Models\Organisation;
+use App\Models\ServiceCase;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+use LogicException;
+
+class CaseItemController extends Controller
+{
+    public function store(
+        StoreCaseItemRequest $request,
+        Organisation $currentOrganisation,
+        string $case,
+        CreateCaseGoal $createGoal,
+        CreateCaseService $createService,
+        CreateExternalReferral $createReferral,
+        CreateCaseTask $createTask,
+        CreateCaseAppointment $createAppointment,
+        RecordCaseInteraction $recordInteraction,
+        SaveCaseNote $saveNote,
+    ): RedirectResponse {
+        $serviceCase = ServiceCase::query()->findOrFail($case);
+        Gate::authorize('update', $serviceCase);
+
+        try {
+            match ($request->string('kind')->toString()) {
+                'goal' => $createGoal->handle($serviceCase, $request->string('title')->toString(), $request->string('description')->toString(), $this->date($request->input('target_at')), $request->user()),
+                'service' => $createService->handle($serviceCase, $request->string('service_code')->toString(), $request->string('summary')->toString(), $this->date($request->input('scheduled_for')), $request->user()),
+                'referral' => $createReferral->handle($serviceCase, $request->string('destination')->toString(), $request->string('purpose')->toString(), $request->string('minimum_necessary')->toString(), $request->string('sharing_authority')->toString(), $request->user()),
+                'task' => $createTask->handle($serviceCase, $request->string('title')->toString(), $request->string('description')->toString(), $this->date($request->input('due_at')), $request->user()),
+                'appointment' => $createAppointment->handle($serviceCase, $request->string('summary')->toString(), $request->string('location')->toString(), $this->date($request->input('scheduled_at')) ?? now(), $request->user()),
+                'interaction' => $recordInteraction->handle($serviceCase, $request->string('interaction_type')->toString(), $request->string('summary')->toString(), $this->date($request->input('occurred_at')) ?? now(), $request->user()),
+                'note' => $saveNote->handle($serviceCase, $request->string('content')->toString(), $request->user(), $this->correctedNote($serviceCase, $request->input('corrects_note_id'))),
+                default => throw new LogicException('Unsupported Case item type.'),
+            };
+        } catch (LogicException $exception) {
+            throw ValidationException::withMessages(['item' => $exception->getMessage()]);
+        }
+
+        return back();
+    }
+
+    private function date(mixed $value): ?CarbonImmutable
+    {
+        return is_string($value) && $value !== '' ? CarbonImmutable::parse($value) : null;
+    }
+
+    private function correctedNote(ServiceCase $case, mixed $id): ?CaseNote
+    {
+        return is_string($id) && $id !== '' ? $case->notes()->findOrFail($id) : null;
+    }
+}

--- a/app/Http/Controllers/Organisations/CaseWorkflowController.php
+++ b/app/Http/Controllers/Organisations/CaseWorkflowController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\CaseDelivery\CarryForwardExternalReferral;
+use App\Actions\CaseDelivery\FinalizeCaseNote;
+use App\Actions\CaseDelivery\TransitionCaseAppointment;
+use App\Actions\CaseDelivery\TransitionCaseGoal;
+use App\Actions\CaseDelivery\TransitionCaseService;
+use App\Actions\CaseDelivery\TransitionCaseTask;
+use App\Actions\CaseDelivery\TransitionExternalReferral;
+use App\Enums\CaseAppointmentStatus;
+use App\Enums\CaseGoalStatus;
+use App\Enums\CaseServiceStatus;
+use App\Enums\CaseTaskStatus;
+use App\Enums\ExternalReferralStatus;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\TransitionCaseItemRequest;
+use App\Models\CaseService;
+use App\Models\Organisation;
+use App\Models\ServiceCase;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+use LogicException;
+
+class CaseWorkflowController extends Controller
+{
+    public function store(
+        TransitionCaseItemRequest $request,
+        Organisation $currentOrganisation,
+        string $case,
+        string $subjectType,
+        string $subject,
+        TransitionCaseGoal $transitionGoal,
+        TransitionCaseService $transitionService,
+        TransitionExternalReferral $transitionReferral,
+        CarryForwardExternalReferral $carryReferral,
+        TransitionCaseTask $transitionTask,
+        TransitionCaseAppointment $transitionAppointment,
+        FinalizeCaseNote $finalizeNote,
+    ): RedirectResponse {
+        $serviceCase = ServiceCase::query()->findOrFail($case);
+        Gate::authorize('update', $serviceCase);
+        $status = $request->string('status')->toString();
+        $version = $request->integer('expected_version');
+        $effectiveAt = CarbonImmutable::parse($request->string('effective_at')->toString());
+        $reason = $request->filled('reason') ? $request->string('reason')->toString() : null;
+
+        try {
+            match ($subjectType) {
+                'goal' => $transitionGoal->handle($serviceCase->goals()->findOrFail($subject), CaseGoalStatus::from($status), $version, $effectiveAt, $request->user(), $reason),
+                'service' => $transitionService->handle($serviceCase->services()->findOrFail($subject), CaseServiceStatus::from($status), $version, $effectiveAt, $request->user(), $reason),
+                'referral' => $status === 'carry_forward'
+                    ? $carryReferral->handle($serviceCase->referrals()->findOrFail($subject), $version, (string) $reason, $effectiveAt, $request->user())
+                    : $transitionReferral->handle($serviceCase->referrals()->findOrFail($subject), ExternalReferralStatus::from($status), $version, $effectiveAt, $request->user(), $reason),
+                'task' => $transitionTask->handle($serviceCase->tasks()->findOrFail($subject), CaseTaskStatus::from($status), $version, $effectiveAt, $request->user(), $reason),
+                'appointment' => $transitionAppointment->handle($serviceCase->appointments()->findOrFail($subject), CaseAppointmentStatus::from($status), $version, $effectiveAt, $request->user(), $reason, $this->completedService($serviceCase, $request->input('completed_service_id'))),
+                'note' => $finalizeNote->handle($serviceCase->notes()->findOrFail($subject), $version, $request->user()),
+                default => throw new LogicException('Unsupported Case item type.'),
+            };
+        } catch (LogicException $exception) {
+            throw ValidationException::withMessages(['status' => $exception->getMessage()]);
+        }
+
+        return back();
+    }
+
+    private function completedService(ServiceCase $case, mixed $id): ?CaseService
+    {
+        return is_string($id) && $id !== '' ? $case->services()->findOrFail($id) : null;
+    }
+}

--- a/app/Http/Controllers/Organisations/ServiceCaseController.php
+++ b/app/Http/Controllers/Organisations/ServiceCaseController.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\CaseDelivery\TransitionServiceCase;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\ServiceCaseStatus;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\TransitionServiceCaseRequest;
+use App\Models\CaseAppointment;
+use App\Models\CaseGoal;
+use App\Models\CaseInteraction;
+use App\Models\CaseNote;
+use App\Models\CaseService;
+use App\Models\CaseTask;
+use App\Models\ExternalReferral;
+use App\Models\Organisation;
+use App\Models\ServiceCase;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+use LogicException;
+
+class ServiceCaseController extends Controller
+{
+    public function show(Request $request, Organisation $currentOrganisation, string $case): Response
+    {
+        $serviceCase = ServiceCase::query()->findOrFail($case);
+        Gate::authorize('view', $serviceCase);
+        $serviceCase->load([
+            'party:id,uuid,display_name', 'program:id,organisation_id,name,configuration', 'intakeRequest:id',
+            'assignments.membership.user:id,name', 'goals', 'services', 'referrals', 'tasks', 'appointments',
+            'interactions', 'notes', 'outcome', 'workflowTransitions' => fn ($query) => $query->orderByDesc('recorded_at'),
+        ]);
+
+        return Inertia::render('cases/show', [
+            'caseRecord' => [
+                'id' => $serviceCase->id,
+                'version' => $serviceCase->version,
+                'status' => $serviceCase->status->value,
+                'confidentiality' => $serviceCase->confidentiality,
+                'openedAt' => $serviceCase->opened_at->toAtomString(),
+                'closedAt' => $serviceCase->closed_at?->toAtomString(),
+                'closureReason' => $serviceCase->closure_reason,
+                'followUpAt' => $serviceCase->follow_up_at?->toAtomString(),
+                'party' => ['uuid' => $serviceCase->party->uuid, 'displayName' => $serviceCase->party->display_name],
+                'program' => ['id' => $serviceCase->program->id, 'name' => $serviceCase->program->name, 'configuration' => $serviceCase->program->configuration],
+                'intakeId' => $serviceCase->intake_request_id,
+                'assignments' => $serviceCase->assignments->map(fn ($assignment): array => ['id' => $assignment->id, 'worker' => $assignment->membership->user->name, 'status' => $assignment->status->value]),
+                'goals' => $serviceCase->goals->map(fn (CaseGoal $goal): array => [...$this->item($goal->id, $goal->status->value, $goal->version, $goal->encrypted_content), 'targetAt' => $goal->target_at?->toAtomString(), 'effectiveAt' => $goal->effective_at?->toAtomString(), 'reason' => $goal->terminal_reason]),
+                'services' => $serviceCase->services->map(fn (CaseService $service): array => [...$this->item($service->id, $service->status->value, $service->version, $service->encrypted_content), 'serviceCode' => $service->service_code, 'scheduledFor' => $service->scheduled_for?->toAtomString(), 'deliveredAt' => $service->delivered_at?->toAtomString(), 'reason' => $service->terminal_reason]),
+                'referrals' => $serviceCase->referrals->map(fn (ExternalReferral $referral): array => [...$this->item($referral->id, $referral->status->value, $referral->version, $referral->encrypted_content), 'sharingAuthority' => $referral->sharing_authority, 'sentAt' => $referral->sent_at?->toAtomString(), 'effectiveAt' => $referral->effective_at?->toAtomString(), 'carriedForwardAt' => $referral->carried_forward_at?->toAtomString(), 'reason' => $referral->terminal_reason ?? $referral->carry_forward_reason]),
+                'tasks' => $serviceCase->tasks->map(fn (CaseTask $task): array => [...$this->item($task->id, $task->status->value, $task->version, $task->encrypted_content), 'dueAt' => $task->due_at?->toAtomString(), 'overdue' => $task->status->value === 'open' && $task->due_at?->isPast(), 'effectiveAt' => $task->effective_at?->toAtomString(), 'reason' => $task->terminal_reason]),
+                'appointments' => $serviceCase->appointments->map(fn (CaseAppointment $appointment): array => [...$this->item($appointment->id, $appointment->status->value, $appointment->version, $appointment->encrypted_content), 'scheduledAt' => $appointment->scheduled_at->toAtomString(), 'effectiveAt' => $appointment->effective_at?->toAtomString(), 'completedServiceId' => $appointment->completed_service_id, 'reason' => $appointment->terminal_reason]),
+                'interactions' => $serviceCase->interactions->map(fn (CaseInteraction $interaction): array => ['id' => $interaction->id, 'type' => $interaction->interaction_type, 'content' => $this->decoded($interaction->encrypted_content), 'occurredAt' => $interaction->occurred_at->toAtomString()]),
+                'notes' => $serviceCase->notes->map(fn (CaseNote $note): array => ['id' => $note->id, 'status' => $note->status->value, 'version' => $note->version, 'content' => $note->encrypted_content->reveal(), 'correctsNoteId' => $note->corrects_note_id, 'finalizedAt' => $note->finalized_at?->toAtomString()]),
+                'outcome' => $serviceCase->outcome === null ? null : ['measures' => $serviceCase->outcome->measures, 'narrative' => $serviceCase->outcome->encrypted_content->reveal(), 'effectiveAt' => $serviceCase->outcome->effective_at->toAtomString()],
+                'transitions' => $serviceCase->workflowTransitions->map(fn ($transition): array => ['id' => $transition->id, 'subjectType' => $transition->subject_type->value, 'from' => $transition->from_status, 'to' => $transition->to_status, 'reason' => $transition->reason, 'effectiveAt' => $transition->effective_at->toAtomString(), 'version' => $transition->version]),
+            ],
+            'canUpdate' => Gate::allows('update', $serviceCase),
+        ]);
+    }
+
+    public function transition(TransitionServiceCaseRequest $request, Organisation $currentOrganisation, string $case, TransitionServiceCase $transitionCase): RedirectResponse
+    {
+        $serviceCase = ServiceCase::query()->findOrFail($case);
+        Gate::authorize('update', $serviceCase);
+
+        try {
+            $transitionCase->handle($serviceCase, ServiceCaseStatus::from($request->string('status')->toString()), $request->integer('expected_version'), CarbonImmutable::parse($request->string('effective_at')->toString()), $request->user(), [
+                'reason' => $request->filled('reason') ? $request->string('reason')->toString() : null,
+                'narrative' => $request->filled('narrative') ? $request->string('narrative')->toString() : null,
+                'measures' => $request->array('measures'),
+                'follow_up_at' => $request->filled('follow_up_at') ? CarbonImmutable::parse($request->string('follow_up_at')->toString()) : null,
+            ]);
+        } catch (LogicException $exception) {
+            throw ValidationException::withMessages(['status' => $exception->getMessage()]);
+        }
+
+        return back();
+    }
+
+    /** @return array{id: string, status: string, version: int, content: array<string, mixed>} */
+    private function item(string $id, string $status, int $version, ClassifiedValue $content): array
+    {
+        return compact('id', 'status', 'version') + ['content' => $this->decoded($content)];
+    }
+
+    /** @return array<string, mixed> */
+    private function decoded(ClassifiedValue $content): array
+    {
+        $decoded = json_decode($content->reveal(), true, flags: JSON_THROW_ON_ERROR);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+}

--- a/app/Http/Requests/Organisations/StoreCaseItemRequest.php
+++ b/app/Http/Requests/Organisations/StoreCaseItemRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreCaseItemRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $kind = $this->string('kind')->toString();
+        $requiredFor = fn (string ...$kinds): bool => in_array($kind, $kinds, true);
+
+        return [
+            'kind' => ['required', Rule::in(['goal', 'service', 'referral', 'task', 'appointment', 'interaction', 'note'])],
+            'title' => [Rule::requiredIf(fn (): bool => $requiredFor('goal', 'task')), 'nullable', 'string', 'max:200'],
+            'description' => [Rule::requiredIf(fn (): bool => $requiredFor('goal', 'task')), 'nullable', 'string', 'max:5000'],
+            'summary' => [Rule::requiredIf(fn (): bool => $requiredFor('service', 'appointment', 'interaction')), 'nullable', 'string', 'max:5000'],
+            'content' => [Rule::requiredIf(fn (): bool => $requiredFor('note')), 'nullable', 'string', 'max:20000'],
+            'service_code' => [Rule::requiredIf(fn (): bool => $requiredFor('service')), 'nullable', 'string', 'regex:/^[a-z0-9_\-]+$/', 'max:64'],
+            'destination' => [Rule::requiredIf(fn (): bool => $requiredFor('referral')), 'nullable', 'string', 'max:500'],
+            'purpose' => [Rule::requiredIf(fn (): bool => $requiredFor('referral')), 'nullable', 'string', 'max:1000'],
+            'minimum_necessary' => [Rule::requiredIf(fn (): bool => $requiredFor('referral')), 'nullable', 'string', 'max:2000'],
+            'sharing_authority' => [Rule::requiredIf(fn (): bool => $requiredFor('referral')), 'nullable', Rule::in(['service_consent'])],
+            'location' => [Rule::requiredIf(fn (): bool => $requiredFor('appointment')), 'nullable', 'string', 'max:500'],
+            'interaction_type' => [Rule::requiredIf(fn (): bool => $requiredFor('interaction')), 'nullable', Rule::in(['in_person', 'telephone', 'email', 'video', 'other'])],
+            'target_at' => ['nullable', 'date'],
+            'scheduled_for' => ['nullable', 'date'],
+            'due_at' => ['nullable', 'date'],
+            'scheduled_at' => [Rule::requiredIf(fn (): bool => $requiredFor('appointment')), 'nullable', 'date'],
+            'occurred_at' => [Rule::requiredIf(fn (): bool => $requiredFor('interaction')), 'nullable', 'date'],
+            'corrects_note_id' => ['nullable', 'uuid'],
+        ];
+    }
+}

--- a/app/Http/Requests/Organisations/TransitionCaseItemRequest.php
+++ b/app/Http/Requests/Organisations/TransitionCaseItemRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TransitionCaseItemRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => ['required', Rule::in(['active', 'achieved', 'not_achieved', 'cancelled', 'withdrawn', 'scheduled', 'completed', 'not_delivered', 'sent', 'acknowledged', 'connected', 'not_connected', 'carry_forward', 'no_show', 'finalized'])],
+            'expected_version' => ['required', 'integer', 'min:1'],
+            'effective_at' => ['required', 'date'],
+            'reason' => ['nullable', 'string', Rule::in(['achieved', 'not_achieved', 'withdrawn', 'no_longer_needed', 'client_cancelled', 'provider_cancelled', 'not_available', 'unable_to_connect', 'no_show', 'completed_elsewhere', 'follow_up_in_new_case', 'stable_tenancy'])],
+            'completed_service_id' => ['nullable', 'uuid'],
+        ];
+    }
+}

--- a/app/Http/Requests/Organisations/TransitionServiceCaseRequest.php
+++ b/app/Http/Requests/Organisations/TransitionServiceCaseRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TransitionServiceCaseRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => ['required', Rule::in(['active', 'on_hold', 'closed', 'cancelled'])],
+            'expected_version' => ['required', 'integer', 'min:1'],
+            'effective_at' => ['required', 'date'],
+            'reason' => ['nullable', 'string', Rule::in(['goals_completed', 'client_withdrew', 'created_in_error', 'support_completed', 'transferred'])],
+            'narrative' => ['nullable', 'string', 'max:10000'],
+            'measures' => ['nullable', 'array'],
+            'measures.*' => ['required', 'numeric'],
+            'follow_up_at' => ['nullable', 'date', 'after:effective_at'],
+        ];
+    }
+}

--- a/app/Models/CaseAppointment.php
+++ b/app/Models/CaseAppointment.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\ClassifiedValueCast;
+use App\Concerns\BelongsToOrganisation;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseAppointmentStatus;
+use Database\Factories\CaseAppointmentFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $service_case_id
+ * @property ClassifiedValue $encrypted_content
+ * @property CaseAppointmentStatus $status
+ * @property int $version
+ * @property Carbon $scheduled_at
+ * @property Carbon|null $effective_at
+ * @property string|null $terminal_reason
+ * @property string|null $completed_service_id
+ * @property-read ServiceCase $serviceCase
+ */
+class CaseAppointment extends Model
+{
+    /** @use HasFactory<CaseAppointmentFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected $guarded = ['organisation_id'];
+
+    /** @return BelongsTo<ServiceCase, $this> */
+    public function serviceCase(): BelongsTo
+    {
+        return $this->belongsTo(ServiceCase::class);
+    }
+
+    /** @return BelongsTo<CaseService, $this> */
+    public function completedService(): BelongsTo
+    {
+        return $this->belongsTo(CaseService::class, 'completed_service_id');
+    }
+
+    protected function casts(): array
+    {
+        return ['encrypted_content' => ClassifiedValueCast::class.':case_appointment', 'status' => CaseAppointmentStatus::class, 'scheduled_at' => 'datetime', 'effective_at' => 'datetime'];
+    }
+}

--- a/app/Models/CaseGoal.php
+++ b/app/Models/CaseGoal.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\ClassifiedValueCast;
+use App\Concerns\BelongsToOrganisation;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseGoalStatus;
+use Database\Factories\CaseGoalFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $service_case_id
+ * @property ClassifiedValue $encrypted_content
+ * @property CaseGoalStatus $status
+ * @property int $version
+ * @property Carbon|null $target_at
+ * @property Carbon|null $effective_at
+ * @property string|null $terminal_reason
+ * @property-read ServiceCase $serviceCase
+ */
+class CaseGoal extends Model
+{
+    /** @use HasFactory<CaseGoalFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected $guarded = ['organisation_id'];
+
+    /** @return BelongsTo<ServiceCase, $this> */
+    public function serviceCase(): BelongsTo
+    {
+        return $this->belongsTo(ServiceCase::class);
+    }
+
+    protected function casts(): array
+    {
+        return ['encrypted_content' => ClassifiedValueCast::class.':case_goal', 'status' => CaseGoalStatus::class, 'target_at' => 'datetime', 'effective_at' => 'datetime'];
+    }
+}

--- a/app/Models/CaseInteraction.php
+++ b/app/Models/CaseInteraction.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\ClassifiedValueCast;
+use App\Concerns\BelongsToOrganisation;
+use App\Data\Values\ClassifiedValue;
+use Database\Factories\CaseInteractionFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $service_case_id
+ * @property string $interaction_type
+ * @property ClassifiedValue $encrypted_content
+ * @property Carbon $occurred_at
+ * @property Carbon $recorded_at
+ * @property-read ServiceCase $serviceCase
+ */
+class CaseInteraction extends Model
+{
+    /** @use HasFactory<CaseInteractionFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    public $timestamps = false;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Case interactions are append-only.'));
+        static::deleting(fn () => throw new LogicException('Case interactions are append-only.'));
+    }
+
+    /** @return BelongsTo<ServiceCase, $this> */
+    public function serviceCase(): BelongsTo
+    {
+        return $this->belongsTo(ServiceCase::class);
+    }
+
+    protected function casts(): array
+    {
+        return ['encrypted_content' => ClassifiedValueCast::class.':case_interaction', 'occurred_at' => 'datetime', 'recorded_at' => 'datetime'];
+    }
+}

--- a/app/Models/CaseNote.php
+++ b/app/Models/CaseNote.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\ClassifiedValueCast;
+use App\Concerns\BelongsToOrganisation;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseNoteStatus;
+use Database\Factories\CaseNoteFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $service_case_id
+ * @property ClassifiedValue $encrypted_content
+ * @property CaseNoteStatus $status
+ * @property int $version
+ * @property string|null $corrects_note_id
+ * @property Carbon|null $finalized_at
+ * @property-read ServiceCase $serviceCase
+ */
+class CaseNote extends Model
+{
+    /** @use HasFactory<CaseNoteFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(function (CaseNote $note): void {
+            if ($note->getRawOriginal('status') === CaseNoteStatus::Finalized->value) {
+                throw new LogicException('Finalized case notes cannot be overwritten. Add a correction or addendum.');
+            }
+        });
+        static::deleting(fn () => throw new LogicException('Case notes are retained as history.'));
+    }
+
+    /** @return BelongsTo<ServiceCase, $this> */
+    public function serviceCase(): BelongsTo
+    {
+        return $this->belongsTo(ServiceCase::class);
+    }
+
+    /** @return BelongsTo<CaseNote, $this> */
+    public function correctedNote(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'corrects_note_id');
+    }
+
+    protected function casts(): array
+    {
+        return ['encrypted_content' => ClassifiedValueCast::class.':case_note', 'status' => CaseNoteStatus::class, 'finalized_at' => 'datetime'];
+    }
+}

--- a/app/Models/CaseOutcome.php
+++ b/app/Models/CaseOutcome.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\ClassifiedValueCast;
+use App\Concerns\BelongsToOrganisation;
+use App\Data\Values\ClassifiedValue;
+use Database\Factories\CaseOutcomeFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $service_case_id
+ * @property array<string, int|float|string> $measures
+ * @property ClassifiedValue $encrypted_content
+ * @property Carbon $effective_at
+ * @property Carbon $recorded_at
+ * @property-read ServiceCase $serviceCase
+ */
+class CaseOutcome extends Model
+{
+    /** @use HasFactory<CaseOutcomeFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    public $timestamps = false;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Case outcomes are append-only.'));
+        static::deleting(fn () => throw new LogicException('Case outcomes are append-only.'));
+    }
+
+    /** @return BelongsTo<ServiceCase, $this> */
+    public function serviceCase(): BelongsTo
+    {
+        return $this->belongsTo(ServiceCase::class);
+    }
+
+    protected function casts(): array
+    {
+        return ['encrypted_content' => ClassifiedValueCast::class.':case_outcome', 'measures' => 'array', 'effective_at' => 'datetime', 'recorded_at' => 'datetime'];
+    }
+}

--- a/app/Models/CaseService.php
+++ b/app/Models/CaseService.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\ClassifiedValueCast;
+use App\Concerns\BelongsToOrganisation;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseServiceStatus;
+use Database\Factories\CaseServiceFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $service_case_id
+ * @property ClassifiedValue $encrypted_content
+ * @property string $service_code
+ * @property CaseServiceStatus $status
+ * @property int $version
+ * @property Carbon|null $scheduled_for
+ * @property Carbon|null $delivered_at
+ * @property string|null $terminal_reason
+ * @property-read ServiceCase $serviceCase
+ */
+class CaseService extends Model
+{
+    /** @use HasFactory<CaseServiceFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected $guarded = ['organisation_id'];
+
+    /** @return BelongsTo<ServiceCase, $this> */
+    public function serviceCase(): BelongsTo
+    {
+        return $this->belongsTo(ServiceCase::class);
+    }
+
+    protected function casts(): array
+    {
+        return ['encrypted_content' => ClassifiedValueCast::class.':case_service', 'status' => CaseServiceStatus::class, 'scheduled_for' => 'datetime', 'delivered_at' => 'datetime'];
+    }
+}

--- a/app/Models/CaseTask.php
+++ b/app/Models/CaseTask.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\ClassifiedValueCast;
+use App\Concerns\BelongsToOrganisation;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseTaskStatus;
+use Database\Factories\CaseTaskFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $service_case_id
+ * @property ClassifiedValue $encrypted_content
+ * @property CaseTaskStatus $status
+ * @property int $version
+ * @property Carbon|null $due_at
+ * @property Carbon|null $effective_at
+ * @property string|null $terminal_reason
+ * @property-read ServiceCase $serviceCase
+ */
+class CaseTask extends Model
+{
+    /** @use HasFactory<CaseTaskFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected $guarded = ['organisation_id'];
+
+    /** @return BelongsTo<ServiceCase, $this> */
+    public function serviceCase(): BelongsTo
+    {
+        return $this->belongsTo(ServiceCase::class);
+    }
+
+    protected function casts(): array
+    {
+        return ['encrypted_content' => ClassifiedValueCast::class.':case_task', 'status' => CaseTaskStatus::class, 'due_at' => 'datetime', 'effective_at' => 'datetime'];
+    }
+}

--- a/app/Models/CaseWorkflowTransition.php
+++ b/app/Models/CaseWorkflowTransition.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\CaseWorkflowSubject;
+use Database\Factories\CaseWorkflowTransitionFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $service_case_id
+ * @property CaseWorkflowSubject $subject_type
+ * @property string $subject_id
+ * @property string|null $from_status
+ * @property string $to_status
+ * @property string|null $reason
+ * @property int $version
+ * @property Carbon $effective_at
+ * @property Carbon $recorded_at
+ * @property-read ServiceCase $serviceCase
+ */
+class CaseWorkflowTransition extends Model
+{
+    /** @use HasFactory<CaseWorkflowTransitionFactory> */
+    use BelongsToOrganisation, HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Case workflow transitions are append-only.'));
+        static::deleting(fn () => throw new LogicException('Case workflow transitions are append-only.'));
+    }
+
+    /** @return BelongsTo<ServiceCase, $this> */
+    public function serviceCase(): BelongsTo
+    {
+        return $this->belongsTo(ServiceCase::class);
+    }
+
+    protected function casts(): array
+    {
+        return ['subject_type' => CaseWorkflowSubject::class, 'effective_at' => 'datetime', 'recorded_at' => 'datetime'];
+    }
+}

--- a/app/Models/ExternalReferral.php
+++ b/app/Models/ExternalReferral.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\ClassifiedValueCast;
+use App\Concerns\BelongsToOrganisation;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\ExternalReferralStatus;
+use Database\Factories\ExternalReferralFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $service_case_id
+ * @property ClassifiedValue $encrypted_content
+ * @property ExternalReferralStatus $status
+ * @property int $version
+ * @property string $sharing_authority
+ * @property Carbon|null $sent_at
+ * @property Carbon|null $effective_at
+ * @property Carbon|null $carried_forward_at
+ * @property string|null $terminal_reason
+ * @property string|null $carry_forward_reason
+ * @property-read ServiceCase $serviceCase
+ */
+class ExternalReferral extends Model
+{
+    /** @use HasFactory<ExternalReferralFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected $guarded = ['organisation_id'];
+
+    /** @return BelongsTo<ServiceCase, $this> */
+    public function serviceCase(): BelongsTo
+    {
+        return $this->belongsTo(ServiceCase::class);
+    }
+
+    protected function casts(): array
+    {
+        return ['encrypted_content' => ClassifiedValueCast::class.':external_referral', 'status' => ExternalReferralStatus::class, 'sent_at' => 'datetime', 'effective_at' => 'datetime', 'carried_forward_at' => 'datetime'];
+    }
+}

--- a/app/Models/MetricEvent.php
+++ b/app/Models/MetricEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\CaseMetricCode;
+use Database\Factories\MetricEventFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property int $program_id
+ * @property CaseMetricCode $code
+ * @property string $value
+ * @property array<string, bool|int|float|string|null> $dimensions
+ * @property string $deduplication_key
+ * @property Carbon $occurred_at
+ * @property Carbon $recorded_at
+ */
+class MetricEvent extends Model
+{
+    /** @use HasFactory<MetricEventFactory> */
+    use BelongsToOrganisation, HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Metric events are append-only.'));
+        static::deleting(fn () => throw new LogicException('Metric events are append-only.'));
+    }
+
+    /** @return BelongsTo<Program, $this> */
+    public function program(): BelongsTo
+    {
+        return $this->belongsTo(Program::class);
+    }
+
+    protected function casts(): array
+    {
+        return ['code' => CaseMetricCode::class, 'dimensions' => 'array', 'value' => 'decimal:4', 'occurred_at' => 'datetime', 'recorded_at' => 'datetime'];
+    }
+}

--- a/app/Models/ServiceCase.php
+++ b/app/Models/ServiceCase.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Carbon;
 
 /**
@@ -19,11 +20,17 @@ use Illuminate\Support\Carbon;
  * @property int $program_id
  * @property int $party_id
  * @property ServiceCaseStatus $status
+ * @property int $version
  * @property string $confidentiality
  * @property Carbon $opened_at
+ * @property Carbon|null $closed_at
+ * @property string|null $closure_reason
+ * @property Carbon|null $follow_up_at
+ * @property array<string, bool>|null $closure_checklist
  * @property-read Organisation $organisation
  * @property-read Program $program
  * @property-read Party $party
+ * @property-read CaseOutcome|null $outcome
  */
 class ServiceCase extends Model
 {
@@ -62,8 +69,68 @@ class ServiceCase extends Model
         return $this->hasMany(CaseAssignment::class);
     }
 
+    /** @return HasMany<CaseGoal, $this> */
+    public function goals(): HasMany
+    {
+        return $this->hasMany(CaseGoal::class);
+    }
+
+    /** @return HasMany<CaseService, $this> */
+    public function services(): HasMany
+    {
+        return $this->hasMany(CaseService::class);
+    }
+
+    /** @return HasMany<ExternalReferral, $this> */
+    public function referrals(): HasMany
+    {
+        return $this->hasMany(ExternalReferral::class);
+    }
+
+    /** @return HasMany<CaseTask, $this> */
+    public function tasks(): HasMany
+    {
+        return $this->hasMany(CaseTask::class);
+    }
+
+    /** @return HasMany<CaseAppointment, $this> */
+    public function appointments(): HasMany
+    {
+        return $this->hasMany(CaseAppointment::class);
+    }
+
+    /** @return HasMany<CaseInteraction, $this> */
+    public function interactions(): HasMany
+    {
+        return $this->hasMany(CaseInteraction::class);
+    }
+
+    /** @return HasMany<CaseNote, $this> */
+    public function notes(): HasMany
+    {
+        return $this->hasMany(CaseNote::class);
+    }
+
+    /** @return HasOne<CaseOutcome, $this> */
+    public function outcome(): HasOne
+    {
+        return $this->hasOne(CaseOutcome::class);
+    }
+
+    /** @return HasMany<CaseWorkflowTransition, $this> */
+    public function workflowTransitions(): HasMany
+    {
+        return $this->hasMany(CaseWorkflowTransition::class);
+    }
+
     protected function casts(): array
     {
-        return ['status' => ServiceCaseStatus::class, 'opened_at' => 'datetime'];
+        return [
+            'status' => ServiceCaseStatus::class,
+            'opened_at' => 'datetime',
+            'closed_at' => 'datetime',
+            'follow_up_at' => 'datetime',
+            'closure_checklist' => 'array',
+        ];
     }
 }

--- a/app/Models/WorkflowCorrection.php
+++ b/app/Models/WorkflowCorrection.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\CaseWorkflowSubject;
+use Database\Factories\WorkflowCorrectionFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $service_case_id
+ * @property CaseWorkflowSubject $subject_type
+ * @property string $subject_id
+ * @property string $correction_type
+ * @property string $reason
+ * @property array<string, bool|int|float|string|null>|null $replacement_values
+ * @property Carbon $effective_at
+ * @property Carbon $recorded_at
+ * @property-read ServiceCase $serviceCase
+ */
+class WorkflowCorrection extends Model
+{
+    /** @use HasFactory<WorkflowCorrectionFactory> */
+    use BelongsToOrganisation, HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Workflow corrections are append-only.'));
+        static::deleting(fn () => throw new LogicException('Workflow corrections are append-only.'));
+    }
+
+    /** @return BelongsTo<ServiceCase, $this> */
+    public function serviceCase(): BelongsTo
+    {
+        return $this->belongsTo(ServiceCase::class);
+    }
+
+    protected function casts(): array
+    {
+        return ['subject_type' => CaseWorkflowSubject::class, 'replacement_values' => 'array', 'effective_at' => 'datetime', 'recorded_at' => 'datetime'];
+    }
+}

--- a/app/Policies/ServiceCasePolicy.php
+++ b/app/Policies/ServiceCasePolicy.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\OrganisationRole;
+use App\Models\ServiceCase;
+use App\Models\User;
+
+class ServiceCasePolicy
+{
+    public function view(User $user, ServiceCase $case): bool
+    {
+        if ($this->managesProgram($user, $case)) {
+            return true;
+        }
+
+        $membership = $user->organisationMembership($case->organisation);
+
+        return $membership !== null
+            && ! $membership->isHeld()
+            && $user->hasOrganisationRole($case->organisation, OrganisationRole::CaseWorker, $case->program)
+            && $user->hasProgramAccess($case->program)
+            && $case->assignments()->where('membership_id', $membership->id)->where('status', 'active')->exists();
+    }
+
+    public function update(User $user, ServiceCase $case): bool
+    {
+        return $this->view($user, $case) && ! $case->status->isTerminal();
+    }
+
+    private function managesProgram(User $user, ServiceCase $case): bool
+    {
+        return $user->hasOrganisationRole($case->organisation, OrganisationRole::ProgramManager, $case->program)
+            && $user->hasProgramAccess($case->program);
+    }
+}

--- a/database/factories/CaseAppointmentFactory.php
+++ b/database/factories/CaseAppointmentFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseAppointmentStatus;
+use App\Models\CaseAppointment;
+use App\Models\ServiceCase;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<CaseAppointment> */
+class CaseAppointmentFactory extends Factory
+{
+    public function definition(): array
+    {
+        return ['id' => Str::uuid()->toString(), 'organisation_id' => app(OrganisationContext::class)->id(), 'service_case_id' => ServiceCase::factory(), 'type' => 'content', 'encrypted_content' => new ClassifiedValue(json_encode(['summary' => fake()->sentence(), 'location' => fake()->streetAddress()], JSON_THROW_ON_ERROR)), 'data_key_version' => app(ClassifiedDataEncrypter::class)->currentVersion(), 'status' => CaseAppointmentStatus::Scheduled, 'version' => 1, 'scheduled_at' => now()->addWeek()];
+    }
+}

--- a/database/factories/CaseGoalFactory.php
+++ b/database/factories/CaseGoalFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseGoalStatus;
+use App\Models\CaseGoal;
+use App\Models\ServiceCase;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<CaseGoal> */
+class CaseGoalFactory extends Factory
+{
+    public function definition(): array
+    {
+        return ['id' => Str::uuid()->toString(), 'organisation_id' => app(OrganisationContext::class)->id(), 'service_case_id' => ServiceCase::factory(), 'type' => 'content', 'encrypted_content' => new ClassifiedValue(json_encode(['title' => fake()->sentence(), 'description' => fake()->paragraph()], JSON_THROW_ON_ERROR)), 'data_key_version' => app(ClassifiedDataEncrypter::class)->currentVersion(), 'status' => CaseGoalStatus::Draft, 'version' => 1, 'target_at' => now()->addMonth()];
+    }
+}

--- a/database/factories/CaseInteractionFactory.php
+++ b/database/factories/CaseInteractionFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Models\CaseInteraction;
+use App\Models\ServiceCase;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<CaseInteraction> */
+class CaseInteractionFactory extends Factory
+{
+    public function definition(): array
+    {
+        return ['id' => Str::uuid()->toString(), 'organisation_id' => app(OrganisationContext::class)->id(), 'service_case_id' => ServiceCase::factory(), 'interaction_type' => 'telephone', 'type' => 'content', 'encrypted_content' => new ClassifiedValue(json_encode(['summary' => fake()->sentence()], JSON_THROW_ON_ERROR)), 'data_key_version' => app(ClassifiedDataEncrypter::class)->currentVersion(), 'occurred_at' => now(), 'recorded_at' => now()];
+    }
+}

--- a/database/factories/CaseNoteFactory.php
+++ b/database/factories/CaseNoteFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseNoteStatus;
+use App\Models\CaseNote;
+use App\Models\ServiceCase;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<CaseNote> */
+class CaseNoteFactory extends Factory
+{
+    public function definition(): array
+    {
+        return ['id' => Str::uuid()->toString(), 'organisation_id' => app(OrganisationContext::class)->id(), 'service_case_id' => ServiceCase::factory(), 'type' => 'content', 'encrypted_content' => new ClassifiedValue(fake()->paragraph()), 'data_key_version' => app(ClassifiedDataEncrypter::class)->currentVersion(), 'status' => CaseNoteStatus::Draft, 'version' => 1];
+    }
+}

--- a/database/factories/CaseOutcomeFactory.php
+++ b/database/factories/CaseOutcomeFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Models\CaseOutcome;
+use App\Models\ServiceCase;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<CaseOutcome> */
+class CaseOutcomeFactory extends Factory
+{
+    public function definition(): array
+    {
+        return ['id' => Str::uuid()->toString(), 'organisation_id' => app(OrganisationContext::class)->id(), 'service_case_id' => ServiceCase::factory(), 'measures' => ['progress' => 3], 'type' => 'content', 'encrypted_content' => new ClassifiedValue(fake()->paragraph()), 'data_key_version' => app(ClassifiedDataEncrypter::class)->currentVersion(), 'effective_at' => now(), 'recorded_at' => now()];
+    }
+}

--- a/database/factories/CaseServiceFactory.php
+++ b/database/factories/CaseServiceFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseServiceStatus;
+use App\Models\CaseService;
+use App\Models\ServiceCase;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<CaseService> */
+class CaseServiceFactory extends Factory
+{
+    public function definition(): array
+    {
+        return ['id' => Str::uuid()->toString(), 'organisation_id' => app(OrganisationContext::class)->id(), 'service_case_id' => ServiceCase::factory(), 'type' => 'content', 'encrypted_content' => new ClassifiedValue(json_encode(['summary' => fake()->sentence()], JSON_THROW_ON_ERROR)), 'data_key_version' => app(ClassifiedDataEncrypter::class)->currentVersion(), 'service_code' => 'support_session', 'status' => CaseServiceStatus::Planned, 'version' => 1];
+    }
+}

--- a/database/factories/CaseTaskFactory.php
+++ b/database/factories/CaseTaskFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseTaskStatus;
+use App\Models\CaseTask;
+use App\Models\ServiceCase;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<CaseTask> */
+class CaseTaskFactory extends Factory
+{
+    public function definition(): array
+    {
+        return ['id' => Str::uuid()->toString(), 'organisation_id' => app(OrganisationContext::class)->id(), 'service_case_id' => ServiceCase::factory(), 'type' => 'content', 'encrypted_content' => new ClassifiedValue(json_encode(['title' => fake()->sentence(), 'details' => fake()->paragraph()], JSON_THROW_ON_ERROR)), 'data_key_version' => app(ClassifiedDataEncrypter::class)->currentVersion(), 'status' => CaseTaskStatus::Open, 'version' => 1, 'due_at' => now()->addWeek()];
+    }
+}

--- a/database/factories/CaseWorkflowTransitionFactory.php
+++ b/database/factories/CaseWorkflowTransitionFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\CaseWorkflowSubject;
+use App\Models\CaseWorkflowTransition;
+use App\Models\ServiceCase;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<CaseWorkflowTransition> */
+class CaseWorkflowTransitionFactory extends Factory
+{
+    public function definition(): array
+    {
+        return ['organisation_id' => app(OrganisationContext::class)->id(), 'service_case_id' => ServiceCase::factory(), 'subject_type' => CaseWorkflowSubject::Goal, 'subject_id' => Str::uuid()->toString(), 'from_status' => 'draft', 'to_status' => 'active', 'effective_at' => now(), 'recorded_at' => now(), 'version' => 2];
+    }
+}

--- a/database/factories/ExternalReferralFactory.php
+++ b/database/factories/ExternalReferralFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\ExternalReferralStatus;
+use App\Models\ExternalReferral;
+use App\Models\ServiceCase;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<ExternalReferral> */
+class ExternalReferralFactory extends Factory
+{
+    public function definition(): array
+    {
+        return ['id' => Str::uuid()->toString(), 'organisation_id' => app(OrganisationContext::class)->id(), 'service_case_id' => ServiceCase::factory(), 'type' => 'content', 'encrypted_content' => new ClassifiedValue(json_encode(['destination' => fake()->company(), 'purpose' => fake()->sentence(), 'minimum_necessary' => fake()->sentence()], JSON_THROW_ON_ERROR)), 'data_key_version' => app(ClassifiedDataEncrypter::class)->currentVersion(), 'status' => ExternalReferralStatus::Draft, 'sharing_authority' => 'service_consent', 'version' => 1];
+    }
+}

--- a/database/factories/IntakeRequestFactory.php
+++ b/database/factories/IntakeRequestFactory.php
@@ -12,6 +12,7 @@ use App\Models\Party;
 use App\Models\Program;
 use App\OrganisationContext;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 
 /**
  * @extends Factory<IntakeRequest>
@@ -26,6 +27,7 @@ class IntakeRequestFactory extends Factory
     public function definition(): array
     {
         return [
+            'id' => Str::uuid()->toString(),
             'organisation_id' => app(OrganisationContext::class)->id(),
             'program_id' => Program::factory()->state(['organisation_id' => app(OrganisationContext::class)->id()]),
             'party_id' => Party::factory()->state(['organisation_id' => app(OrganisationContext::class)->id()]),

--- a/database/factories/MetricEventFactory.php
+++ b/database/factories/MetricEventFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\CaseMetricCode;
+use App\Models\MetricEvent;
+use App\Models\Program;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<MetricEvent> */
+class MetricEventFactory extends Factory
+{
+    public function definition(): array
+    {
+        return ['organisation_id' => app(OrganisationContext::class)->id(), 'program_id' => Program::factory()->state(['organisation_id' => app(OrganisationContext::class)->id()]), 'code' => CaseMetricCode::ServiceDelivered, 'value' => 1, 'dimensions' => [], 'deduplication_key' => hash('sha256', Str::uuid()->toString()), 'occurred_at' => now(), 'recorded_at' => now()];
+    }
+}

--- a/database/factories/WorkflowCorrectionFactory.php
+++ b/database/factories/WorkflowCorrectionFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\CaseWorkflowSubject;
+use App\Models\ServiceCase;
+use App\Models\WorkflowCorrection;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/** @extends Factory<WorkflowCorrection> */
+class WorkflowCorrectionFactory extends Factory
+{
+    public function definition(): array
+    {
+        return ['organisation_id' => app(OrganisationContext::class)->id(), 'service_case_id' => ServiceCase::factory(), 'subject_type' => CaseWorkflowSubject::Service, 'subject_id' => Str::uuid()->toString(), 'correction_type' => 'correction', 'reason' => 'data_entry_error', 'replacement_values' => ['effective_at' => now()->toAtomString()], 'effective_at' => now(), 'recorded_at' => now()];
+    }
+}

--- a/database/migrations/2026_08_31_061042_create_case_delivery_tables.php
+++ b/database/migrations/2026_08_31_061042_create_case_delivery_tables.php
@@ -1,0 +1,251 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('service_cases', function (Blueprint $table) {
+            $table->timestamp('closed_at')->nullable();
+            $table->string('closure_reason', 64)->nullable();
+            $table->timestamp('follow_up_at')->nullable();
+            $table->json('closure_checklist')->nullable();
+        });
+
+        Schema::create('case_goals', function (Blueprint $table) {
+            $this->caseRecord($table);
+            $table->string('status', 32)->default('draft');
+            $table->timestamp('target_at')->nullable();
+            $table->timestamp('effective_at')->nullable();
+            $table->string('terminal_reason', 64)->nullable();
+            $this->caseRecordIndexes($table, 'case_goals');
+        });
+
+        Schema::create('case_services', function (Blueprint $table) {
+            $this->caseRecord($table);
+            $table->string('service_code', 64);
+            $table->string('status', 32)->default('planned');
+            $table->timestamp('scheduled_for')->nullable();
+            $table->timestamp('delivered_at')->nullable();
+            $table->string('terminal_reason', 64)->nullable();
+            $this->caseRecordIndexes($table, 'case_services');
+        });
+
+        Schema::create('external_referrals', function (Blueprint $table) {
+            $this->caseRecord($table);
+            $table->string('status', 32)->default('draft');
+            $table->string('sharing_authority', 64);
+            $table->timestamp('sent_at')->nullable();
+            $table->timestamp('effective_at')->nullable();
+            $table->string('terminal_reason', 64)->nullable();
+            $table->timestamp('carried_forward_at')->nullable();
+            $table->string('carry_forward_reason', 64)->nullable();
+            $this->caseRecordIndexes($table, 'external_referrals');
+        });
+
+        Schema::create('case_tasks', function (Blueprint $table) {
+            $this->caseRecord($table);
+            $table->string('status', 32)->default('open');
+            $table->timestamp('due_at')->nullable();
+            $table->timestamp('effective_at')->nullable();
+            $table->string('terminal_reason', 64)->nullable();
+            $this->caseRecordIndexes($table, 'case_tasks');
+        });
+
+        Schema::create('case_appointments', function (Blueprint $table) {
+            $this->caseRecord($table);
+            $table->string('status', 32)->default('scheduled');
+            $table->timestamp('scheduled_at');
+            $table->timestamp('effective_at')->nullable();
+            $table->string('terminal_reason', 64)->nullable();
+            $table->uuid('completed_service_id')->nullable();
+            $this->caseRecordIndexes($table, 'case_appointments');
+            $table->foreign(['organisation_id', 'completed_service_id'])
+                ->references(['organisation_id', 'id'])->on('case_services')->restrictOnDelete();
+        });
+
+        Schema::create('case_interactions', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->uuid('service_case_id');
+            $table->string('interaction_type', 64);
+            $table->string('type', 32)->default('content');
+            $table->text('encrypted_content');
+            $table->string('data_key_version', 64);
+            $table->timestamp('occurred_at');
+            $table->timestamp('recorded_at');
+            $table->foreignId('recorded_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->unique(['organisation_id', 'id']);
+            $table->foreign(['organisation_id', 'service_case_id'])
+                ->references(['organisation_id', 'id'])->on('service_cases')->cascadeOnDelete();
+            $table->index(['organisation_id', 'service_case_id', 'occurred_at']);
+        });
+
+        Schema::create('case_notes', function (Blueprint $table) {
+            $this->caseRecord($table);
+            $table->string('status', 32)->default('draft');
+            $table->uuid('corrects_note_id')->nullable();
+            $table->timestamp('finalized_at')->nullable();
+            $table->foreignId('authored_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $this->caseRecordIndexes($table, 'case_notes');
+            $table->foreign(['organisation_id', 'corrects_note_id'])
+                ->references(['organisation_id', 'id'])->on('case_notes')->restrictOnDelete();
+        });
+
+        Schema::create('case_outcomes', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->uuid('service_case_id');
+            $table->json('measures');
+            $table->string('type', 32)->default('content');
+            $table->text('encrypted_content');
+            $table->string('data_key_version', 64);
+            $table->timestamp('effective_at');
+            $table->timestamp('recorded_at');
+            $table->foreignId('recorded_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'service_case_id']);
+            $table->foreign(['organisation_id', 'service_case_id'])
+                ->references(['organisation_id', 'id'])->on('service_cases')->cascadeOnDelete();
+        });
+
+        Schema::create('case_workflow_transitions', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->uuid('service_case_id');
+            $table->string('subject_type', 32);
+            $table->uuid('subject_id');
+            $table->string('from_status', 32)->nullable();
+            $table->string('to_status', 32);
+            $table->string('reason', 64)->nullable();
+            $table->timestamp('effective_at');
+            $table->timestamp('recorded_at');
+            $table->unsignedInteger('version');
+            $table->foreignId('actor_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreign(['organisation_id', 'service_case_id'])
+                ->references(['organisation_id', 'id'])->on('service_cases')->cascadeOnDelete();
+            $table->unique(['organisation_id', 'subject_type', 'subject_id', 'version'], 'case_workflow_transition_version_unique');
+            $table->index(['organisation_id', 'service_case_id', 'recorded_at']);
+        });
+
+        Schema::create('workflow_corrections', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->uuid('service_case_id');
+            $table->string('subject_type', 32);
+            $table->uuid('subject_id');
+            $table->string('correction_type', 32);
+            $table->string('reason', 64);
+            $table->json('replacement_values')->nullable();
+            $table->timestamp('effective_at');
+            $table->timestamp('recorded_at');
+            $table->foreignId('actor_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreign(['organisation_id', 'service_case_id'])
+                ->references(['organisation_id', 'id'])->on('service_cases')->cascadeOnDelete();
+            $table->index(['organisation_id', 'subject_type', 'subject_id']);
+        });
+
+        Schema::create('metric_events', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('program_id');
+            $table->string('code', 64);
+            $table->decimal('value', 14, 4)->default(1);
+            $table->json('dimensions')->default('{}');
+            $table->string('deduplication_key', 64);
+            $table->timestamp('occurred_at');
+            $table->timestamp('recorded_at');
+            $table->foreign(['organisation_id', 'program_id'])
+                ->references(['organisation_id', 'id'])->on('programs')->restrictOnDelete();
+            $table->unique(['organisation_id', 'deduplication_key']);
+            $table->index(['organisation_id', 'program_id', 'code', 'occurred_at']);
+        });
+
+        $this->guardAppendOnlyTables();
+    }
+
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::unprepared('DROP FUNCTION IF EXISTS guard_case_delivery_history() CASCADE');
+        }
+
+        Schema::dropIfExists('metric_events');
+        Schema::dropIfExists('workflow_corrections');
+        Schema::dropIfExists('case_workflow_transitions');
+        Schema::dropIfExists('case_outcomes');
+        Schema::dropIfExists('case_notes');
+        Schema::dropIfExists('case_interactions');
+        Schema::dropIfExists('case_appointments');
+        Schema::dropIfExists('case_tasks');
+        Schema::dropIfExists('external_referrals');
+        Schema::dropIfExists('case_services');
+        Schema::dropIfExists('case_goals');
+
+        Schema::table('service_cases', function (Blueprint $table) {
+            $table->dropColumn(['closed_at', 'closure_reason', 'follow_up_at', 'closure_checklist']);
+        });
+    }
+
+    private function caseRecord(Blueprint $table): void
+    {
+        $table->uuid('id')->primary();
+        $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+        $table->uuid('service_case_id');
+        $table->string('type', 32)->default('content');
+        $table->text('encrypted_content');
+        $table->string('data_key_version', 64);
+        $table->unsignedInteger('version')->default(1);
+        $table->foreignId('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+        $table->timestamps();
+    }
+
+    private function caseRecordIndexes(Blueprint $table, string $tableName): void
+    {
+        $table->unique(['organisation_id', 'id']);
+        $table->foreign(['organisation_id', 'service_case_id'], "{$tableName}_organisation_case_foreign")
+            ->references(['organisation_id', 'id'])->on('service_cases')->cascadeOnDelete();
+        $table->index(['organisation_id', 'service_case_id', 'status']);
+    }
+
+    private function guardAppendOnlyTables(): void
+    {
+        $tables = ['case_workflow_transitions', 'workflow_corrections', 'metric_events', 'case_interactions', 'case_outcomes'];
+
+        if (DB::getDriverName() === 'sqlite') {
+            foreach ($tables as $table) {
+                DB::unprepared("CREATE TRIGGER {$table}_append_only_update BEFORE UPDATE ON {$table} BEGIN SELECT RAISE(ABORT, 'Case delivery history is append-only.'); END");
+                DB::unprepared("CREATE TRIGGER {$table}_append_only_delete BEFORE DELETE ON {$table} BEGIN SELECT RAISE(ABORT, 'Case delivery history is append-only.'); END");
+            }
+
+            return;
+        }
+
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        DB::unprepared(<<<'SQL'
+            CREATE OR REPLACE FUNCTION guard_case_delivery_history() RETURNS trigger AS $$
+            BEGIN
+                RAISE EXCEPTION 'Case delivery history is append-only.';
+            END;
+            $$ LANGUAGE plpgsql;
+
+            CREATE TRIGGER case_workflow_transitions_append_only BEFORE UPDATE OR DELETE ON case_workflow_transitions
+                FOR EACH ROW EXECUTE FUNCTION guard_case_delivery_history();
+            CREATE TRIGGER workflow_corrections_append_only BEFORE UPDATE OR DELETE ON workflow_corrections
+                FOR EACH ROW EXECUTE FUNCTION guard_case_delivery_history();
+            CREATE TRIGGER metric_events_append_only BEFORE UPDATE OR DELETE ON metric_events
+                FOR EACH ROW EXECUTE FUNCTION guard_case_delivery_history();
+            CREATE TRIGGER case_interactions_append_only BEFORE UPDATE OR DELETE ON case_interactions
+                FOR EACH ROW EXECUTE FUNCTION guard_case_delivery_history();
+            CREATE TRIGGER case_outcomes_append_only BEFORE UPDATE OR DELETE ON case_outcomes
+                FOR EACH ROW EXECUTE FUNCTION guard_case_delivery_history();
+            SQL);
+    }
+};

--- a/resources/js/pages/cases/show.tsx
+++ b/resources/js/pages/cases/show.tsx
@@ -1,0 +1,750 @@
+import { Form, Head, Link, usePage } from '@inertiajs/react';
+import { useState } from 'react';
+import Heading from '@/components/heading';
+import InputError from '@/components/input-error';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { show as showIntake } from '@/routes/intakes';
+import { store as storeItem } from '@/routes/cases/items';
+import { store as transitionItem } from '@/routes/cases/items/transitions';
+import { store as transitionCase } from '@/routes/cases/transitions';
+
+const nextStates: Record<string, Record<string, string[]>> = {
+    goal: {
+        draft: ['active', 'cancelled'],
+        active: ['achieved', 'not_achieved', 'cancelled', 'withdrawn'],
+    },
+    service: {
+        planned: ['scheduled', 'completed', 'cancelled'],
+        scheduled: ['completed', 'cancelled', 'not_delivered'],
+    },
+    referral: {
+        draft: ['sent', 'cancelled'],
+        sent: [
+            'acknowledged',
+            'connected',
+            'not_connected',
+            'cancelled',
+            'carry_forward',
+        ],
+        acknowledged: [
+            'connected',
+            'not_connected',
+            'cancelled',
+            'carry_forward',
+        ],
+    },
+    task: { open: ['completed', 'cancelled'] },
+    appointment: { scheduled: ['completed', 'cancelled', 'no_show'] },
+    note: { draft: ['finalized'] },
+};
+
+const reasonCodes = [
+    'achieved',
+    'not_achieved',
+    'withdrawn',
+    'no_longer_needed',
+    'client_cancelled',
+    'provider_cancelled',
+    'not_available',
+    'unable_to_connect',
+    'no_show',
+    'completed_elsewhere',
+    'follow_up_in_new_case',
+    'stable_tenancy',
+];
+
+function whenNow() {
+    return new Date().toISOString().slice(0, 16);
+}
+
+function ItemCard({ type, item, args, services, canUpdate }: any) {
+    const options = nextStates[type]?.[item.status] ?? [];
+
+    return (
+        <div className="space-y-3 rounded-lg border p-4">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+                <div>
+                    <strong>
+                        {item.content.title ??
+                            item.content.summary ??
+                            item.content.destination ??
+                            item.content}
+                    </strong>
+                    {(item.content.description ?? item.content.purpose) ? (
+                        <p className="text-muted-foreground mt-1 text-sm">
+                            {item.content.description ?? item.content.purpose}
+                        </p>
+                    ) : null}
+                </div>
+                <Badge variant="outline">
+                    {item.status.replaceAll('_', ' ')}
+                </Badge>
+            </div>
+            {item.dueAt ? (
+                <p
+                    className={
+                        item.overdue
+                            ? 'text-destructive text-sm'
+                            : 'text-muted-foreground text-sm'
+                    }
+                >
+                    Due {new Date(item.dueAt).toLocaleString()}
+                    {item.overdue ? ' · overdue' : ''}
+                </p>
+            ) : null}
+            {item.reason ? (
+                <p className="text-muted-foreground text-sm">
+                    Reason: {item.reason}
+                </p>
+            ) : null}
+            {canUpdate && options.length > 0 ? (
+                <Form
+                    action={transitionItem.url([
+                        args[0],
+                        args[1],
+                        type,
+                        item.id,
+                    ])}
+                    method="post"
+                    className="grid gap-2 sm:grid-cols-4"
+                >
+                    {({ errors, processing }) => (
+                        <>
+                            <input
+                                type="hidden"
+                                name="expected_version"
+                                value={item.version}
+                            />
+                            <Input
+                                type="datetime-local"
+                                name="effective_at"
+                                defaultValue={whenNow()}
+                                required
+                            />
+                            <select
+                                name="status"
+                                className="h-9 rounded-md border bg-transparent px-3"
+                                required
+                            >
+                                {options.map((status: string) => (
+                                    <option key={status} value={status}>
+                                        {status.replaceAll('_', ' ')}
+                                    </option>
+                                ))}
+                            </select>
+                            <select
+                                name="reason"
+                                className="h-9 rounded-md border bg-transparent px-3"
+                            >
+                                <option value="">No reason</option>
+                                {reasonCodes.map((reason) => (
+                                    <option key={reason} value={reason}>
+                                        {reason.replaceAll('_', ' ')}
+                                    </option>
+                                ))}
+                            </select>
+                            {type === 'appointment' ? (
+                                <select
+                                    name="completed_service_id"
+                                    className="h-9 rounded-md border bg-transparent px-3"
+                                >
+                                    <option value="">No linked service</option>
+                                    {services
+                                        .filter(
+                                            (service: any) =>
+                                                service.status === 'completed',
+                                        )
+                                        .map((service: any) => (
+                                            <option
+                                                key={service.id}
+                                                value={service.id}
+                                            >
+                                                {service.serviceCode}
+                                            </option>
+                                        ))}
+                                </select>
+                            ) : null}
+                            <Button disabled={processing}>
+                                Apply transition
+                            </Button>
+                            <InputError
+                                className="sm:col-span-4"
+                                message={errors.status}
+                            />
+                        </>
+                    )}
+                </Form>
+            ) : null}
+        </div>
+    );
+}
+
+export default function CaseShow({ caseRecord, canUpdate }: any) {
+    const organisation = usePage().props.currentOrganisation!;
+    const args = [organisation.slug, caseRecord.id] as [string, string];
+    const [kind, setKind] = useState('goal');
+    const caseTransitions: Record<string, string[]> = {
+        open: ['active', 'on_hold', 'closed', 'cancelled'],
+        active: ['on_hold', 'closed'],
+        on_hold: ['active', 'closed'],
+    };
+    const availableCaseTransitions = caseTransitions[caseRecord.status] ?? [];
+    const [caseStatus, setCaseStatus] = useState(
+        availableCaseTransitions[0] ?? '',
+    );
+
+    return (
+        <>
+            <Head title={`${caseRecord.party.displayName} case`} />
+            <div className="space-y-8 p-4">
+                <div>
+                    <Link
+                        className="text-muted-foreground text-sm"
+                        href={showIntake.url([
+                            organisation.slug,
+                            caseRecord.intakeId,
+                        ])}
+                    >
+                        ← Service request
+                    </Link>
+                    <Heading
+                        title={caseRecord.party.displayName}
+                        description={caseRecord.program.name}
+                    />
+                    <div className="flex flex-wrap gap-2">
+                        <Badge>{caseRecord.status.replaceAll('_', ' ')}</Badge>
+                        <Badge variant="outline">
+                            {caseRecord.confidentiality}
+                        </Badge>
+                        {caseRecord.assignments
+                            .filter((item: any) => item.status === 'active')
+                            .map((item: any) => (
+                                <Badge key={item.id} variant="secondary">
+                                    {item.worker}
+                                </Badge>
+                            ))}
+                    </div>
+                </div>
+
+                {canUpdate ? (
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Record case activity</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <Form
+                                action={storeItem.url(args)}
+                                method="post"
+                                className="grid gap-4 md:grid-cols-2"
+                            >
+                                {({ errors, processing }) => (
+                                    <>
+                                        <div className="space-y-2 md:col-span-2">
+                                            <Label htmlFor="kind">
+                                                Record type
+                                            </Label>
+                                            <select
+                                                id="kind"
+                                                name="kind"
+                                                value={kind}
+                                                onChange={(event) =>
+                                                    setKind(event.target.value)
+                                                }
+                                                className="h-9 w-full rounded-md border bg-transparent px-3"
+                                            >
+                                                {[
+                                                    'goal',
+                                                    'service',
+                                                    'referral',
+                                                    'task',
+                                                    'appointment',
+                                                    'interaction',
+                                                    'note',
+                                                ].map((value) => (
+                                                    <option
+                                                        key={value}
+                                                        value={value}
+                                                    >
+                                                        {value}
+                                                    </option>
+                                                ))}
+                                            </select>
+                                        </div>
+                                        {['goal', 'task'].includes(kind) ? (
+                                            <>
+                                                <div className="space-y-2">
+                                                    <Label>Title</Label>
+                                                    <Input
+                                                        name="title"
+                                                        required
+                                                    />
+                                                </div>
+                                                <div className="space-y-2">
+                                                    <Label>
+                                                        {kind === 'goal'
+                                                            ? 'Target date'
+                                                            : 'Due date'}
+                                                    </Label>
+                                                    <Input
+                                                        type="datetime-local"
+                                                        name={
+                                                            kind === 'goal'
+                                                                ? 'target_at'
+                                                                : 'due_at'
+                                                        }
+                                                    />
+                                                </div>
+                                                <div className="space-y-2 md:col-span-2">
+                                                    <Label>Details</Label>
+                                                    <Textarea
+                                                        name="description"
+                                                        required
+                                                    />
+                                                </div>
+                                            </>
+                                        ) : null}
+                                        {kind === 'service' ? (
+                                            <>
+                                                <div className="space-y-2">
+                                                    <Label>Service code</Label>
+                                                    <Input
+                                                        name="service_code"
+                                                        placeholder="housing_advice"
+                                                        required
+                                                    />
+                                                </div>
+                                                <div className="space-y-2">
+                                                    <Label>Scheduled for</Label>
+                                                    <Input
+                                                        type="datetime-local"
+                                                        name="scheduled_for"
+                                                    />
+                                                </div>
+                                                <div className="space-y-2 md:col-span-2">
+                                                    <Label>Summary</Label>
+                                                    <Textarea
+                                                        name="summary"
+                                                        required
+                                                    />
+                                                </div>
+                                            </>
+                                        ) : null}
+                                        {kind === 'referral' ? (
+                                            <>
+                                                <div className="space-y-2">
+                                                    <Label>Destination</Label>
+                                                    <Input
+                                                        name="destination"
+                                                        required
+                                                    />
+                                                </div>
+                                                <div className="space-y-2">
+                                                    <Label>
+                                                        Sharing authority
+                                                    </Label>
+                                                    <Input
+                                                        name="sharing_authority"
+                                                        value="service_consent"
+                                                        readOnly
+                                                    />
+                                                </div>
+                                                <div className="space-y-2">
+                                                    <Label>Purpose</Label>
+                                                    <Textarea
+                                                        name="purpose"
+                                                        required
+                                                    />
+                                                </div>
+                                                <div className="space-y-2">
+                                                    <Label>
+                                                        Minimum necessary
+                                                        information
+                                                    </Label>
+                                                    <Textarea
+                                                        name="minimum_necessary"
+                                                        required
+                                                    />
+                                                </div>
+                                            </>
+                                        ) : null}
+                                        {kind === 'appointment' ? (
+                                            <>
+                                                <div className="space-y-2">
+                                                    <Label>Scheduled at</Label>
+                                                    <Input
+                                                        type="datetime-local"
+                                                        name="scheduled_at"
+                                                        required
+                                                    />
+                                                </div>
+                                                <div className="space-y-2">
+                                                    <Label>Location</Label>
+                                                    <Input
+                                                        name="location"
+                                                        required
+                                                    />
+                                                </div>
+                                                <div className="space-y-2 md:col-span-2">
+                                                    <Label>Summary</Label>
+                                                    <Textarea
+                                                        name="summary"
+                                                        required
+                                                    />
+                                                </div>
+                                            </>
+                                        ) : null}
+                                        {kind === 'interaction' ? (
+                                            <>
+                                                <div className="space-y-2">
+                                                    <Label>Occurred at</Label>
+                                                    <Input
+                                                        type="datetime-local"
+                                                        name="occurred_at"
+                                                        defaultValue={whenNow()}
+                                                        required
+                                                    />
+                                                </div>
+                                                <div className="space-y-2">
+                                                    <Label>Type</Label>
+                                                    <select
+                                                        name="interaction_type"
+                                                        className="h-9 w-full rounded-md border bg-transparent px-3"
+                                                    >
+                                                        <option value="in_person">
+                                                            In person
+                                                        </option>
+                                                        <option value="telephone">
+                                                            Telephone
+                                                        </option>
+                                                        <option value="email">
+                                                            Email
+                                                        </option>
+                                                        <option value="video">
+                                                            Video
+                                                        </option>
+                                                        <option value="other">
+                                                            Other
+                                                        </option>
+                                                    </select>
+                                                </div>
+                                                <div className="space-y-2 md:col-span-2">
+                                                    <Label>Summary</Label>
+                                                    <Textarea
+                                                        name="summary"
+                                                        required
+                                                    />
+                                                </div>
+                                            </>
+                                        ) : null}
+                                        {kind === 'note' ? (
+                                            <div className="space-y-2 md:col-span-2">
+                                                <Label>Confidential note</Label>
+                                                <Textarea
+                                                    name="content"
+                                                    required
+                                                />
+                                                <select
+                                                    name="corrects_note_id"
+                                                    className="h-9 w-full rounded-md border bg-transparent px-3"
+                                                >
+                                                    <option value="">
+                                                        New note
+                                                    </option>
+                                                    {caseRecord.notes
+                                                        .filter(
+                                                            (note: any) =>
+                                                                note.status ===
+                                                                'finalized',
+                                                        )
+                                                        .map((note: any) => (
+                                                            <option
+                                                                key={note.id}
+                                                                value={note.id}
+                                                            >
+                                                                Correction/addendum
+                                                                to{' '}
+                                                                {note.id.slice(
+                                                                    0,
+                                                                    8,
+                                                                )}
+                                                            </option>
+                                                        ))}
+                                                </select>
+                                            </div>
+                                        ) : null}
+                                        <InputError
+                                            className="md:col-span-2"
+                                            message={errors.item}
+                                        />
+                                        <Button
+                                            className="md:col-span-2"
+                                            disabled={processing}
+                                        >
+                                            Add {kind}
+                                        </Button>
+                                    </>
+                                )}
+                            </Form>
+                        </CardContent>
+                    </Card>
+                ) : null}
+
+                <div className="grid gap-6 xl:grid-cols-2">
+                    {[
+                        ['Goals', 'goal', caseRecord.goals],
+                        ['Services', 'service', caseRecord.services],
+                        [
+                            'External referrals',
+                            'referral',
+                            caseRecord.referrals,
+                        ],
+                        ['Tasks', 'task', caseRecord.tasks],
+                        [
+                            'Appointments',
+                            'appointment',
+                            caseRecord.appointments,
+                        ],
+                        [
+                            'Case notes',
+                            'note',
+                            caseRecord.notes.map((note: any) => ({
+                                ...note,
+                                content: { title: note.content },
+                            })),
+                        ],
+                    ].map(([title, type, items]: any) => (
+                        <Card key={type}>
+                            <CardHeader>
+                                <CardTitle>{title}</CardTitle>
+                            </CardHeader>
+                            <CardContent className="space-y-3">
+                                {items.map((item: any) => (
+                                    <ItemCard
+                                        key={item.id}
+                                        type={type}
+                                        item={item}
+                                        args={args}
+                                        services={caseRecord.services}
+                                        canUpdate={canUpdate}
+                                    />
+                                ))}
+                                {items.length === 0 ? (
+                                    <p className="text-muted-foreground text-sm">
+                                        Nothing recorded.
+                                    </p>
+                                ) : null}
+                            </CardContent>
+                        </Card>
+                    ))}
+                </div>
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Interactions</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-3">
+                        {caseRecord.interactions.map((item: any) => (
+                            <div
+                                key={item.id}
+                                className="rounded-lg border p-3 text-sm"
+                            >
+                                <strong>
+                                    {item.type.replaceAll('_', ' ')}
+                                </strong>{' '}
+                                · {new Date(item.occurredAt).toLocaleString()}
+                                <p className="text-muted-foreground mt-1">
+                                    {item.content.summary}
+                                </p>
+                            </div>
+                        ))}
+                        {caseRecord.interactions.length === 0 ? (
+                            <p className="text-muted-foreground text-sm">
+                                No interactions recorded.
+                            </p>
+                        ) : null}
+                    </CardContent>
+                </Card>
+
+                {canUpdate && availableCaseTransitions.length > 0 ? (
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Case state and closure</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <Form
+                                action={transitionCase.url(args)}
+                                method="post"
+                                className="grid gap-4 md:grid-cols-2"
+                            >
+                                {({ errors, processing }) => (
+                                    <>
+                                        <input
+                                            type="hidden"
+                                            name="expected_version"
+                                            value={caseRecord.version}
+                                        />
+                                        <div className="space-y-2">
+                                            <Label>Next status</Label>
+                                            <select
+                                                name="status"
+                                                value={caseStatus}
+                                                onChange={(event) =>
+                                                    setCaseStatus(
+                                                        event.target.value,
+                                                    )
+                                                }
+                                                className="h-9 w-full rounded-md border bg-transparent px-3"
+                                            >
+                                                {availableCaseTransitions.map(
+                                                    (status) => (
+                                                        <option
+                                                            key={status}
+                                                            value={status}
+                                                        >
+                                                            {status.replaceAll(
+                                                                '_',
+                                                                ' ',
+                                                            )}
+                                                        </option>
+                                                    ),
+                                                )}
+                                            </select>
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label>Effective at</Label>
+                                            <Input
+                                                type="datetime-local"
+                                                name="effective_at"
+                                                defaultValue={whenNow()}
+                                                required
+                                            />
+                                        </div>
+                                        <div className="space-y-2">
+                                            <Label>Reason code</Label>
+                                            <select
+                                                name="reason"
+                                                className="h-9 w-full rounded-md border bg-transparent px-3"
+                                            >
+                                                <option value="">
+                                                    No reason
+                                                </option>
+                                                <option value="goals_completed">
+                                                    Goals completed
+                                                </option>
+                                                <option value="support_completed">
+                                                    Support completed
+                                                </option>
+                                                <option value="client_withdrew">
+                                                    Client withdrew
+                                                </option>
+                                                <option value="created_in_error">
+                                                    Created in error
+                                                </option>
+                                                <option value="transferred">
+                                                    Transferred
+                                                </option>
+                                            </select>
+                                        </div>
+                                        {caseStatus === 'closed' ? (
+                                            <>
+                                                <div className="space-y-2">
+                                                    <Label>
+                                                        Follow-up date
+                                                    </Label>
+                                                    <Input
+                                                        type="datetime-local"
+                                                        name="follow_up_at"
+                                                    />
+                                                </div>
+                                                <div className="space-y-2 md:col-span-2">
+                                                    <Label>
+                                                        Outcome narrative
+                                                    </Label>
+                                                    <Textarea
+                                                        name="narrative"
+                                                        required
+                                                    />
+                                                </div>
+                                                {caseRecord.program.configuration.outcome_measures.map(
+                                                    (measure: any) => (
+                                                        <div
+                                                            key={measure.key}
+                                                            className="space-y-2"
+                                                        >
+                                                            <Label>
+                                                                {measure.label}{' '}
+                                                                ({measure.unit})
+                                                            </Label>
+                                                            <Input
+                                                                type="number"
+                                                                step="any"
+                                                                name={`measures[${measure.key}]`}
+                                                                required
+                                                            />
+                                                        </div>
+                                                    ),
+                                                )}
+                                            </>
+                                        ) : null}
+                                        <InputError
+                                            className="md:col-span-2"
+                                            message={errors.status}
+                                        />
+                                        <Button
+                                            className="md:col-span-2"
+                                            disabled={processing}
+                                        >
+                                            Apply Case transition
+                                        </Button>
+                                    </>
+                                )}
+                            </Form>
+                        </CardContent>
+                    </Card>
+                ) : null}
+
+                {caseRecord.outcome ? (
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Structured outcome</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <p>{caseRecord.outcome.narrative}</p>
+                            <div className="mt-3 flex flex-wrap gap-2">
+                                {Object.entries(
+                                    caseRecord.outcome.measures,
+                                ).map(([key, value]) => (
+                                    <Badge key={key} variant="outline">
+                                        {key.replaceAll('_', ' ')}:{' '}
+                                        {String(value)}
+                                    </Badge>
+                                ))}
+                            </div>
+                        </CardContent>
+                    </Card>
+                ) : null}
+
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Immutable workflow history</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-2 text-sm">
+                        {caseRecord.transitions.map((item: any) => (
+                            <p key={item.id}>
+                                {item.subjectType} v{item.version}:{' '}
+                                {item.from ?? 'created'} → {item.to}
+                                {item.reason ? ` — ${item.reason}` : ''} ·{' '}
+                                {new Date(item.effectiveAt).toLocaleString()}
+                            </p>
+                        ))}
+                    </CardContent>
+                </Card>
+            </div>
+        </>
+    );
+}

--- a/resources/js/pages/intakes/show.tsx
+++ b/resources/js/pages/intakes/show.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
+import { show as showCase } from '@/routes/cases';
 import { index } from '@/routes/intakes';
 import { store as assign } from '@/routes/intakes/assignments';
 import { store as transition } from '@/routes/intakes/transitions';
@@ -407,6 +408,18 @@ export default function IntakeShow({ intake, canTransition, workers }: any) {
                                 ).toLocaleString()}
                             </div>
                         ))}
+                        {intake.case ? (
+                            <Button asChild variant="outline">
+                                <Link
+                                    href={showCase.url([
+                                        organisation.slug,
+                                        intake.case.id,
+                                    ])}
+                                >
+                                    Open case delivery
+                                </Link>
+                            </Button>
+                        ) : null}
                         {intake.case && canTransition ? (
                             <Form
                                 action={assign.url(args)}

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,8 @@
 
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Organisations\CaseAssignmentController;
+use App\Http\Controllers\Organisations\CaseItemController;
+use App\Http\Controllers\Organisations\CaseWorkflowController;
 use App\Http\Controllers\Organisations\IntakeRequestController;
 use App\Http\Controllers\Organisations\IntakeTransitionController;
 use App\Http\Controllers\Organisations\OrganisationInvitationController;
@@ -12,6 +14,7 @@ use App\Http\Controllers\Organisations\PartyDuplicateReviewController;
 use App\Http\Controllers\Organisations\PartyRelationshipController;
 use App\Http\Controllers\Organisations\PartySafeContactInstructionController;
 use App\Http\Controllers\Organisations\ProgramController;
+use App\Http\Controllers\Organisations\ServiceCaseController;
 use App\Http\Controllers\Public\OrganisationController as PublicOrganisationController;
 use App\Http\Middleware\EnsureOrganisationAccess;
 use App\Http\Middleware\EnsureOrganisationMembership;
@@ -85,6 +88,10 @@ Route::prefix('{current_organisation}')
             ->only(['index', 'store', 'show']);
         Route::post('intakes/{intake}/transitions', [IntakeTransitionController::class, 'store'])->name('intakes.transitions.store');
         Route::post('intakes/{intake}/assignments', [CaseAssignmentController::class, 'store'])->name('intakes.assignments.store');
+        Route::get('cases/{case}', [ServiceCaseController::class, 'show'])->name('cases.show');
+        Route::post('cases/{case}/transitions', [ServiceCaseController::class, 'transition'])->name('cases.transitions.store');
+        Route::post('cases/{case}/items', [CaseItemController::class, 'store'])->name('cases.items.store');
+        Route::post('cases/{case}/items/{subjectType}/{subject}/transitions', [CaseWorkflowController::class, 'store'])->name('cases.items.transitions.store');
         Route::post('duplicate-reviews/{duplicate_review}', [PartyDuplicateReviewController::class, 'store'])->name('duplicate-reviews.store');
         Route::delete('duplicate-reviews/{duplicate_review}', [PartyDuplicateReviewController::class, 'destroy'])->name('duplicate-reviews.destroy');
         Route::post('parties/{party}/consents', [PartyConsentController::class, 'store'])->name('parties.consents.store');

--- a/tests/Feature/CaseDeliveryWorkflowTest.php
+++ b/tests/Feature/CaseDeliveryWorkflowTest.php
@@ -1,0 +1,257 @@
+<?php
+
+use App\Actions\CaseDelivery\CarryForwardExternalReferral;
+use App\Actions\CaseDelivery\CreateCaseAppointment;
+use App\Actions\CaseDelivery\CreateCaseGoal;
+use App\Actions\CaseDelivery\CreateCaseService;
+use App\Actions\CaseDelivery\CreateCaseTask;
+use App\Actions\CaseDelivery\CreateExternalReferral;
+use App\Actions\CaseDelivery\FinalizeCaseNote;
+use App\Actions\CaseDelivery\RecordCaseInteraction;
+use App\Actions\CaseDelivery\SaveCaseNote;
+use App\Actions\CaseDelivery\TransitionCaseAppointment;
+use App\Actions\CaseDelivery\TransitionCaseGoal;
+use App\Actions\CaseDelivery\TransitionCaseService;
+use App\Actions\CaseDelivery\TransitionCaseTask;
+use App\Actions\CaseDelivery\TransitionExternalReferral;
+use App\Actions\CaseDelivery\TransitionServiceCase;
+use App\Actions\Intake\AssignCaseWorker;
+use App\Actions\Intake\CreateIntakeRequest;
+use App\Actions\Parties\RecordPartyConsent;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseAppointmentStatus;
+use App\Enums\CaseGoalStatus;
+use App\Enums\CaseMetricCode;
+use App\Enums\CaseServiceStatus;
+use App\Enums\CaseTaskStatus;
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use App\Enums\ExternalReferralStatus;
+use App\Enums\OrganisationRole;
+use App\Enums\ServiceCaseStatus;
+use App\Models\CaseWorkflowTransition;
+use App\Models\Membership;
+use App\Models\MetricEvent;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\Program;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\QueryException;
+use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/** @return array{organisation: Organisation, program: Program, party: Party, manager: User, worker: User, workerMembership: Membership, case: ServiceCase} */
+function caseDeliveryFixture(): array
+{
+    $organisation = Organisation::factory()->active()->create();
+    $manager = User::factory()->create();
+    $worker = User::factory()->create();
+    $managerMembership = $organisation->memberships()->create(['user_id' => $manager->id, 'role' => OrganisationRole::ProgramManager]);
+    $workerMembership = $organisation->memberships()->create(['user_id' => $worker->id, 'role' => OrganisationRole::CaseWorker]);
+
+    [$program, $party, $case] = app(OrganisationContext::class)->run($organisation, function () use ($organisation, $manager, $managerMembership, $workerMembership): array {
+        $program = Program::factory()->for($organisation)->create(['configuration' => [
+            'labels' => ['request' => 'Housing request', 'case' => 'Housing journey'],
+            'stages' => [['key' => 'received', 'label' => 'Received']],
+            'outcome_measures' => [['key' => 'housing_stability', 'label' => 'Housing stability', 'unit' => 'score']],
+            'taxonomies' => [], 'intake_fields' => [], 'eligibility_fields' => [], 'risk_flags' => [],
+        ]]);
+        $managerMembership->programs()->attach($program);
+        $workerMembership->programs()->attach($program);
+        $party = Party::factory()->for($organisation)->create();
+        $party->programs()->attach($program);
+        app(RecordPartyConsent::class)->handle($party, [
+            'purpose' => ConsentPurpose::Service,
+            'decision' => ConsentDecision::Granted,
+            'wording_version' => 'test-v1',
+            'wording' => 'Synthetic test consent.',
+            'source' => 'test',
+            'occurred_at' => '2026-06-01T09:00:00+02:00',
+        ], $manager);
+        $intake = app(CreateIntakeRequest::class)->handle($organisation, $program, $party, [
+            'source' => 'test',
+            'narrative' => 'Synthetic test request.',
+            'presenting_needs' => 'Housing support.',
+            'intake_fields' => [],
+            'eligibility_context' => [],
+            'risk_flags' => [],
+            'email' => null,
+            'telephone' => null,
+            'idempotency_key' => null,
+            'consent_granted' => true,
+            'consent_source' => 'test',
+        ], $manager);
+        $case = ServiceCase::factory()->create(['organisation_id' => $organisation->id, 'intake_request_id' => $intake->id, 'program_id' => $program->id, 'party_id' => $party->id, 'opened_at' => '2026-06-02 08:00:00']);
+
+        return [$program, $party, $case];
+    });
+
+    return compact('organisation', 'program', 'party', 'manager', 'worker', 'workerMembership', 'case');
+}
+
+it('defines every required valid state path explicitly', function () {
+    expect(ServiceCaseStatus::Open->allowedTransitions())->toEqualCanonicalizing([ServiceCaseStatus::Active, ServiceCaseStatus::OnHold, ServiceCaseStatus::Closed, ServiceCaseStatus::Cancelled])
+        ->and(ServiceCaseStatus::Active->allowedTransitions())->toEqualCanonicalizing([ServiceCaseStatus::OnHold, ServiceCaseStatus::Closed])
+        ->and(ServiceCaseStatus::OnHold->allowedTransitions())->toEqualCanonicalizing([ServiceCaseStatus::Active, ServiceCaseStatus::Closed])
+        ->and(CaseGoalStatus::Draft->allowedTransitions())->toEqualCanonicalizing([CaseGoalStatus::Active, CaseGoalStatus::Cancelled])
+        ->and(CaseGoalStatus::Active->allowedTransitions())->toEqualCanonicalizing([CaseGoalStatus::Achieved, CaseGoalStatus::NotAchieved, CaseGoalStatus::Cancelled, CaseGoalStatus::Withdrawn])
+        ->and(CaseServiceStatus::Planned->allowedTransitions())->toEqualCanonicalizing([CaseServiceStatus::Scheduled, CaseServiceStatus::Completed, CaseServiceStatus::Cancelled])
+        ->and(CaseServiceStatus::Scheduled->allowedTransitions())->toEqualCanonicalizing([CaseServiceStatus::Completed, CaseServiceStatus::Cancelled, CaseServiceStatus::NotDelivered])
+        ->and(ExternalReferralStatus::Draft->allowedTransitions())->toEqualCanonicalizing([ExternalReferralStatus::Sent, ExternalReferralStatus::Cancelled])
+        ->and(ExternalReferralStatus::Sent->allowedTransitions())->toEqualCanonicalizing([ExternalReferralStatus::Acknowledged, ExternalReferralStatus::Connected, ExternalReferralStatus::NotConnected, ExternalReferralStatus::Cancelled])
+        ->and(ExternalReferralStatus::Acknowledged->allowedTransitions())->toEqualCanonicalizing([ExternalReferralStatus::Connected, ExternalReferralStatus::NotConnected, ExternalReferralStatus::Cancelled])
+        ->and(CaseTaskStatus::Open->allowedTransitions())->toEqualCanonicalizing([CaseTaskStatus::Completed, CaseTaskStatus::Cancelled])
+        ->and(CaseAppointmentStatus::Scheduled->allowedTransitions())->toEqualCanonicalizing([CaseAppointmentStatus::Completed, CaseAppointmentStatus::Cancelled, CaseAppointmentStatus::NoShow]);
+});
+
+it('delivers and closes a complete case atomically with immutable history and reconciled metric dates', function () {
+    $fixture = caseDeliveryFixture();
+    $at = fn (string $time): CarbonImmutable => CarbonImmutable::parse($time, 'Africa/Johannesburg')->utc();
+
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture, $at): void {
+        expect(fn () => app(TransitionServiceCase::class)->handle($fixture['case'], ServiceCaseStatus::Active, 1, $at('2026-06-03 09:00'), $fixture['manager']))
+            ->toThrow(LogicException::class, 'primary case-worker assignment');
+        app(AssignCaseWorker::class)->handle($fixture['case'], $fixture['workerMembership'], $fixture['manager']);
+        app(TransitionServiceCase::class)->handle($fixture['case'], ServiceCaseStatus::Active, 1, $at('2026-06-03 09:00'), $fixture['manager']);
+
+        $goal = app(CreateCaseGoal::class)->handle($fixture['case'], 'Secure stable housing', 'Find a sustainable tenancy.', $at('2026-06-25 17:00'), $fixture['worker']);
+        app(TransitionCaseGoal::class)->handle($goal, CaseGoalStatus::Active, 1, $at('2026-06-03 10:00'), $fixture['worker']);
+        app(TransitionCaseGoal::class)->handle($goal->refresh(), CaseGoalStatus::Achieved, 2, $at('2026-06-27 14:00'), $fixture['worker'], 'stable_tenancy');
+
+        $service = app(CreateCaseService::class)->handle($fixture['case'], 'housing_advice', 'Tenancy advice session.', $at('2026-06-10 11:00'), $fixture['worker']);
+        app(TransitionCaseService::class)->handle($service, CaseServiceStatus::Scheduled, 1, $at('2026-06-04 09:00'), $fixture['worker']);
+        app(TransitionCaseService::class)->handle($service->refresh(), CaseServiceStatus::Completed, 2, $at('2026-06-10 12:00'), $fixture['worker']);
+
+        $referral = app(CreateExternalReferral::class)->handle($fixture['case'], 'Synthetic Housing Partner', 'Tenancy placement', 'Name and contact preference only', 'service_consent', $fixture['worker']);
+        app(TransitionExternalReferral::class)->handle($referral, ExternalReferralStatus::Sent, 1, $at('2026-06-05 09:00'), $fixture['worker']);
+        app(TransitionExternalReferral::class)->handle($referral->refresh(), ExternalReferralStatus::Acknowledged, 2, $at('2026-06-06 09:00'), $fixture['worker']);
+        app(TransitionExternalReferral::class)->handle($referral->refresh(), ExternalReferralStatus::Connected, 3, $at('2026-06-12 09:00'), $fixture['worker']);
+
+        $task = app(CreateCaseTask::class)->handle($fixture['case'], 'Confirm tenancy', 'Check signed agreement.', $at('2026-06-20 17:00'), $fixture['worker']);
+        app(TransitionCaseTask::class)->handle($task, CaseTaskStatus::Completed, 1, $at('2026-06-18 10:00'), $fixture['worker']);
+        $appointment = app(CreateCaseAppointment::class)->handle($fixture['case'], 'Housing review', 'HarbourKind office', $at('2026-06-10 11:00'), $fixture['worker']);
+        app(TransitionCaseAppointment::class)->handle($appointment, CaseAppointmentStatus::Completed, 1, $at('2026-06-10 12:00'), $fixture['worker'], completedService: $service->refresh());
+        app(RecordCaseInteraction::class)->handle($fixture['case'], 'telephone', 'Confirmed appointment details.', $at('2026-06-04 12:00'), $fixture['worker']);
+        $note = app(SaveCaseNote::class)->handle($fixture['case'], 'Synthetic confidential case note.', $fixture['worker']);
+        $finalizedNote = app(FinalizeCaseNote::class)->handle($note, 1, $fixture['worker']);
+        expect(fn () => $finalizedNote->update(['encrypted_content' => new ClassifiedValue('Attempted rewrite')]))
+            ->toThrow(LogicException::class, 'cannot be overwritten');
+        $addendum = app(SaveCaseNote::class)->handle($fixture['case'], 'Correction without overwriting the original.', $fixture['worker'], $note->refresh());
+        app(FinalizeCaseNote::class)->handle($addendum, 1, $fixture['worker']);
+
+        $closed = app(TransitionServiceCase::class)->handle($fixture['case']->refresh(), ServiceCaseStatus::Closed, 2, $at('2026-06-28 15:00'), $fixture['manager'], [
+            'reason' => 'goals_completed',
+            'narrative' => 'Stable housing was secured in this fictional scenario.',
+            'measures' => ['housing_stability' => 4],
+            'follow_up_at' => $at('2026-07-28 09:00'),
+        ]);
+
+        expect($closed->status)->toBe(ServiceCaseStatus::Closed)
+            ->and($closed->closure_checklist)->not->toContain(false)
+            ->and($closed->outcome->measures)->toBe(['housing_stability' => 4])
+            ->and(MetricEvent::query()->where('code', CaseMetricCode::ServiceDelivered)->firstOrFail()->occurred_at->equalTo($at('2026-06-10 12:00')))->toBeTrue()
+            ->and(MetricEvent::query()->where('code', CaseMetricCode::CaseClosed)->firstOrFail()->occurred_at->equalTo($at('2026-06-28 15:00')))->toBeTrue();
+        expect(DB::table('case_outcomes')->where('service_case_id', $closed->id)->value('encrypted_content'))->not->toContain('Stable housing');
+        expect(fn () => DB::table('case_workflow_transitions')->where('service_case_id', $closed->id)->update(['reason' => 'rewritten']))->toThrow(QueryException::class);
+    });
+});
+
+it('rejects stale and invalid transitions without partial writes', function () {
+    $fixture = caseDeliveryFixture();
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): void {
+        $goal = app(CreateCaseGoal::class)->handle($fixture['case'], 'Goal', 'Details', null, $fixture['manager']);
+        $transitionCount = CaseWorkflowTransition::query()->count();
+        expect(fn () => app(TransitionCaseGoal::class)->handle($goal, CaseGoalStatus::Achieved, 1, now(), $fixture['manager'], 'outcome'))
+            ->toThrow(LogicException::class, 'Cannot transition')
+            ->and(fn () => app(TransitionCaseGoal::class)->handle($goal, CaseGoalStatus::Active, 99, now(), $fixture['manager']))
+            ->toThrow(LogicException::class, 'changed while');
+        expect($goal->refresh()->status)->toBe(CaseGoalStatus::Draft)
+            ->and(CaseWorkflowTransition::query()->count())->toBe($transitionCount);
+    });
+});
+
+it('blocks closure until open work is terminal or a pending referral is carried forward with a reason', function () {
+    $fixture = caseDeliveryFixture();
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): void {
+        app(AssignCaseWorker::class)->handle($fixture['case'], $fixture['workerMembership'], $fixture['manager']);
+        app(TransitionServiceCase::class)->handle($fixture['case'], ServiceCaseStatus::Active, 1, now(), $fixture['manager']);
+        $task = app(CreateCaseTask::class)->handle($fixture['case'], 'Open task', 'Still pending', now()->addDay(), $fixture['worker']);
+        $referral = app(CreateExternalReferral::class)->handle($fixture['case'], 'Synthetic Partner', 'Support', 'Contact preference', 'service_consent', $fixture['worker']);
+        app(TransitionExternalReferral::class)->handle($referral, ExternalReferralStatus::Sent, 1, now(), $fixture['worker']);
+        $closure = ['reason' => 'completed', 'narrative' => 'Outcome', 'measures' => ['housing_stability' => 3]];
+
+        expect(fn () => app(TransitionServiceCase::class)->handle($fixture['case']->refresh(), ServiceCaseStatus::Closed, 2, now(), $fixture['manager'], $closure))
+            ->toThrow(LogicException::class, 'Complete, cancel, resolve');
+        expect($fixture['case']->refresh()->status)->toBe(ServiceCaseStatus::Active)->and($fixture['case']->outcome()->exists())->toBeFalse();
+
+        app(TransitionCaseTask::class)->handle($task, CaseTaskStatus::Cancelled, 1, now(), $fixture['worker'], 'no_longer_needed');
+        app(CarryForwardExternalReferral::class)->handle($referral->refresh(), 2, 'follow_up_in_new_case', now(), $fixture['worker']);
+        expect(fn () => app(TransitionServiceCase::class)->handle($fixture['case']->refresh(), ServiceCaseStatus::Closed, 2, now(), $fixture['manager'], [...$closure, 'measures' => ['housing_stability' => 3, 'unexpected' => 1]]))
+            ->toThrow(LogicException::class, 'configured outcome measure');
+        expect(fn () => app(TransitionServiceCase::class)->handle($fixture['case']->refresh(), ServiceCaseStatus::Closed, 2, now(), $fixture['manager'], [...$closure, 'follow_up_at' => now()->subDay()]))
+            ->toThrow(LogicException::class, 'after Case closure');
+        app(TransitionServiceCase::class)->handle($fixture['case']->refresh(), ServiceCaseStatus::Closed, 2, now(), $fixture['manager'], $closure);
+        expect($fixture['case']->refresh()->status)->toBe(ServiceCaseStatus::Closed);
+    });
+});
+
+it('only cancels cases without substantive service or unresolved work', function () {
+    $fixture = caseDeliveryFixture();
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): void {
+        $service = app(CreateCaseService::class)->handle($fixture['case'], 'planned_support', 'Planned but not delivered.', null, $fixture['manager']);
+        expect(fn () => app(TransitionServiceCase::class)->handle($fixture['case'], ServiceCaseStatus::Cancelled, 1, now(), $fixture['manager'], ['reason' => 'created_in_error']))
+            ->toThrow(LogicException::class, 'Resolve every open');
+        app(TransitionCaseService::class)->handle($service, CaseServiceStatus::Cancelled, 1, now(), $fixture['manager'], 'client_cancelled');
+        app(TransitionServiceCase::class)->handle($fixture['case']->refresh(), ServiceCaseStatus::Cancelled, 1, now(), $fixture['manager'], ['reason' => 'created_in_error']);
+        expect($fixture['case']->refresh()->status)->toBe(ServiceCaseStatus::Cancelled);
+    });
+});
+
+it('rechecks sharing authority when an external referral is sent', function () {
+    $fixture = caseDeliveryFixture();
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): void {
+        $referral = app(CreateExternalReferral::class)->handle($fixture['case'], 'Synthetic Partner', 'Housing support', 'Name only', 'service_consent', $fixture['manager']);
+        app(RecordPartyConsent::class)->handle($fixture['party'], [
+            'purpose' => ConsentPurpose::Service,
+            'decision' => ConsentDecision::Withdrawn,
+            'wording_version' => 'test-v1',
+            'wording' => 'Synthetic test consent.',
+            'source' => 'test',
+            'occurred_at' => now()->addMinute()->toAtomString(),
+        ], $fixture['manager']);
+
+        expect(fn () => app(TransitionExternalReferral::class)->handle($referral, ExternalReferralStatus::Sent, 1, now()->addMinutes(2), $fixture['manager']))
+            ->toThrow(LogicException::class, 'current service-consent');
+        expect($referral->refresh()->status)->toBe(ExternalReferralStatus::Draft);
+    });
+});
+
+it('enforces tenant, Program, role, and active-assignment boundaries on the case workspace', function () {
+    $fixture = caseDeliveryFixture();
+    $administrator = User::factory()->create();
+    $fixture['organisation']->memberships()->create(['user_id' => $administrator->id, 'role' => OrganisationRole::OrganisationAdministrator]);
+    $otherOrganisation = Organisation::factory()->active()->create();
+    $otherManager = User::factory()->create();
+    $otherOrganisation->memberships()->create(['user_id' => $otherManager->id, 'role' => OrganisationRole::ProgramManager]);
+
+    $this->actingAs($fixture['worker'])->get(route('cases.show', [$fixture['organisation'], $fixture['case']]))->assertForbidden();
+    $this->actingAs($administrator)->get(route('cases.show', [$fixture['organisation'], $fixture['case']]))->assertForbidden();
+    $this->actingAs($otherManager)->get(route('cases.show', [$otherOrganisation, $fixture['case']]))->assertNotFound();
+    app(OrganisationContext::class)->run($fixture['organisation'], fn () => expect(fn () => app(CreateCaseGoal::class)->handle($fixture['case'], 'Forbidden goal', 'No assignment.', null, $fixture['worker']))
+        ->toThrow(LogicException::class, 'not authorised'));
+
+    app(OrganisationContext::class)->run($fixture['organisation'], fn () => app(AssignCaseWorker::class)->handle($fixture['case'], $fixture['workerMembership'], $fixture['manager']));
+    $this->actingAs($fixture['worker'])
+        ->get(route('cases.show', [$fixture['organisation'], $fixture['case']]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page->component('cases/show')->where('caseRecord.id', $fixture['case']->id)->where('canUpdate', true));
+    $this->actingAs($fixture['worker'])->post(route('cases.items.store', [$fixture['organisation'], $fixture['case']]), [
+        'kind' => 'goal',
+        'title' => 'Worker-owned goal',
+        'description' => 'A goal in the assigned case.',
+    ])->assertRedirect()->assertSessionHasNoErrors();
+    app(OrganisationContext::class)->run($fixture['organisation'], fn () => expect($fixture['case']->goals()->count())->toBe(1));
+});

--- a/tests/Feature/CommunityKindScenarioSeederTest.php
+++ b/tests/Feature/CommunityKindScenarioSeederTest.php
@@ -6,11 +6,13 @@ use App\Actions\Programs\SearchPrograms;
 use App\Data\Demo\ScenarioCatalog;
 use App\Enums\OrganisationStatus;
 use App\Models\Membership;
+use App\Models\MetricEvent;
 use App\Models\Organisation;
 use App\Models\Party;
 use App\Models\PartyContactPoint;
 use App\Models\Program;
 use App\Models\RoleAssignment;
+use App\Models\ServiceCase;
 use App\Models\User;
 use App\OrganisationCache;
 use App\OrganisationContext;
@@ -41,6 +43,8 @@ it('seeds the versioned synthetic scenarios deterministically', function () {
     $partyIds = Party::withoutGlobalScopes()->orderBy('uuid')->pluck('id', 'uuid')->all();
     $harbourKindId = Organisation::query()->where('slug', 'harbourkind')->valueOrFail('id');
     $neighbourLinkId = Organisation::query()->where('slug', 'neighbourlink')->valueOrFail('id');
+    $showcaseCase = ServiceCase::withoutGlobalScopes()->firstOrFail();
+    $serviceMetric = MetricEvent::withoutGlobalScopes()->where('code', 'service_delivered')->firstOrFail();
     $harbourKindPartyCounts = DB::table('parties')
         ->where('organisation_id', $harbourKindId)
         ->selectRaw('kind, count(*) as aggregate')
@@ -56,7 +60,7 @@ it('seeds the versioned synthetic scenarios deterministically', function () {
         ->map(fn (int|string $count): int => (int) $count)
         ->all();
 
-    expect(ScenarioCatalog::VERSION)->toBe('2026.2')
+    expect(ScenarioCatalog::VERSION)->toBe('2026.3')
         ->and(ScenarioCatalog::AS_OF)->toBe('2026-06-30 23:59:59')
         ->and(Date::getTestNow())->toBeNull()
         ->and(Organisation::query()->count())->toBe(2)
@@ -67,6 +71,11 @@ it('seeds the versioned synthetic scenarios deterministically', function () {
         ->and(Program::withoutGlobalScopes()->count())->toBe(4)
         ->and(RoleAssignment::withoutGlobalScopes()->count())->toBe(10)
         ->and(DB::table('membership_program')->count())->toBe(6)
+        ->and(ServiceCase::withoutGlobalScopes()->count())->toBe(1)
+        ->and(MetricEvent::withoutGlobalScopes()->count())->toBe(5)
+        ->and($showcaseCase->opened_at->toDateTimeString())->toBe('2026-06-02 06:00:00')
+        ->and($showcaseCase->closed_at?->toDateTimeString())->toBe('2026-06-28 13:00:00')
+        ->and($serviceMetric->occurred_at->toDateTimeString())->toBe('2026-06-10 10:00:00')
         ->and(Membership::withoutGlobalScopes()->where('organisation_id', $harbourKindId)->count())->toBe(9)
         ->and(Membership::withoutGlobalScopes()->where('organisation_id', $neighbourLinkId)->count())->toBe(3)
         ->and($harbourKindPartyCounts)->toBe(['household' => 100, 'organisation' => 150, 'person' => 1750])
@@ -82,7 +91,9 @@ it('seeds the versioned synthetic scenarios deterministically', function () {
         ->and(Membership::withoutGlobalScopes()->count())->toBe(12)
         ->and(Party::withoutGlobalScopes()->count())->toBe(2030)
         ->and(PartyContactPoint::withoutGlobalScopes()->orderBy('id')->pluck('id')->all())->toBe($contactIds)
-        ->and(Party::withoutGlobalScopes()->orderBy('uuid')->pluck('id', 'uuid')->all())->toBe($partyIds);
+        ->and(Party::withoutGlobalScopes()->orderBy('uuid')->pluck('id', 'uuid')->all())->toBe($partyIds)
+        ->and(ServiceCase::withoutGlobalScopes()->count())->toBe(1)
+        ->and(MetricEvent::withoutGlobalScopes()->count())->toBe(5);
 });
 
 it('keeps every scenario identity and reserved showcase explicitly synthetic', function () {


### PR DESCRIPTION
## Summary
- model case delivery as explicit, audited state transitions across goals, services, referrals, tasks, appointments, notes, outcomes, and closure
- add an assignment-aware case workspace with authorization boundaries and a complete seeded request-to-outcome journey
- emit de-identified operational metrics while protecting sensitive narrative fields and immutable history

## Review fixes
- serialize case mutations and closure through a shared case lock
- recheck current consent while sending referrals and prevent finalized-note rewrites
- enforce cancellation, closure, chronology, and cross-case integrity constraints

## Verification
- `composer ci:check` (282 tests, 1,277 assertions)
- `npm test`
- `npm run build`
- local seeded journey verified in the case workspace

Stacked on #52.

Closes #12