### PR TITLE
Protect confidential cases, risk, and safe-contact information

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ php artisan config:clear
 php artisan db:seed
 ```
 
-Scenario catalog version `2026.3` uses the fixed reporting instant
+Scenario catalog version `2026.4` uses the fixed reporting instant
 `2026-06-30 23:59:59` in each Organisation's local timezone: HarbourKind uses
 `Africa/Johannesburg` and ZAR, while NeighbourLink uses `Europe/London` and
 GBP. It can be seeded repeatedly without duplicating its records. All demo

--- a/app/Actions/CaseConfidentiality/ExportIdentifiableCases.php
+++ b/app/Actions/CaseConfidentiality/ExportIdentifiableCases.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Actions\CaseConfidentiality;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Authorization\CaseAccess;
+use App\Enums\CaseClassification;
+use App\Enums\RestrictedAccessPermission;
+use App\Enums\TenantAuditEventType;
+use App\Models\Program;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use LogicException;
+
+class ExportIdentifiableCases
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly CaseAccess $access,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    public function handle(Program $program, User $actor): string
+    {
+        $this->context->ensureOwns($program->organisation_id);
+        if (! $this->access->canExportProgram($actor, $program)) {
+            throw new LogicException('Identifiable Case export requires explicit Program export access.');
+        }
+
+        $membership = $actor->organisationMembership($program->organisation);
+        if ($membership === null) {
+            throw new LogicException('Identifiable Case export requires an active Organisation Membership.');
+        }
+
+        $cases = ServiceCase::query()
+            ->where('program_id', $program->id)
+            ->where(fn ($query) => $query
+                ->where('confidentiality', CaseClassification::Confidential)
+                ->orWhereHas('restrictedAccessGrants', fn ($grants) => $grants
+                    ->whereDoesntHave('revocation')
+                    ->where(fn ($active) => $active->whereNull('expires_at')->orWhere('expires_at', '>', now()))
+                    ->where('membership_id', $membership->id)
+                    ->where('permission', RestrictedAccessPermission::SensitiveData)))
+            ->with(['organisation', 'program', 'party:id,uuid,display_name'])
+            ->orderBy('opened_at')
+            ->get();
+        $stream = fopen('php://temp', 'r+');
+        if ($stream === false) {
+            throw new LogicException('Unable to create Case export.');
+        }
+
+        fputcsv($stream, ['case_id', 'party_uuid', 'party_name', 'status', 'classification', 'opened_at', 'closed_at']);
+        foreach ($cases as $case) {
+            fputcsv($stream, [
+                $case->id,
+                $case->party->uuid,
+                $case->party->display_name,
+                $case->status->value,
+                $case->confidentiality->value,
+                $case->opened_at->toAtomString(),
+                $case->closed_at?->toAtomString(),
+            ]);
+        }
+
+        rewind($stream);
+        $contents = stream_get_contents($stream);
+        fclose($stream);
+        if ($contents === false) {
+            throw new LogicException('Unable to read Case export.');
+        }
+
+        $this->recordAudit->handle($program->organisation, TenantAuditEventType::IdentifiableCaseExported, 'program', (string) $program->id, [
+            'program_id' => $program->id,
+            'record_count' => $cases->count(),
+        ], $actor);
+
+        return $contents;
+    }
+}

--- a/app/Actions/CaseConfidentiality/GrantRestrictedAccess.php
+++ b/app/Actions/CaseConfidentiality/GrantRestrictedAccess.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Actions\CaseConfidentiality;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Authorization\CaseAccess;
+use App\Enums\OrganisationRole;
+use App\Enums\RestrictedAccessPermission;
+use App\Enums\TenantAuditEventType;
+use App\Models\Membership;
+use App\Models\RestrictedAccessGrant;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class GrantRestrictedAccess
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly CaseAccess $access,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    public function handle(
+        ServiceCase $case,
+        Membership $membership,
+        RestrictedAccessPermission $permission,
+        string $reason,
+        User $actor,
+        ?CarbonImmutable $expiresAt = null,
+    ): RestrictedAccessGrant {
+        return DB::transaction(function () use ($case, $membership, $permission, $reason, $actor, $expiresAt): RestrictedAccessGrant {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($case->id);
+            $this->context->ensureOwns($case->organisation_id);
+
+            if (! $this->access->canManageAccess($actor, $case)) {
+                throw new LogicException('Only a Program manager may grant restricted Case access.');
+            }
+
+            if ($membership->organisation_id !== $case->organisation_id || $membership->isHeld()) {
+                throw new LogicException('Restricted access may only be granted to an active Membership in this Organisation.');
+            }
+
+            $eligible = $membership->hasRole(OrganisationRole::ProgramManager, $case->program)
+                || ($membership->hasRole(OrganisationRole::CaseWorker, $case->program)
+                    && $case->assignments()->where('membership_id', $membership->id)->where('status', 'active')->exists());
+
+            if (! $eligible) {
+                throw new LogicException('Restricted access requires an eligible scoped service Role and active Case assignment where applicable.');
+            }
+
+            if ($permission === RestrictedAccessPermission::IdentifiableCaseExport
+                && ! $membership->hasRole(OrganisationRole::ProgramManager, $case->program)) {
+                throw new LogicException('Only Program managers may receive identifiable Case export access.');
+            }
+
+            $serviceCaseId = $permission === RestrictedAccessPermission::SensitiveData ? $case->id : null;
+            $grant = RestrictedAccessGrant::query()->create([
+                'membership_id' => $membership->id,
+                'program_id' => $case->program_id,
+                'service_case_id' => $serviceCaseId,
+                'permission' => $permission,
+                'reason' => $reason,
+                'granted_at' => now(),
+                'expires_at' => $expiresAt,
+                'granted_by_user_id' => $actor->id,
+            ]);
+
+            $this->recordAudit->handle($case->organisation, TenantAuditEventType::RestrictedAccessGranted, 'restricted_access_grant', $grant->id, [
+                'case_id' => $serviceCaseId,
+                'membership_id' => $membership->id,
+                'program_id' => $case->program_id,
+                'permission' => $permission->value,
+                'reason' => $reason,
+            ], $actor);
+
+            return $grant;
+        });
+    }
+}

--- a/app/Actions/CaseConfidentiality/ReclassifyServiceCase.php
+++ b/app/Actions/CaseConfidentiality/ReclassifyServiceCase.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Actions\CaseConfidentiality;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Authorization\CaseAccess;
+use App\Enums\CaseClassification;
+use App\Enums\TenantAuditEventType;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class ReclassifyServiceCase
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly CaseAccess $access,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    public function handle(ServiceCase $case, CaseClassification $classification, string $reason, User $actor): ServiceCase
+    {
+        return DB::transaction(function () use ($case, $classification, $reason, $actor): ServiceCase {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($case->id);
+            $this->context->ensureOwns($case->organisation_id);
+
+            if (! $this->access->canManageAccess($actor, $case)) {
+                throw new LogicException('Only a Program manager may reclassify a Case.');
+            }
+
+            $from = $case->confidentiality;
+            if ($from === $classification) {
+                return $case;
+            }
+
+            if ($from === CaseClassification::HighlyRestricted
+                && ! $this->access->canViewSensitive($actor, $case)) {
+                throw new LogicException('Lowering Case sensitivity requires current restricted access.');
+            }
+
+            $case->update(['confidentiality' => $classification]);
+            $this->recordAudit->handle($case->organisation, TenantAuditEventType::CaseReclassified, 'service_case', $case->id, [
+                'case_id' => $case->id,
+                'from' => $from->value,
+                'to' => $classification->value,
+                'reason' => $reason,
+            ], $actor);
+
+            return $case->refresh();
+        });
+    }
+}

--- a/app/Actions/CaseConfidentiality/RecordCaseRiskAssessment.php
+++ b/app/Actions/CaseConfidentiality/RecordCaseRiskAssessment.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Actions\CaseConfidentiality;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Authorization\CaseAccess;
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseClassification;
+use App\Enums\TenantAuditEventType;
+use App\Models\CaseRiskAssessment;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class RecordCaseRiskAssessment
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly CaseAccess $access,
+        private readonly ClassifiedDataEncrypter $encrypter,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    public function handle(ServiceCase $case, string $content, User $actor): CaseRiskAssessment
+    {
+        return DB::transaction(function () use ($case, $content, $actor): CaseRiskAssessment {
+            $case = ServiceCase::query()->lockForUpdate()->findOrFail($case->id);
+            $this->context->ensureOwns($case->organisation_id);
+
+            if (! $this->access->canViewSensitive($actor, $case)) {
+                throw new LogicException('Recording risk information requires restricted Case access.');
+            }
+
+            $assessment = new CaseRiskAssessment;
+            $assessment->forceFill([
+                'id' => $assessment->newUniqueId(),
+                'organisation_id' => $case->organisation_id,
+                'service_case_id' => $case->id,
+                'type' => 'risk_assessment',
+                'classification' => CaseClassification::HighlyRestricted,
+                'data_key_version' => $this->encrypter->currentVersion(),
+                'effective_at' => now(),
+                'recorded_by_user_id' => $actor->id,
+            ]);
+            $assessment->encrypted_content = new ClassifiedValue($content);
+            $assessment->save();
+            $this->recordAudit->handle($case->organisation, TenantAuditEventType::CaseRiskRecorded, 'case_risk_assessment', $assessment->id, [
+                'case_id' => $case->id,
+                'classification' => CaseClassification::HighlyRestricted->value,
+            ], $actor);
+
+            return $assessment;
+        });
+    }
+}

--- a/app/Actions/CaseConfidentiality/RevokeRestrictedAccess.php
+++ b/app/Actions/CaseConfidentiality/RevokeRestrictedAccess.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Actions\CaseConfidentiality;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Authorization\CaseAccess;
+use App\Enums\TenantAuditEventType;
+use App\Models\RestrictedAccessGrant;
+use App\Models\RestrictedAccessRevocation;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class RevokeRestrictedAccess
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly CaseAccess $access,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    public function handle(RestrictedAccessGrant $grant, string $reason, User $actor): RestrictedAccessRevocation
+    {
+        return DB::transaction(function () use ($grant, $reason, $actor): RestrictedAccessRevocation {
+            $grant = RestrictedAccessGrant::query()->lockForUpdate()->findOrFail($grant->id);
+            $this->context->ensureOwns($grant->organisation_id);
+
+            if (! $this->access->canManageProgram($actor, $grant->program)) {
+                throw new LogicException('Only a scoped Program manager may revoke restricted access.');
+            }
+
+            $existing = $grant->revocation()->first();
+            if ($existing !== null) {
+                return $existing;
+            }
+
+            $revocation = RestrictedAccessRevocation::query()->create([
+                'restricted_access_grant_id' => $grant->id,
+                'reason' => $reason,
+                'revoked_at' => now(),
+                'revoked_by_user_id' => $actor->id,
+            ]);
+            $this->recordAudit->handle($grant->program->organisation, TenantAuditEventType::RestrictedAccessRevoked, 'restricted_access_grant', $grant->id, [
+                'grant_id' => $grant->id,
+                'reason' => $reason,
+            ], $actor);
+
+            return $revocation;
+        });
+    }
+}

--- a/app/Actions/CaseDelivery/EnsureCanManageCase.php
+++ b/app/Actions/CaseDelivery/EnsureCanManageCase.php
@@ -2,7 +2,7 @@
 
 namespace App\Actions\CaseDelivery;
 
-use App\Enums\OrganisationRole;
+use App\Authorization\CaseAccess;
 use App\Models\ServiceCase;
 use App\Models\User;
 use App\OrganisationContext;
@@ -10,23 +10,16 @@ use LogicException;
 
 class EnsureCanManageCase
 {
-    public function __construct(private readonly OrganisationContext $context) {}
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly CaseAccess $access,
+    ) {}
 
     public function handle(ServiceCase $case, User $actor): void
     {
         $this->context->ensureOwns($case->organisation_id);
 
-        if ($actor->hasOrganisationRole($case->organisation, OrganisationRole::ProgramManager, $case->program)
-            && $actor->hasProgramAccess($case->program)) {
-            return;
-        }
-
-        $membership = $actor->organisationMembership($case->organisation);
-        if ($membership !== null
-            && ! $membership->isHeld()
-            && $actor->hasOrganisationRole($case->organisation, OrganisationRole::CaseWorker, $case->program)
-            && $actor->hasProgramAccess($case->program)
-            && $case->assignments()->where('membership_id', $membership->id)->where('status', 'active')->exists()) {
+        if ($this->access->canView($actor, $case)) {
             return;
         }
 

--- a/app/Actions/Demo/BuildRequestToOutcomeScenario.php
+++ b/app/Actions/Demo/BuildRequestToOutcomeScenario.php
@@ -2,6 +2,9 @@
 
 namespace App\Actions\Demo;
 
+use App\Actions\CaseConfidentiality\GrantRestrictedAccess;
+use App\Actions\CaseConfidentiality\ReclassifyServiceCase;
+use App\Actions\CaseConfidentiality\RecordCaseRiskAssessment;
 use App\Actions\CaseDelivery\CreateCaseAppointment;
 use App\Actions\CaseDelivery\CreateCaseGoal;
 use App\Actions\CaseDelivery\CreateCaseService;
@@ -18,7 +21,9 @@ use App\Actions\CaseDelivery\TransitionExternalReferral;
 use App\Actions\CaseDelivery\TransitionServiceCase;
 use App\Actions\Intake\CreateIntakeRequest;
 use App\Actions\Intake\TransitionIntakeRequest;
+use App\Actions\Parties\StoreSafeContactInstruction;
 use App\Enums\CaseAppointmentStatus;
+use App\Enums\CaseClassification;
 use App\Enums\CaseGoalStatus;
 use App\Enums\CaseServiceStatus;
 use App\Enums\CaseTaskStatus;
@@ -26,12 +31,14 @@ use App\Enums\EligibilityStatus;
 use App\Enums\ExternalReferralStatus;
 use App\Enums\IntakeStatus;
 use App\Enums\IntakeUrgency;
+use App\Enums\RestrictedAccessPermission;
 use App\Enums\ServiceCaseStatus;
 use App\Models\IntakeRequest;
 use App\Models\Membership;
 use App\Models\Organisation;
 use App\Models\Party;
 use App\Models\Program;
+use App\Models\RestrictedAccessGrant;
 use App\Models\ServiceCase;
 use App\Models\User;
 use Carbon\CarbonImmutable;
@@ -56,12 +63,18 @@ class BuildRequestToOutcomeScenario
         private readonly RecordCaseInteraction $recordInteraction,
         private readonly SaveCaseNote $saveNote,
         private readonly FinalizeCaseNote $finalizeNote,
+        private readonly GrantRestrictedAccess $grantRestrictedAccess,
+        private readonly ReclassifyServiceCase $reclassifyCase,
+        private readonly RecordCaseRiskAssessment $recordRisk,
+        private readonly StoreSafeContactInstruction $storeSafeContact,
     ) {}
 
     public function handle(Organisation $organisation, Program $program, Party $party, User $manager, Membership $workerMembership): ServiceCase
     {
         $existing = IntakeRequest::query()->where('idempotency_key', 'scenario-request-to-outcome-v1')->first();
         if ($existing?->serviceCase !== null) {
+            $this->ensureConfidentialityFixture($existing->serviceCase, $party, $manager, $workerMembership);
+
             return $existing->serviceCase;
         }
 
@@ -92,6 +105,7 @@ class BuildRequestToOutcomeScenario
             ]);
             $this->transitionIntake->handle($intake->refresh(), IntakeStatus::Accepted, 3, $manager, worker: $workerMembership);
             $case = $intake->refresh()->serviceCase()->firstOrFail();
+            $this->ensureConfidentialityFixture($case, $party, $manager, $workerMembership);
 
             Date::setTestNow($this->at('2026-06-03 09:00'));
             $this->transitionCase->handle($case, ServiceCaseStatus::Active, 1, now(), $manager);
@@ -138,5 +152,47 @@ class BuildRequestToOutcomeScenario
     private function at(string $localTime): CarbonImmutable
     {
         return CarbonImmutable::parse($localTime, 'Africa/Johannesburg')->utc();
+    }
+
+    private function ensureConfidentialityFixture(ServiceCase $case, Party $party, User $manager, Membership $workerMembership): void
+    {
+        $managerMembership = $manager->organisationMembership($case->organisation);
+        if ($managerMembership === null) {
+            throw new \LogicException('The demo Program manager requires an Organisation Membership.');
+        }
+
+        foreach ([
+            [$managerMembership, RestrictedAccessPermission::SensitiveData, $case->id, 'Synthetic safeguarding access.'],
+            [$workerMembership, RestrictedAccessPermission::SensitiveData, $case->id, 'Assigned worker safeguarding access.'],
+            [$managerMembership, RestrictedAccessPermission::IdentifiableCaseExport, null, 'Synthetic Program export fixture.'],
+        ] as [$membership, $permission, $serviceCaseId, $reason]) {
+            $exists = RestrictedAccessGrant::query()
+                ->active()
+                ->where('membership_id', $membership->id)
+                ->where('program_id', $case->program_id)
+                ->where('permission', $permission)
+                ->where('service_case_id', $serviceCaseId)
+                ->exists();
+
+            if (! $exists) {
+                $this->grantRestrictedAccess->handle($case, $membership, $permission, $reason, $manager);
+            }
+        }
+
+        if ($case->confidentiality !== CaseClassification::HighlyRestricted) {
+            $this->reclassifyCase->handle($case, CaseClassification::HighlyRestricted, 'Synthetic detailed risk fixture.', $manager);
+        }
+
+        if (! $case->riskAssessments()->exists()) {
+            $this->recordRisk->handle($case->refresh(), 'Synthetic non-graphic risk assessment for authorization testing.', $manager);
+        }
+
+        if (! $party->safeContactInstructions()->whereNull('ended_at')->exists()) {
+            $this->storeSafeContact->handle($party, [
+                'instruction' => 'Do not leave voicemail.',
+                'source' => 'synthetic_client_preference',
+                'effective_at' => now()->toAtomString(),
+            ], $manager);
+        }
     }
 }

--- a/app/Actions/Intake/TransitionIntakeRequest.php
+++ b/app/Actions/Intake/TransitionIntakeRequest.php
@@ -5,6 +5,7 @@ namespace App\Actions\Intake;
 use App\Actions\CaseDelivery\RecordCaseMetric;
 use App\Actions\CaseDelivery\RecordCaseWorkflowTransition;
 use App\Actions\Parties\RecordPartyConsent;
+use App\Enums\CaseClassification;
 use App\Enums\CaseMetricCode;
 use App\Enums\CaseWorkflowSubject;
 use App\Enums\ConsentDecision;
@@ -96,7 +97,9 @@ class TransitionIntakeRequest
                         'program_id' => $locked->program_id,
                         'party_id' => $locked->party_id,
                         'status' => ServiceCaseStatus::Open,
-                        'confidentiality' => 'confidential',
+                        'confidentiality' => CaseClassification::tryFrom(
+                            (string) data_get($locked->program->configuration, 'case_default_classification', ''),
+                        ) ?? CaseClassification::Confidential,
                         'opened_at' => now(),
                         'created_by_user_id' => $actor->id,
                     ],

--- a/app/Authorization/CaseAccess.php
+++ b/app/Authorization/CaseAccess.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace App\Authorization;
+
+use App\Enums\CaseClassification;
+use App\Enums\OrganisationRole;
+use App\Enums\RestrictedAccessPermission;
+use App\Models\Membership;
+use App\Models\Program;
+use App\Models\RestrictedAccessGrant;
+use App\Models\ServiceCase;
+use App\Models\User;
+
+class CaseAccess
+{
+    public function canView(User $user, ServiceCase $case): bool
+    {
+        if (! $this->canViewConfidential($user, $case)) {
+            return false;
+        }
+
+        return $case->confidentiality === CaseClassification::Confidential
+            || $this->hasGrant($user, $case, RestrictedAccessPermission::SensitiveData);
+    }
+
+    public function canViewConfidential(User $user, ServiceCase $case): bool
+    {
+        if ($user->hasOrganisationRole($case->organisation, OrganisationRole::ProgramManager, $case->program)
+            && $user->hasProgramAccess($case->program)) {
+            return true;
+        }
+
+        $membership = $this->membership($user, $case);
+
+        return $membership !== null
+            && $user->hasOrganisationRole($case->organisation, OrganisationRole::CaseWorker, $case->program)
+            && $user->hasProgramAccess($case->program)
+            && $case->assignments()->where('membership_id', $membership->id)->where('status', 'active')->exists();
+    }
+
+    public function canViewSensitive(User $user, ServiceCase $case): bool
+    {
+        return $this->canViewConfidential($user, $case)
+            && $this->hasGrant($user, $case, RestrictedAccessPermission::SensitiveData);
+    }
+
+    public function canManageAccess(User $user, ServiceCase $case): bool
+    {
+        return $this->canManageProgram($user, $case->program);
+    }
+
+    public function canManageProgram(User $user, Program $program): bool
+    {
+        return $user->hasOrganisationRole($program->organisation, OrganisationRole::ProgramManager, $program)
+            && $user->hasProgramAccess($program);
+    }
+
+    public function canExport(User $user, ServiceCase $case): bool
+    {
+        return $this->canManageAccess($user, $case)
+            && $this->hasGrant($user, $case, RestrictedAccessPermission::IdentifiableCaseExport);
+    }
+
+    public function canExportProgram(User $user, Program $program): bool
+    {
+        $membership = $user->organisationMembership($program->organisation);
+
+        return $membership !== null
+            && ! $membership->isHeld()
+            && $user->hasOrganisationRole($program->organisation, OrganisationRole::ProgramManager, $program)
+            && $user->hasProgramAccess($program)
+            && RestrictedAccessGrant::query()
+                ->active()
+                ->where('membership_id', $membership->id)
+                ->where('program_id', $program->id)
+                ->whereNull('service_case_id')
+                ->where('permission', RestrictedAccessPermission::IdentifiableCaseExport)
+                ->exists();
+    }
+
+    public function hasGrant(User $user, ServiceCase $case, RestrictedAccessPermission $permission): bool
+    {
+        $membership = $this->membership($user, $case);
+
+        if ($membership === null) {
+            return false;
+        }
+
+        return RestrictedAccessGrant::query()
+            ->active()
+            ->where('membership_id', $membership->id)
+            ->where('program_id', $case->program_id)
+            ->where('permission', $permission)
+            ->when(
+                $permission === RestrictedAccessPermission::SensitiveData,
+                fn ($query) => $query->where('service_case_id', $case->id),
+                fn ($query) => $query->whereNull('service_case_id'),
+            )
+            ->exists();
+    }
+
+    private function membership(User $user, ServiceCase $case): ?Membership
+    {
+        $membership = $user->organisationMembership($case->organisation);
+
+        return $membership !== null && ! $membership->isHeld() ? $membership : null;
+    }
+}

--- a/app/Data/Demo/ScenarioCatalog.php
+++ b/app/Data/Demo/ScenarioCatalog.php
@@ -9,7 +9,7 @@ use InvalidArgumentException;
 
 final class ScenarioCatalog
 {
-    public const VERSION = '2026.3';
+    public const VERSION = '2026.4';
 
     public const AS_OF = '2026-06-30 23:59:59';
 

--- a/app/Enums/CaseClassification.php
+++ b/app/Enums/CaseClassification.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Enums;
+
+enum CaseClassification: string
+{
+    case Confidential = 'confidential';
+    case HighlyRestricted = 'highly_restricted';
+
+    public function isAtLeast(self $classification): bool
+    {
+        return $this->rank() >= $classification->rank();
+    }
+
+    private function rank(): int
+    {
+        return match ($this) {
+            self::Confidential => 1,
+            self::HighlyRestricted => 2,
+        };
+    }
+}

--- a/app/Enums/RestrictedAccessPermission.php
+++ b/app/Enums/RestrictedAccessPermission.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum RestrictedAccessPermission: string
+{
+    case SensitiveData = 'sensitive_data';
+    case IdentifiableCaseExport = 'identifiable_case_export';
+}

--- a/app/Enums/TenantAuditEventType.php
+++ b/app/Enums/TenantAuditEventType.php
@@ -6,6 +6,13 @@ enum TenantAuditEventType: string
 {
     case ProgramUpdated = 'program_updated';
     case CaseAssigned = 'case_assigned';
+    case CaseViewed = 'case_viewed';
+    case RestrictedCaseViewed = 'restricted_case_viewed';
+    case CaseReclassified = 'case_reclassified';
+    case CaseRiskRecorded = 'case_risk_recorded';
+    case RestrictedAccessGranted = 'restricted_access_granted';
+    case RestrictedAccessRevoked = 'restricted_access_revoked';
+    case IdentifiableCaseExported = 'identifiable_case_exported';
 
     /** @return array<string, string> */
     public function payloadSchema(): array
@@ -18,6 +25,35 @@ enum TenantAuditEventType: string
             self::CaseAssigned => [
                 'case_id' => 'string',
                 'membership_id' => 'integer',
+            ],
+            self::CaseViewed, self::RestrictedCaseViewed => [
+                'case_id' => 'string',
+                'classification' => 'string',
+            ],
+            self::CaseReclassified => [
+                'case_id' => 'string',
+                'from' => 'string',
+                'to' => 'string',
+                'reason' => 'string',
+            ],
+            self::CaseRiskRecorded => [
+                'case_id' => 'string',
+                'classification' => 'string',
+            ],
+            self::RestrictedAccessGranted => [
+                'case_id' => 'nullable_string',
+                'membership_id' => 'integer',
+                'program_id' => 'integer',
+                'permission' => 'string',
+                'reason' => 'string',
+            ],
+            self::RestrictedAccessRevoked => [
+                'grant_id' => 'string',
+                'reason' => 'string',
+            ],
+            self::IdentifiableCaseExported => [
+                'program_id' => 'integer',
+                'record_count' => 'integer',
             ],
         };
     }

--- a/app/Http/Controllers/Organisations/CaseConfidentialityController.php
+++ b/app/Http/Controllers/Organisations/CaseConfidentialityController.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\CaseConfidentiality\GrantRestrictedAccess;
+use App\Actions\CaseConfidentiality\ReclassifyServiceCase;
+use App\Actions\CaseConfidentiality\RecordCaseRiskAssessment;
+use App\Actions\CaseConfidentiality\RevokeRestrictedAccess;
+use App\Enums\CaseClassification;
+use App\Enums\RestrictedAccessPermission;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\ReclassifyServiceCaseRequest;
+use App\Http\Requests\Organisations\StoreRestrictedAccessGrantRequest;
+use App\Models\Membership;
+use App\Models\Organisation;
+use App\Models\RestrictedAccessGrant;
+use App\Models\ServiceCase;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+use LogicException;
+
+class CaseConfidentialityController extends Controller
+{
+    public function reclassify(
+        ReclassifyServiceCaseRequest $request,
+        Organisation $currentOrganisation,
+        string $case,
+        ReclassifyServiceCase $reclassify,
+    ): RedirectResponse {
+        $serviceCase = ServiceCase::query()->findOrFail($case);
+        Gate::authorize('manageAccess', $serviceCase);
+
+        try {
+            $reclassify->handle(
+                $serviceCase,
+                CaseClassification::from($request->string('classification')->toString()),
+                $request->string('reason')->toString(),
+                $request->user(),
+            );
+        } catch (LogicException $exception) {
+            throw ValidationException::withMessages(['classification' => $exception->getMessage()]);
+        }
+
+        return back();
+    }
+
+    public function grant(
+        StoreRestrictedAccessGrantRequest $request,
+        Organisation $currentOrganisation,
+        string $case,
+        GrantRestrictedAccess $grantAccess,
+    ): RedirectResponse {
+        $serviceCase = ServiceCase::query()->findOrFail($case);
+        Gate::authorize('manageAccess', $serviceCase);
+        $membership = Membership::query()
+            ->where('organisation_id', $currentOrganisation->id)
+            ->whereKey($request->integer('membership_id'))
+            ->firstOrFail();
+
+        try {
+            $grantAccess->handle(
+                $serviceCase,
+                $membership,
+                RestrictedAccessPermission::from($request->string('permission')->toString()),
+                $request->string('reason')->toString(),
+                $request->user(),
+                $request->filled('expires_at') ? CarbonImmutable::parse($request->string('expires_at')->toString()) : null,
+            );
+        } catch (LogicException $exception) {
+            throw ValidationException::withMessages(['membership_id' => $exception->getMessage()]);
+        }
+
+        return back();
+    }
+
+    public function risk(
+        Request $request,
+        Organisation $currentOrganisation,
+        string $case,
+        RecordCaseRiskAssessment $recordRisk,
+    ): RedirectResponse {
+        $validated = $request->validate(['content' => ['required', 'string', 'max:10000']]);
+        $serviceCase = ServiceCase::query()->findOrFail($case);
+        Gate::authorize('viewSensitive', $serviceCase);
+        $recordRisk->handle($serviceCase, $validated['content'], $request->user());
+
+        return back();
+    }
+
+    public function revoke(
+        Request $request,
+        Organisation $currentOrganisation,
+        string $case,
+        string $grant,
+        RevokeRestrictedAccess $revokeAccess,
+    ): RedirectResponse {
+        $validated = $request->validate(['reason' => ['required', 'string', 'max:255']]);
+        $serviceCase = ServiceCase::query()->findOrFail($case);
+        Gate::authorize('manageAccess', $serviceCase);
+        $accessGrant = RestrictedAccessGrant::query()
+            ->whereKey($grant)
+            ->where(fn ($query) => $query->where('service_case_id', $serviceCase->id)->orWhere(function ($export) use ($serviceCase): void {
+                $export->whereNull('service_case_id')->where('program_id', $serviceCase->program_id);
+            }))
+            ->firstOrFail();
+        $revokeAccess->handle($accessGrant, $validated['reason'], $request->user());
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Organisations/CaseExportController.php
+++ b/app/Http/Controllers/Organisations/CaseExportController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\CaseConfidentiality\ExportIdentifiableCases;
+use App\Http\Controllers\Controller;
+use App\Models\Organisation;
+use App\Models\Program;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Validation\ValidationException;
+use LogicException;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class CaseExportController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(
+        Request $request,
+        Organisation $currentOrganisation,
+        string $program,
+        ExportIdentifiableCases $export,
+    ): StreamedResponse {
+        $program = Program::query()->findOrFail($program);
+        abort_unless($program->organisation_id === $currentOrganisation->id, Response::HTTP_NOT_FOUND);
+
+        try {
+            $contents = $export->handle($program, $request->user());
+        } catch (LogicException $exception) {
+            throw ValidationException::withMessages(['export' => $exception->getMessage()]);
+        }
+
+        return response()->streamDownload(
+            fn () => print $contents,
+            "program-{$program->id}-cases.csv",
+            ['Content-Type' => 'text/csv; charset=UTF-8'],
+        );
+    }
+}

--- a/app/Http/Controllers/Organisations/PartyController.php
+++ b/app/Http/Controllers/Organisations/PartyController.php
@@ -15,11 +15,13 @@ use App\Models\Organisation;
 use App\Models\Party;
 use App\Models\PartyContactPoint;
 use App\Models\PartyRole;
+use App\Models\Program;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -29,27 +31,39 @@ class PartyController extends Controller
     {
         Gate::authorize('viewAny', [Party::class, $currentOrganisation]);
         $request->validate(['query' => ['nullable', 'string', 'max:100']]);
+        $user = $request->user();
+        $canSearchNames = ! $user->hasOrganisationRole($currentOrganisation, OrganisationRole::OrganisationAdministrator);
+        $canCreate = Gate::allows('create', [Party::class, $currentOrganisation]);
         $parties = $this->visibleParties($request->user(), $currentOrganisation)
             ->with(['businessRoles', 'programs:id,name,slug'])
-            ->when($request->string('query')->isNotEmpty(), fn (Builder $query) => $query
+            ->when($canSearchNames && $request->string('query')->isNotEmpty(), fn (Builder $query) => $query
                 ->where('display_name', 'like', '%'.$request->string('query')->toString().'%'))
             ->orderBy('display_name')
             ->orderBy('id')
             ->paginate(25)
             ->withQueryString()
-            ->through(fn (Party $party): array => [
-                'uuid' => $party->uuid,
-                'kind' => $party->kind->value,
-                'displayName' => $party->display_name,
-                'roles' => $party->businessRoles->map(fn (PartyRole $role): string => $role->role->label())->values(),
-                'programs' => $party->programs->pluck('name')->values(),
-            ]);
+            ->through(function (Party $party) use ($user): array {
+                $supporterSafe = Gate::allows('supporterSafe', $party);
+                $administrativeMetadata = $user->hasOrganisationRole($party->organisation, OrganisationRole::OrganisationAdministrator);
+
+                return [
+                    'uuid' => $party->uuid,
+                    'kind' => $party->kind->value,
+                    'displayName' => $administrativeMetadata ? 'Administrative Party record' : $party->display_name,
+                    'roles' => $administrativeMetadata
+                        ? []
+                        : $party->businessRoles
+                            ->reject(fn (PartyRole $role): bool => $supporterSafe && $role->role === PartyBusinessRole::Client)
+                            ->map(fn (PartyRole $role): string => $role->role->label())->values(),
+                    'programs' => $supporterSafe || $administrativeMetadata ? [] : $party->programs->pluck('name')->values(),
+                ];
+            });
 
         return Inertia::render('parties/index', [
             'parties' => $parties,
             'query' => $request->string('query')->toString(),
-            'canCreate' => Gate::allows('create', [Party::class, $currentOrganisation]),
-            ...$this->formOptions($currentOrganisation),
+            'canCreate' => $canCreate,
+            ...($canCreate ? $this->formOptions($currentOrganisation, $user) : $this->emptyFormOptions()),
         ]);
     }
 
@@ -59,9 +73,11 @@ class PartyController extends Controller
         CreatePartyProfile $createPartyProfile,
     ): RedirectResponse {
         Gate::authorize('create', [Party::class, $currentOrganisation]);
+        $attributes = $this->profileAttributes($request);
+        $this->ensureProgramScope($request->user(), $currentOrganisation, $attributes['program_ids']);
         $party = $createPartyProfile->handle(
             $currentOrganisation,
-            $this->profileAttributes($request),
+            $attributes,
             $request->user(),
         );
 
@@ -72,6 +88,9 @@ class PartyController extends Controller
     {
         $party = $this->findParty($party);
         Gate::authorize('view', $party);
+        $supporterSafe = Gate::allows('supporterSafe', $party);
+        $administrativeMetadata = $request->user()->hasOrganisationRole($party->organisation, OrganisationRole::OrganisationAdministrator);
+        $serviceProjection = ! $supporterSafe && ! $administrativeMetadata;
         $party->load([
             'addresses',
             'businessRoles',
@@ -83,6 +102,7 @@ class PartyController extends Controller
             'timelineEvents' => fn ($query) => $query->latest('occurred_at')->latest('id')->limit(100),
         ]);
         $canManageSafeContact = Gate::allows('manageSafeContact', $party);
+        $canUpdate = Gate::allows('update', $party);
 
         if ($canManageSafeContact) {
             $party->load(['safeContactInstructions' => fn ($query) => $query->latest('effective_at')]);
@@ -92,20 +112,22 @@ class PartyController extends Controller
             'party' => [
                 'uuid' => $party->uuid,
                 'kind' => $party->kind->value,
-                'displayName' => $party->display_name,
-                'email' => $this->contactValue($party, PartyContactType::Email),
-                'telephone' => $this->contactValue($party, PartyContactType::Telephone),
-                'programIds' => $party->programs->modelKeys(),
-                'roles' => $party->businessRoles->pluck('role')->map->value->values(),
-                'interests' => $party->interests->pluck('label')->values(),
-                'addresses' => $party->addresses->map(fn ($address): array => [
+                'displayName' => $administrativeMetadata ? 'Administrative Party record' : $party->display_name,
+                'email' => $administrativeMetadata ? null : $this->contactValue($party, PartyContactType::Email),
+                'telephone' => $administrativeMetadata ? null : $this->contactValue($party, PartyContactType::Telephone),
+                'programIds' => $serviceProjection ? $party->programs->modelKeys() : [],
+                'roles' => $administrativeMetadata ? [] : $party->businessRoles->pluck('role')
+                    ->reject(fn (PartyBusinessRole $role): bool => $supporterSafe && $role === PartyBusinessRole::Client)
+                    ->map->value->values(),
+                'interests' => $serviceProjection ? $party->interests->pluck('label')->values() : [],
+                'addresses' => $serviceProjection ? $party->addresses->map(fn ($address): array => [
                     'id' => $address->id,
                     'label' => $address->label,
                     'address' => $address->encrypted_value->reveal(),
                     'serviceArea' => $address->service_area,
                     'countryCode' => $address->country_code,
-                ])->values(),
-                'relationships' => $party->relationships->map(fn ($relationship): array => [
+                ])->values() : [],
+                'relationships' => $serviceProjection ? $party->relationships->map(fn ($relationship): array => [
                     'id' => $relationship->id,
                     'type' => $relationship->type,
                     'relatedParty' => [
@@ -114,8 +136,8 @@ class PartyController extends Controller
                     ],
                     'startedAt' => $relationship->started_at?->toAtomString(),
                     'endedAt' => $relationship->ended_at?->toAtomString(),
-                ])->values(),
-                'consents' => $party->consents->map(fn ($consent): array => [
+                ])->values() : [],
+                'consents' => $serviceProjection ? $party->consents->map(fn ($consent): array => [
                     'id' => $consent->id,
                     'purpose' => $consent->purpose->value,
                     'decision' => $consent->decision->value,
@@ -124,7 +146,7 @@ class PartyController extends Controller
                     'source' => $consent->source,
                     'occurredAt' => $consent->occurred_at->toAtomString(),
                     'supersedesId' => $consent->supersedes_id,
-                ])->values(),
+                ])->values() : [],
                 'safeContactInstructions' => $canManageSafeContact
                     ? $party->safeContactInstructions->map(fn ($instruction): array => [
                         'id' => $instruction->id,
@@ -134,17 +156,19 @@ class PartyController extends Controller
                         'endedAt' => $instruction->ended_at?->toAtomString(),
                     ])->values()
                     : [],
-                'timeline' => $party->timelineEvents->map(fn ($event): array => [
+                'timeline' => $serviceProjection ? $party->timelineEvents->map(fn ($event): array => [
                     'id' => $event->id,
                     'type' => $event->type->value,
                     'summary' => $event->summary,
                     'occurredAt' => $event->occurred_at->toAtomString(),
-                ])->values(),
+                ])->values() : [],
+                'supporterSafe' => $supporterSafe,
+                'administrativeMetadata' => $administrativeMetadata,
             ],
-            'canUpdate' => Gate::allows('update', $party),
+            'canUpdate' => $canUpdate,
             'canRecordConsent' => Gate::allows('recordConsent', $party),
             'canManageSafeContact' => $canManageSafeContact,
-            'relationshipCandidates' => Party::query()
+            'relationshipCandidates' => $serviceProjection ? $this->visibleParties($request->user(), $currentOrganisation)
                 ->whereKeyNot($party->id)
                 ->orderBy('display_name')
                 ->limit(100)
@@ -153,8 +177,8 @@ class PartyController extends Controller
                     'id' => $candidate->id,
                     'uuid' => $candidate->uuid,
                     'displayName' => $candidate->display_name,
-                ]),
-            ...$this->formOptions($currentOrganisation),
+                ]) : [],
+            ...($canUpdate ? $this->formOptions($currentOrganisation, $request->user()) : $this->emptyFormOptions()),
         ]);
     }
 
@@ -166,7 +190,9 @@ class PartyController extends Controller
     ): RedirectResponse {
         $party = $this->findParty($party);
         Gate::authorize('update', $party);
-        $updatePartyProfile->handle($party, $this->profileAttributes($request), $request->user());
+        $attributes = $this->profileAttributes($request);
+        $this->ensureProgramScope($request->user(), $currentOrganisation, $attributes['program_ids']);
+        $updatePartyProfile->handle($party, $attributes, $request->user());
 
         return back();
     }
@@ -188,10 +214,10 @@ class PartyController extends Controller
     }
 
     /** @return array{programs: mixed, partyKinds: list<array{value: string, label: string}>, partyRoles: list<array{value: string, label: string}>} */
-    private function formOptions(Organisation $organisation): array
+    private function formOptions(Organisation $organisation, User $user): array
     {
         return [
-            'programs' => $organisation->programs()->orderBy('name')->get(['id', 'name', 'slug']),
+            'programs' => $this->managedPrograms($organisation, $user)->orderBy('name')->get(['id', 'name', 'slug']),
             'partyKinds' => array_values(collect(PartyKind::cases())->map(fn (PartyKind $kind): array => [
                 'value' => $kind->value,
                 'label' => ucfirst($kind->value),
@@ -201,6 +227,39 @@ class PartyController extends Controller
                 'label' => $role->label(),
             ])->all()),
         ];
+    }
+
+    /** @return array{programs: array<never>, partyKinds: array<never>, partyRoles: array<never>} */
+    private function emptyFormOptions(): array
+    {
+        return ['programs' => [], 'partyKinds' => [], 'partyRoles' => []];
+    }
+
+    /** @param list<int> $programIds */
+    private function ensureProgramScope(User $user, Organisation $organisation, array $programIds): void
+    {
+        if ($programIds === []) {
+            throw ValidationException::withMessages(['program_ids' => 'A Program-managed Party must belong to at least one Program.']);
+        }
+
+        $allowedIds = $this->managedPrograms($organisation, $user)->pluck('id');
+        if (collect($programIds)->diff($allowedIds)->isNotEmpty()) {
+            throw ValidationException::withMessages(['program_ids' => 'You may only manage Parties in your assigned Programs.']);
+        }
+    }
+
+    /** @return Builder<Program> */
+    private function managedPrograms(Organisation $organisation, User $user): Builder
+    {
+        $membership = $user->organisationMembership($organisation);
+        $programIds = $membership?->roleAssignments()
+            ->whereNull('ended_at')
+            ->where('role', OrganisationRole::ProgramManager)
+            ->pluck('program_id');
+
+        return Program::query()
+            ->where('organisation_id', $organisation->id)
+            ->when(! $programIds?->contains(null), fn (Builder $query) => $query->whereKey($programIds ?? []));
     }
 
     private function contactValue(Party $party, PartyContactType $type): ?string
@@ -224,6 +283,11 @@ class PartyController extends Controller
             return Party::query();
         }
 
+        if ($this->hasRoleInAnyScope($user, $organisation, OrganisationRole::EngagementOfficer)) {
+            return Party::query()->whereHas('businessRoles', fn (Builder $query) => $query
+                ->whereIn('role', ['donor', 'volunteer', 'partner_contact', 'event_attendee']));
+        }
+
         $membership = $user->organisationMembership($organisation);
         $programIds = $membership?->roleAssignments()
             ->whereNull('ended_at')
@@ -234,6 +298,25 @@ class PartyController extends Controller
             return Party::query();
         }
 
-        return Party::query()->whereHas('programs', fn (Builder $query) => $query->whereKey($programIds ?? []));
+        $membershipId = $membership?->id;
+
+        return Party::query()->where(function (Builder $query) use ($programIds, $membershipId): void {
+            $query->whereHas('programs', fn (Builder $programs) => $programs->whereKey($programIds ?? []));
+
+            if ($membershipId !== null) {
+                $query->orWhereHas('serviceCases.assignments', fn (Builder $assignments) => $assignments
+                    ->where('membership_id', $membershipId)
+                    ->where('status', 'active'));
+            }
+        });
+    }
+
+    private function hasRoleInAnyScope(User $user, Organisation $organisation, OrganisationRole $role): bool
+    {
+        $membership = $user->organisationMembership($organisation);
+
+        return $membership !== null
+            && ! $membership->isHeld()
+            && $membership->roleAssignments()->whereNull('ended_at')->where('role', $role)->exists();
     }
 }

--- a/app/Http/Controllers/Organisations/ServiceCaseController.php
+++ b/app/Http/Controllers/Organisations/ServiceCaseController.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Controllers\Organisations;
 
+use App\Actions\Auditing\RecordTenantAuditEvent;
 use App\Actions\CaseDelivery\TransitionServiceCase;
 use App\Data\Values\ClassifiedValue;
 use App\Enums\ServiceCaseStatus;
+use App\Enums\TenantAuditEventType;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Organisations\TransitionServiceCaseRequest;
 use App\Models\CaseAppointment;
@@ -27,15 +29,39 @@ use LogicException;
 
 class ServiceCaseController extends Controller
 {
-    public function show(Request $request, Organisation $currentOrganisation, string $case): Response
-    {
+    public function show(
+        Request $request,
+        Organisation $currentOrganisation,
+        string $case,
+        RecordTenantAuditEvent $recordAudit,
+    ): Response {
         $serviceCase = ServiceCase::query()->findOrFail($case);
         Gate::authorize('view', $serviceCase);
+        $canViewSensitive = Gate::allows('viewSensitive', $serviceCase);
+        $recordAudit->handle($serviceCase->organisation, TenantAuditEventType::CaseViewed, 'service_case', $serviceCase->id, [
+            'case_id' => $serviceCase->id,
+            'classification' => $serviceCase->confidentiality->value,
+        ], $request->user());
+
+        if ($canViewSensitive) {
+            $recordAudit->handle($serviceCase->organisation, TenantAuditEventType::RestrictedCaseViewed, 'service_case', $serviceCase->id, [
+                'case_id' => $serviceCase->id,
+                'classification' => $serviceCase->confidentiality->value,
+            ], $request->user());
+        }
+
         $serviceCase->load([
             'party:id,uuid,display_name', 'program:id,organisation_id,name,configuration', 'intakeRequest:id',
             'assignments.membership.user:id,name', 'goals', 'services', 'referrals', 'tasks', 'appointments',
             'interactions', 'notes', 'outcome', 'workflowTransitions' => fn ($query) => $query->orderByDesc('recorded_at'),
         ]);
+
+        if ($canViewSensitive) {
+            $serviceCase->load([
+                'riskAssessments' => fn ($query) => $query->whereNull('ended_at')->latest('effective_at'),
+                'party.safeContactInstructions' => fn ($query) => $query->whereNull('ended_at')->latest('effective_at'),
+            ]);
+        }
 
         return Inertia::render('cases/show', [
             'caseRecord' => [
@@ -60,8 +86,21 @@ class ServiceCaseController extends Controller
                 'notes' => $serviceCase->notes->map(fn (CaseNote $note): array => ['id' => $note->id, 'status' => $note->status->value, 'version' => $note->version, 'content' => $note->encrypted_content->reveal(), 'correctsNoteId' => $note->corrects_note_id, 'finalizedAt' => $note->finalized_at?->toAtomString()]),
                 'outcome' => $serviceCase->outcome === null ? null : ['measures' => $serviceCase->outcome->measures, 'narrative' => $serviceCase->outcome->encrypted_content->reveal(), 'effectiveAt' => $serviceCase->outcome->effective_at->toAtomString()],
                 'transitions' => $serviceCase->workflowTransitions->map(fn ($transition): array => ['id' => $transition->id, 'subjectType' => $transition->subject_type->value, 'from' => $transition->from_status, 'to' => $transition->to_status, 'reason' => $transition->reason, 'effectiveAt' => $transition->effective_at->toAtomString(), 'version' => $transition->version]),
+                'safeContactBanner' => $canViewSensitive
+                    ? $serviceCase->party->safeContactInstructions->first()?->encrypted_value->reveal()
+                    : null,
+                'riskAssessments' => $canViewSensitive
+                    ? $serviceCase->riskAssessments->map(fn ($risk): array => [
+                        'id' => $risk->id,
+                        'content' => $risk->encrypted_content->reveal(),
+                        'classification' => $risk->classification->value,
+                        'effectiveAt' => $risk->effective_at->toAtomString(),
+                    ])->values()
+                    : [],
             ],
             'canUpdate' => Gate::allows('update', $serviceCase),
+            'canManageAccess' => Gate::allows('manageAccess', $serviceCase),
+            'canViewSensitive' => $canViewSensitive,
         ]);
     }
 

--- a/app/Http/Requests/Organisations/ReclassifyServiceCaseRequest.php
+++ b/app/Http/Requests/Organisations/ReclassifyServiceCaseRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Enums\CaseClassification;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class ReclassifyServiceCaseRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'classification' => ['required', Rule::enum(CaseClassification::class)],
+            'reason' => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/app/Http/Requests/Organisations/StoreRestrictedAccessGrantRequest.php
+++ b/app/Http/Requests/Organisations/StoreRestrictedAccessGrantRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Enums\RestrictedAccessPermission;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreRestrictedAccessGrantRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'membership_id' => ['required', 'integer'],
+            'permission' => ['required', Rule::enum(RestrictedAccessPermission::class)],
+            'reason' => ['required', 'string', 'max:255'],
+            'expires_at' => ['nullable', 'date', 'after:now'],
+        ];
+    }
+}

--- a/app/Models/CaseRiskAssessment.php
+++ b/app/Models/CaseRiskAssessment.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Models;
+
+use App\Casts\ClassifiedValueCast;
+use App\Concerns\BelongsToOrganisation;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseClassification;
+use Database\Factories\CaseRiskAssessmentFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property string $service_case_id
+ * @property CaseClassification $classification
+ * @property ClassifiedValue $encrypted_content
+ * @property Carbon $effective_at
+ * @property Carbon|null $ended_at
+ */
+class CaseRiskAssessment extends Model
+{
+    /** @use HasFactory<CaseRiskAssessmentFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected $guarded = ['organisation_id'];
+
+    /** @return BelongsTo<ServiceCase, $this> */
+    public function serviceCase(): BelongsTo
+    {
+        return $this->belongsTo(ServiceCase::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'classification' => CaseClassification::class,
+            'encrypted_content' => ClassifiedValueCast::class.':case_risk_assessment',
+            'effective_at' => 'datetime',
+            'ended_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/Party.php
+++ b/app/Models/Party.php
@@ -106,6 +106,12 @@ class Party extends Model
         return $this->hasMany(PartyTimelineEvent::class);
     }
 
+    /** @return HasMany<ServiceCase, $this> */
+    public function serviceCases(): HasMany
+    {
+        return $this->hasMany(ServiceCase::class);
+    }
+
     /** @return array<string, string> */
     protected function casts(): array
     {

--- a/app/Models/RestrictedAccessGrant.php
+++ b/app/Models/RestrictedAccessGrant.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\RestrictedAccessPermission;
+use Database\Factories\RestrictedAccessGrantFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $membership_id
+ * @property int $program_id
+ * @property string|null $service_case_id
+ * @property RestrictedAccessPermission $permission
+ * @property Carbon $granted_at
+ * @property Carbon|null $expires_at
+ */
+class RestrictedAccessGrant extends Model
+{
+    /** @use HasFactory<RestrictedAccessGrantFactory> */
+    use BelongsToOrganisation, HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Restricted access grants are append-only.'));
+        static::deleting(fn () => throw new LogicException('Restricted access grants are append-only.'));
+    }
+
+    /** @return BelongsTo<Membership, $this> */
+    public function membership(): BelongsTo
+    {
+        return $this->belongsTo(Membership::class);
+    }
+
+    /** @return BelongsTo<Program, $this> */
+    public function program(): BelongsTo
+    {
+        return $this->belongsTo(Program::class);
+    }
+
+    /** @return BelongsTo<ServiceCase, $this> */
+    public function serviceCase(): BelongsTo
+    {
+        return $this->belongsTo(ServiceCase::class);
+    }
+
+    /** @param Builder<self> $query */
+    public function scopeActive(Builder $query): void
+    {
+        $query->whereDoesntHave('revocation')
+            ->where(fn (Builder $active) => $active->whereNull('expires_at')->orWhere('expires_at', '>', now()));
+    }
+
+    /** @return HasOne<RestrictedAccessRevocation, $this> */
+    public function revocation(): HasOne
+    {
+        return $this->hasOne(RestrictedAccessRevocation::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'permission' => RestrictedAccessPermission::class,
+            'granted_at' => 'datetime',
+            'expires_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/RestrictedAccessRevocation.php
+++ b/app/Models/RestrictedAccessRevocation.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use Database\Factories\RestrictedAccessRevocationFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property string $restricted_access_grant_id
+ * @property string $reason
+ * @property Carbon $revoked_at
+ */
+class RestrictedAccessRevocation extends Model
+{
+    /** @use HasFactory<RestrictedAccessRevocationFactory> */
+    use BelongsToOrganisation, HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Restricted access revocations are append-only.'));
+        static::deleting(fn () => throw new LogicException('Restricted access revocations are append-only.'));
+    }
+
+    /** @return BelongsTo<RestrictedAccessGrant, $this> */
+    public function grant(): BelongsTo
+    {
+        return $this->belongsTo(RestrictedAccessGrant::class, 'restricted_access_grant_id');
+    }
+
+    protected function casts(): array
+    {
+        return ['revoked_at' => 'datetime'];
+    }
+}

--- a/app/Models/ServiceCase.php
+++ b/app/Models/ServiceCase.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\BelongsToOrganisation;
+use App\Enums\CaseClassification;
 use App\Enums\ServiceCaseStatus;
 use Database\Factories\ServiceCaseFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -21,7 +22,7 @@ use Illuminate\Support\Carbon;
  * @property int $party_id
  * @property ServiceCaseStatus $status
  * @property int $version
- * @property string $confidentiality
+ * @property CaseClassification $confidentiality
  * @property Carbon $opened_at
  * @property Carbon|null $closed_at
  * @property string|null $closure_reason
@@ -123,10 +124,23 @@ class ServiceCase extends Model
         return $this->hasMany(CaseWorkflowTransition::class);
     }
 
+    /** @return HasMany<RestrictedAccessGrant, $this> */
+    public function restrictedAccessGrants(): HasMany
+    {
+        return $this->hasMany(RestrictedAccessGrant::class);
+    }
+
+    /** @return HasMany<CaseRiskAssessment, $this> */
+    public function riskAssessments(): HasMany
+    {
+        return $this->hasMany(CaseRiskAssessment::class);
+    }
+
     protected function casts(): array
     {
         return [
             'status' => ServiceCaseStatus::class,
+            'confidentiality' => CaseClassification::class,
             'opened_at' => 'datetime',
             'closed_at' => 'datetime',
             'follow_up_at' => 'datetime',

--- a/app/Policies/PartyPolicy.php
+++ b/app/Policies/PartyPolicy.php
@@ -2,20 +2,26 @@
 
 namespace App\Policies;
 
+use App\Authorization\CaseAccess;
 use App\Enums\OrganisationRole;
 use App\Models\Organisation;
 use App\Models\Party;
+use App\Models\ServiceCase;
 use App\Models\User;
 
 class PartyPolicy
 {
+    public function __construct(private readonly CaseAccess $caseAccess) {}
+
     /**
      * Determine whether the user can view any models.
      */
     public function viewAny(User $user, Organisation $organisation): bool
     {
         return $user->hasOrganisationRole($organisation, OrganisationRole::OrganisationAdministrator)
-            || $this->hasRoleInAnyScope($user, $organisation, OrganisationRole::ProgramManager);
+            || $this->hasRoleInAnyScope($user, $organisation, OrganisationRole::ProgramManager)
+            || $this->hasRoleInAnyScope($user, $organisation, OrganisationRole::CaseWorker)
+            || $this->hasRoleInAnyScope($user, $organisation, OrganisationRole::EngagementOfficer);
     }
 
     /**
@@ -31,13 +37,24 @@ class PartyPolicy
             return true;
         }
 
-        return $party->programs()
+        if ($party->programs()
             ->get()
             ->contains(fn ($program): bool => $user->hasOrganisationRole(
                 $party->organisation,
                 OrganisationRole::ProgramManager,
                 $program,
-            ));
+            ))) {
+            return true;
+        }
+
+        if ($this->supporterSafe($user, $party)) {
+            return true;
+        }
+
+        return ServiceCase::query()
+            ->where('party_id', $party->id)
+            ->get()
+            ->contains(fn (ServiceCase $case): bool => $this->caseAccess->canViewConfidential($user, $case));
     }
 
     /**
@@ -45,7 +62,7 @@ class PartyPolicy
      */
     public function create(User $user, Organisation $organisation): bool
     {
-        return $user->hasOrganisationRole($organisation, OrganisationRole::OrganisationAdministrator);
+        return $this->hasRoleInAnyScope($user, $organisation, OrganisationRole::ProgramManager);
     }
 
     /**
@@ -53,27 +70,30 @@ class PartyPolicy
      */
     public function update(User $user, Party $party): bool
     {
-        return $user->hasOrganisationRole($party->organisation, OrganisationRole::OrganisationAdministrator);
+        return $this->hasProgramManagerAccess($user, $party);
     }
 
     public function recordConsent(User $user, Party $party): bool
     {
-        return $this->view($user, $party);
+        return $this->hasProgramManagerAccess($user, $party)
+            || ServiceCase::query()
+                ->where('party_id', $party->id)
+                ->get()
+                ->contains(fn (ServiceCase $case): bool => $this->caseAccess->canViewConfidential($user, $case));
     }
 
     public function manageSafeContact(User $user, Party $party): bool
     {
-        if ($user->hasOrganisationRole($party->organisation, OrganisationRole::ProgramManager)) {
-            return true;
-        }
-
-        return $party->programs()
+        return ServiceCase::query()
+            ->where('party_id', $party->id)
             ->get()
-            ->contains(fn ($program): bool => $user->hasOrganisationRole(
-                $party->organisation,
-                OrganisationRole::ProgramManager,
-                $program,
-            ));
+            ->contains(fn (ServiceCase $case): bool => $this->caseAccess->canViewSensitive($user, $case));
+    }
+
+    public function supporterSafe(User $user, Party $party): bool
+    {
+        return $this->hasRoleInAnyScope($user, $party->organisation, OrganisationRole::EngagementOfficer)
+            && $party->businessRoles()->whereIn('role', ['donor', 'volunteer', 'partner_contact', 'event_attendee'])->exists();
     }
 
     /**
@@ -112,5 +132,18 @@ class PartyPolicy
             ->whereNull('ended_at')
             ->where('role', $role)
             ->exists();
+    }
+
+    private function hasProgramManagerAccess(User $user, Party $party): bool
+    {
+        if ($user->hasOrganisationRole($party->organisation, OrganisationRole::ProgramManager)) {
+            return true;
+        }
+
+        return $party->programs()->get()->contains(fn ($program): bool => $user->hasOrganisationRole(
+            $party->organisation,
+            OrganisationRole::ProgramManager,
+            $program,
+        ));
     }
 }

--- a/app/Policies/RestrictedAccessGrantPolicy.php
+++ b/app/Policies/RestrictedAccessGrantPolicy.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Policies;
+
+use App\Authorization\CaseAccess;
+use App\Models\RestrictedAccessGrant;
+use App\Models\User;
+
+class RestrictedAccessGrantPolicy
+{
+    public function __construct(private readonly CaseAccess $access) {}
+
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, RestrictedAccessGrant $restrictedAccessGrant): bool
+    {
+        return $restrictedAccessGrant->serviceCase !== null
+            && $this->access->canManageAccess($user, $restrictedAccessGrant->serviceCase);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, RestrictedAccessGrant $restrictedAccessGrant): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, RestrictedAccessGrant $restrictedAccessGrant): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, RestrictedAccessGrant $restrictedAccessGrant): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, RestrictedAccessGrant $restrictedAccessGrant): bool
+    {
+        return false;
+    }
+}

--- a/app/Policies/ServiceCasePolicy.php
+++ b/app/Policies/ServiceCasePolicy.php
@@ -2,25 +2,17 @@
 
 namespace App\Policies;
 
-use App\Enums\OrganisationRole;
+use App\Authorization\CaseAccess;
 use App\Models\ServiceCase;
 use App\Models\User;
 
 class ServiceCasePolicy
 {
+    public function __construct(private readonly CaseAccess $access) {}
+
     public function view(User $user, ServiceCase $case): bool
     {
-        if ($this->managesProgram($user, $case)) {
-            return true;
-        }
-
-        $membership = $user->organisationMembership($case->organisation);
-
-        return $membership !== null
-            && ! $membership->isHeld()
-            && $user->hasOrganisationRole($case->organisation, OrganisationRole::CaseWorker, $case->program)
-            && $user->hasProgramAccess($case->program)
-            && $case->assignments()->where('membership_id', $membership->id)->where('status', 'active')->exists();
+        return $this->access->canView($user, $case);
     }
 
     public function update(User $user, ServiceCase $case): bool
@@ -28,9 +20,18 @@ class ServiceCasePolicy
         return $this->view($user, $case) && ! $case->status->isTerminal();
     }
 
-    private function managesProgram(User $user, ServiceCase $case): bool
+    public function viewSensitive(User $user, ServiceCase $case): bool
     {
-        return $user->hasOrganisationRole($case->organisation, OrganisationRole::ProgramManager, $case->program)
-            && $user->hasProgramAccess($case->program);
+        return $this->access->canViewSensitive($user, $case);
+    }
+
+    public function manageAccess(User $user, ServiceCase $case): bool
+    {
+        return $this->access->canManageAccess($user, $case);
+    }
+
+    public function export(User $user, ServiceCase $case): bool
+    {
+        return $this->access->canExport($user, $case);
     }
 }

--- a/database/factories/CaseRiskAssessmentFactory.php
+++ b/database/factories/CaseRiskAssessmentFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Cryptography\ClassifiedDataEncrypter;
+use App\Enums\CaseClassification;
+use App\Models\CaseRiskAssessment;
+use App\Models\ServiceCase;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<CaseRiskAssessment>
+ */
+class CaseRiskAssessmentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'id' => (string) Str::uuid(),
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'service_case_id' => ServiceCase::factory(),
+            'type' => 'risk_assessment',
+            'classification' => CaseClassification::HighlyRestricted,
+            'encrypted_content' => fake()->sentence(),
+            'data_key_version' => app(ClassifiedDataEncrypter::class)->currentVersion(),
+            'effective_at' => now(),
+        ];
+    }
+}

--- a/database/factories/RestrictedAccessGrantFactory.php
+++ b/database/factories/RestrictedAccessGrantFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\RestrictedAccessPermission;
+use App\Models\RestrictedAccessGrant;
+use App\Models\ServiceCase;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<RestrictedAccessGrant>
+ */
+class RestrictedAccessGrantFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'membership_id' => fn (): int => app(OrganisationContext::class)->organisation()
+                ->memberships()->create(['user_id' => User::factory()->create()->id])->id,
+            'program_id' => fn (array $attributes): int => ServiceCase::query()
+                ->whereKey($attributes['service_case_id'])->firstOrFail()->program_id,
+            'service_case_id' => ServiceCase::factory(),
+            'permission' => RestrictedAccessPermission::SensitiveData,
+            'reason' => fake()->sentence(),
+            'granted_at' => now(),
+        ];
+    }
+}

--- a/database/factories/RestrictedAccessRevocationFactory.php
+++ b/database/factories/RestrictedAccessRevocationFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\RestrictedAccessGrant;
+use App\Models\RestrictedAccessRevocation;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<RestrictedAccessRevocation>
+ */
+class RestrictedAccessRevocationFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'restricted_access_grant_id' => RestrictedAccessGrant::factory(),
+            'reason' => fake()->sentence(),
+            'revoked_at' => now(),
+        ];
+    }
+}

--- a/database/factories/ServiceCaseFactory.php
+++ b/database/factories/ServiceCaseFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\CaseClassification;
 use App\Enums\ServiceCaseStatus;
 use App\Models\IntakeRequest;
 use App\Models\ServiceCase;
@@ -26,7 +27,7 @@ class ServiceCaseFactory extends Factory
             'program_id' => fn (array $attributes): int => IntakeRequest::query()->where('id', $attributes['intake_request_id'])->firstOrFail()->program_id,
             'party_id' => fn (array $attributes): int => IntakeRequest::query()->where('id', $attributes['intake_request_id'])->firstOrFail()->party_id,
             'status' => ServiceCaseStatus::Open,
-            'confidentiality' => 'confidential',
+            'confidentiality' => CaseClassification::Confidential,
             'opened_at' => now(),
         ];
     }

--- a/database/migrations/2026_08_31_072102_create_case_confidentiality_tables.php
+++ b/database/migrations/2026_08_31_072102_create_case_confidentiality_tables.php
@@ -1,0 +1,89 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('restricted_access_grants', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('membership_id');
+            $table->foreignId('program_id');
+            $table->uuid('service_case_id')->nullable();
+            $table->string('permission', 64);
+            $table->string('reason', 255);
+            $table->timestamp('granted_at');
+            $table->timestamp('expires_at')->nullable();
+            $table->unsignedBigInteger('granted_by_user_id')->nullable()->index();
+
+            $table->foreign(['organisation_id', 'program_id'])
+                ->references(['organisation_id', 'id'])->on('programs')->restrictOnDelete();
+            $table->foreign(['organisation_id', 'service_case_id'])
+                ->references(['organisation_id', 'id'])->on('service_cases')->restrictOnDelete();
+            $table->unique(['organisation_id', 'id']);
+            $table->index(['organisation_id', 'membership_id', 'program_id', 'permission'], 'restricted_grant_lookup');
+        });
+
+        Schema::create('restricted_access_revocations', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->ulid('restricted_access_grant_id');
+            $table->string('reason', 255);
+            $table->timestamp('revoked_at');
+            $table->unsignedBigInteger('revoked_by_user_id')->nullable()->index();
+
+            $table->foreign(['organisation_id', 'restricted_access_grant_id'], 'restricted_revocation_grant_foreign')
+                ->references(['organisation_id', 'id'])->on('restricted_access_grants')->restrictOnDelete();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'restricted_access_grant_id'], 'restricted_grant_single_revocation');
+        });
+
+        Schema::create('case_risk_assessments', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->uuid('service_case_id');
+            $table->string('type', 32)->default('risk_assessment');
+            $table->string('classification', 32)->default('highly_restricted');
+            $table->text('encrypted_content');
+            $table->string('data_key_version', 64);
+            $table->timestamp('effective_at');
+            $table->timestamp('ended_at')->nullable();
+            $table->foreignId('recorded_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->foreign(['organisation_id', 'service_case_id'])
+                ->references(['organisation_id', 'id'])->on('service_cases')->restrictOnDelete();
+            $table->unique(['organisation_id', 'id']);
+            $table->index(['organisation_id', 'service_case_id', 'ended_at']);
+        });
+
+        if (DB::getDriverName() === 'pgsql') {
+            foreach (['restricted_access_grants', 'restricted_access_revocations'] as $table) {
+                DB::unprepared("CREATE TRIGGER {$table}_append_only BEFORE UPDATE OR DELETE OR TRUNCATE ON {$table} FOR EACH STATEMENT EXECUTE FUNCTION prevent_append_only_mutation()");
+            }
+        } elseif (DB::getDriverName() === 'sqlite') {
+            foreach (['restricted_access_grants', 'restricted_access_revocations'] as $table) {
+                DB::unprepared("CREATE TRIGGER {$table}_update BEFORE UPDATE ON {$table} BEGIN SELECT RAISE(ABORT, 'append-only table'); END");
+                DB::unprepared("CREATE TRIGGER {$table}_delete BEFORE DELETE ON {$table} BEGIN SELECT RAISE(ABORT, 'append-only table'); END");
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('case_risk_assessments');
+        Schema::dropIfExists('restricted_access_revocations');
+        Schema::dropIfExists('restricted_access_grants');
+    }
+};

--- a/resources/js/pages/cases/show.tsx
+++ b/resources/js/pages/cases/show.tsx
@@ -231,6 +231,44 @@ export default function CaseShow({ caseRecord, canUpdate }: any) {
                     </div>
                 </div>
 
+                {caseRecord.safeContactBanner ? (
+                    <div
+                        role="alert"
+                        className="rounded-lg border border-amber-500/40 bg-amber-50 p-4 text-amber-950 dark:bg-amber-950/30 dark:text-amber-100"
+                    >
+                        <p className="text-xs font-semibold tracking-wide uppercase">
+                            Contact safety
+                        </p>
+                        <p className="mt-1 font-medium">
+                            {caseRecord.safeContactBanner}
+                        </p>
+                    </div>
+                ) : null}
+
+                {caseRecord.riskAssessments.length > 0 ? (
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Highly restricted risk detail</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-3">
+                            {caseRecord.riskAssessments.map((risk: any) => (
+                                <div
+                                    key={risk.id}
+                                    className="rounded-lg border p-3 text-sm"
+                                >
+                                    <Badge variant="destructive">
+                                        {risk.classification.replaceAll(
+                                            '_',
+                                            ' ',
+                                        )}
+                                    </Badge>
+                                    <p className="mt-2">{risk.content}</p>
+                                </div>
+                            ))}
+                        </CardContent>
+                    </Card>
+                ) : null}
+
                 {canUpdate ? (
                     <Card>
                         <CardHeader>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,8 @@
 
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Organisations\CaseAssignmentController;
+use App\Http\Controllers\Organisations\CaseConfidentialityController;
+use App\Http\Controllers\Organisations\CaseExportController;
 use App\Http\Controllers\Organisations\CaseItemController;
 use App\Http\Controllers\Organisations\CaseWorkflowController;
 use App\Http\Controllers\Organisations\IntakeRequestController;
@@ -90,6 +92,11 @@ Route::prefix('{current_organisation}')
         Route::post('intakes/{intake}/assignments', [CaseAssignmentController::class, 'store'])->name('intakes.assignments.store');
         Route::get('cases/{case}', [ServiceCaseController::class, 'show'])->name('cases.show');
         Route::post('cases/{case}/transitions', [ServiceCaseController::class, 'transition'])->name('cases.transitions.store');
+        Route::post('cases/{case}/classification', [CaseConfidentialityController::class, 'reclassify'])->name('cases.classification.store');
+        Route::post('cases/{case}/restricted-access-grants', [CaseConfidentialityController::class, 'grant'])->name('cases.restricted-access-grants.store');
+        Route::delete('cases/{case}/restricted-access-grants/{grant}', [CaseConfidentialityController::class, 'revoke'])->name('cases.restricted-access-grants.destroy');
+        Route::post('cases/{case}/risk-assessments', [CaseConfidentialityController::class, 'risk'])->name('cases.risk-assessments.store');
+        Route::get('programs/{program}/cases/export', CaseExportController::class)->name('programs.cases.export');
         Route::post('cases/{case}/items', [CaseItemController::class, 'store'])->name('cases.items.store');
         Route::post('cases/{case}/items/{subjectType}/{subject}/transitions', [CaseWorkflowController::class, 'store'])->name('cases.items.transitions.store');
         Route::post('duplicate-reviews/{duplicate_review}', [PartyDuplicateReviewController::class, 'store'])->name('duplicate-reviews.store');

--- a/tests/Feature/CaseConfidentialityAuthorizationTest.php
+++ b/tests/Feature/CaseConfidentialityAuthorizationTest.php
@@ -1,0 +1,260 @@
+<?php
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Actions\CaseConfidentiality\GrantRestrictedAccess;
+use App\Actions\CaseConfidentiality\ReclassifyServiceCase;
+use App\Actions\CaseConfidentiality\RecordCaseRiskAssessment;
+use App\Actions\CaseConfidentiality\RevokeRestrictedAccess;
+use App\Actions\Intake\AssignCaseWorker;
+use App\Actions\Intake\TransitionIntakeRequest;
+use App\Actions\Parties\StoreSafeContactInstruction;
+use App\Data\Values\ClassifiedValue;
+use App\Enums\CaseClassification;
+use App\Enums\IntakeStatus;
+use App\Enums\OrganisationRole;
+use App\Enums\PartyBusinessRole;
+use App\Enums\RestrictedAccessPermission;
+use App\Enums\TenantAuditEventType;
+use App\Models\IntakeRequest;
+use App\Models\Membership;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\PartyRole;
+use App\Models\Program;
+use App\Models\RestrictedAccessGrant;
+use App\Models\ServiceCase;
+use App\Models\TenantAuditEvent;
+use App\Models\User;
+use App\OrganisationContext;
+use Inertia\Testing\AssertableInertia as Assert;
+use Mockery\MockInterface;
+
+/** @return array{organisation: Organisation, program: Program, party: Party, case: ServiceCase, manager: User, managerMembership: Membership, worker: User, workerMembership: Membership, engagement: User, administrator: User, owner: User, executive: User} */
+function caseConfidentialityFixture(): array
+{
+    $organisation = Organisation::factory()->active()->create();
+    $program = app(OrganisationContext::class)->run($organisation, fn (): Program => Program::factory()->for($organisation)->create(['configuration' => ['case_default_classification' => 'highly_restricted']]));
+    $users = collect(['manager', 'worker', 'engagement', 'administrator', 'owner', 'executive'])
+        ->mapWithKeys(fn (string $key): array => [$key => User::factory()->create()]);
+    $managerMembership = $organisation->memberships()->create(['user_id' => $users['manager']->id, 'role' => OrganisationRole::ProgramManager]);
+    $workerMembership = $organisation->memberships()->create(['user_id' => $users['worker']->id, 'role' => OrganisationRole::CaseWorker]);
+    $organisation->memberships()->create(['user_id' => $users['engagement']->id, 'role' => OrganisationRole::EngagementOfficer]);
+    $organisation->memberships()->create(['user_id' => $users['administrator']->id, 'role' => OrganisationRole::OrganisationAdministrator]);
+    $organisation->memberships()->create(['user_id' => $users['owner']->id, 'is_owner' => true]);
+    $organisation->memberships()->create(['user_id' => $users['executive']->id, 'role' => OrganisationRole::ExecutiveViewer]);
+
+    [$party, $case] = app(OrganisationContext::class)->run($organisation, function () use ($organisation, $program): array {
+        $party = Party::factory()->for($organisation)->create(['display_name' => 'Dual Role Person']);
+        $party->programs()->attach($program);
+        PartyRole::factory()->for($party)->create(['role' => PartyBusinessRole::Client]);
+        PartyRole::factory()->for($party)->create(['role' => PartyBusinessRole::Volunteer]);
+        $intake = IntakeRequest::factory()->create(['program_id' => $program->id, 'party_id' => $party->id]);
+        $case = ServiceCase::factory()->create([
+            'intake_request_id' => $intake->id,
+            'program_id' => $program->id,
+            'party_id' => $party->id,
+        ]);
+
+        return [$party, $case];
+    });
+    app(OrganisationContext::class)->run($organisation, function () use ($managerMembership, $program, $workerMembership): void {
+        $managerMembership->programs()->attach($program);
+        $workerMembership->programs()->attach($program);
+    });
+
+    return [
+        'organisation' => $organisation,
+        'program' => $program,
+        'party' => $party,
+        'case' => $case,
+        'manager' => $users['manager'],
+        'managerMembership' => $managerMembership,
+        'worker' => $users['worker'],
+        'workerMembership' => $workerMembership,
+        'engagement' => $users['engagement'],
+        'administrator' => $users['administrator'],
+        'owner' => $users['owner'],
+        'executive' => $users['executive'],
+    ];
+}
+
+it('defaults Case content to confidential and audits every reasoned reclassification', function () {
+    $fixture = caseConfidentialityFixture();
+
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): void {
+        expect($fixture['case']->confidentiality)->toBe(CaseClassification::Confidential);
+        $intake = IntakeRequest::factory()->create([
+            'program_id' => $fixture['program']->id,
+            'party_id' => $fixture['party']->id,
+            'status' => IntakeStatus::UnderReview,
+            'version' => 3,
+            'encrypted_content' => new ClassifiedValue(json_encode([
+                'narrative' => 'Synthetic request.',
+                'presenting_needs' => 'Support.',
+                'intake_fields' => [],
+                'service_consent' => ['granted' => true, 'source' => 'test', 'captured_at' => now()->toAtomString()],
+            ], JSON_THROW_ON_ERROR)),
+        ]);
+        app(TransitionIntakeRequest::class)->handle($intake, IntakeStatus::Accepted, 3, $fixture['manager']);
+        expect($intake->refresh()->serviceCase->confidentiality)->toBe(CaseClassification::HighlyRestricted);
+
+        app(ReclassifyServiceCase::class)->handle($fixture['case'], CaseClassification::HighlyRestricted, 'Detailed risk recorded.', $fixture['manager']);
+        $audit = TenantAuditEvent::query()->where('type', TenantAuditEventType::CaseReclassified)->sole();
+        expect($fixture['case']->refresh()->confidentiality)->toBe(CaseClassification::HighlyRestricted)
+            ->and($audit->payload)->toBe([
+                'case_id' => $fixture['case']->id,
+                'from' => 'confidential',
+                'to' => 'highly_restricted',
+                'reason' => 'Detailed risk recorded.',
+            ]);
+        expect(fn () => app(ReclassifyServiceCase::class)->handle($fixture['case'], CaseClassification::Confidential, 'No longer sensitive.', $fixture['manager']))
+            ->toThrow(LogicException::class, 'requires current restricted access');
+        app(GrantRestrictedAccess::class)->handle($fixture['case'], $fixture['managerMembership'], RestrictedAccessPermission::SensitiveData, 'Reclassification review.', $fixture['manager']);
+        app(ReclassifyServiceCase::class)->handle($fixture['case'], CaseClassification::Confidential, 'Risk was resolved.', $fixture['manager']);
+        expect($fixture['case']->refresh()->confidentiality)->toBe(CaseClassification::Confidential)
+            ->and(TenantAuditEvent::query()->where('type', TenantAuditEventType::CaseReclassified)->count())->toBe(2);
+    });
+});
+
+it('enforces role Program assignment and restricted-access boundaries for every MVP role', function () {
+    $fixture = caseConfidentialityFixture();
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): void {
+        app(AssignCaseWorker::class)->handle($fixture['case'], $fixture['workerMembership'], $fixture['manager']);
+        app(ReclassifyServiceCase::class)->handle($fixture['case'], CaseClassification::HighlyRestricted, 'Sensitive fixture.', $fixture['manager']);
+    });
+
+    foreach (['manager', 'worker', 'engagement', 'administrator', 'owner', 'executive'] as $actor) {
+        $this->actingAs($fixture[$actor])->get(route('cases.show', [$fixture['organisation'], $fixture['case']]))->assertForbidden();
+    }
+
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): void {
+        app(GrantRestrictedAccess::class)->handle($fixture['case'], $fixture['managerMembership'], RestrictedAccessPermission::SensitiveData, 'Manager safeguarding duty.', $fixture['manager']);
+        app(GrantRestrictedAccess::class)->handle($fixture['case'], $fixture['workerMembership'], RestrictedAccessPermission::SensitiveData, 'Assigned worker safeguarding duty.', $fixture['manager']);
+    });
+
+    $this->actingAs($fixture['manager'])->get(route('cases.show', [$fixture['organisation'], $fixture['case']]))->assertOk();
+    $this->actingAs($fixture['worker'])->get(route('cases.show', [$fixture['organisation'], $fixture['case']]))->assertOk();
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): void {
+        $workerGrant = RestrictedAccessGrant::query()
+            ->where('membership_id', $fixture['workerMembership']->id)
+            ->where('permission', RestrictedAccessPermission::SensitiveData)
+            ->sole();
+        app(RevokeRestrictedAccess::class)->handle($workerGrant, 'Assignment changed.', $fixture['manager']);
+        expect($workerGrant->revocation()->exists())->toBeTrue()
+            ->and(TenantAuditEvent::query()->where('type', TenantAuditEventType::RestrictedAccessRevoked)->exists())->toBeTrue();
+    });
+    $this->actingAs($fixture['worker'])->get(route('cases.show', [$fixture['organisation'], $fixture['case']]))->assertForbidden();
+    foreach (['engagement', 'administrator', 'owner', 'executive'] as $actor) {
+        $this->actingAs($fixture[$actor])->get(route('cases.show', [$fixture['organisation'], $fixture['case']]))->assertForbidden();
+    }
+
+    $otherOrganisation = Organisation::factory()->active()->create();
+    $otherManager = User::factory()->create();
+    $otherOrganisation->memberships()->create(['user_id' => $otherManager->id, 'role' => OrganisationRole::ProgramManager]);
+    $this->actingAs($otherManager)->get(route('cases.show', [$otherOrganisation, $fixture['case']]))->assertNotFound();
+});
+
+it('reveals risk and safe-contact values only with Case-specific sensitive access and audits without content', function () {
+    $fixture = caseConfidentialityFixture();
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): void {
+        app(AssignCaseWorker::class)->handle($fixture['case'], $fixture['workerMembership'], $fixture['manager']);
+        app(GrantRestrictedAccess::class)->handle($fixture['case'], $fixture['managerMembership'], RestrictedAccessPermission::SensitiveData, 'Safeguarding review.', $fixture['manager']);
+        app(RecordCaseRiskAssessment::class)->handle($fixture['case'], 'Synthetic protected risk detail.', $fixture['manager']);
+        app(StoreSafeContactInstruction::class)->handle($fixture['party'], [
+            'instruction' => 'Do not leave voicemail.',
+            'source' => 'test',
+            'effective_at' => now()->toAtomString(),
+        ], $fixture['manager']);
+    });
+
+    $this->actingAs($fixture['worker'])
+        ->get(route('cases.show', [$fixture['organisation'], $fixture['case']]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('caseRecord.safeContactBanner', null)
+            ->has('caseRecord.riskAssessments', 0));
+    $this->actingAs($fixture['manager'])
+        ->get(route('cases.show', [$fixture['organisation'], $fixture['case']]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('caseRecord.safeContactBanner', 'Do not leave voicemail.')
+            ->where('caseRecord.riskAssessments.0.content', 'Synthetic protected risk detail.'));
+
+    app(OrganisationContext::class)->run($fixture['organisation'], function (): void {
+        $payloads = TenantAuditEvent::query()->pluck('payload')->map(fn (array $payload): string => json_encode($payload, JSON_THROW_ON_ERROR))->implode(' ');
+        expect($payloads)->not->toContain('voicemail')->not->toContain('risk detail');
+    });
+});
+
+it('gives engagement staff a supporter-safe projection and keeps exports explicit and redacted', function () {
+    $fixture = caseConfidentialityFixture();
+
+    $this->actingAs($fixture['engagement'])
+        ->get(route('parties.show', [$fixture['organisation'], $fixture['party']]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('party.displayName', 'Dual Role Person')
+            ->where('party.supporterSafe', true)
+            ->where('party.roles', ['volunteer'])
+            ->where('party.interests', [])
+            ->where('party.programIds', [])
+            ->where('party.timeline', [])
+            ->where('party.safeContactInstructions', []));
+    $this->actingAs($fixture['engagement'])
+        ->get(route('parties.index', [$fixture['organisation'], 'query' => 'Dual Role']))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('parties.data', 1)
+            ->where('parties.data.0.roles', ['Volunteer'])
+            ->where('parties.data.0.programs', []));
+    $this->actingAs($fixture['administrator'])
+        ->get(route('parties.show', [$fixture['organisation'], $fixture['party']]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('party.displayName', 'Administrative Party record')
+            ->where('party.email', null)
+            ->where('party.roles', [])
+            ->where('party.programIds', []));
+
+    $this->actingAs($fixture['manager'])
+        ->get(route('programs.cases.export', [$fixture['organisation'], $fixture['program']]))
+        ->assertSessionHasErrors('export');
+
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): void {
+        app(GrantRestrictedAccess::class)->handle($fixture['case'], $fixture['managerMembership'], RestrictedAccessPermission::IdentifiableCaseExport, 'Approved synthetic export.', $fixture['manager']);
+        app(ReclassifyServiceCase::class)->handle($fixture['case'], CaseClassification::HighlyRestricted, 'Restricted export fixture.', $fixture['manager']);
+    });
+    $export = $this->actingAs($fixture['manager'])->get(route('programs.cases.export', [$fixture['organisation'], $fixture['program']]));
+    $export->assertOk();
+    expect($export->streamedContent())
+        ->not->toContain('Dual Role Person');
+
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): void {
+        app(GrantRestrictedAccess::class)->handle($fixture['case'], $fixture['managerMembership'], RestrictedAccessPermission::SensitiveData, 'Approved restricted export.', $fixture['manager']);
+    });
+    $authorizedExport = $this->actingAs($fixture['manager'])->get(route('programs.cases.export', [$fixture['organisation'], $fixture['program']]));
+    expect($authorizedExport->streamedContent())
+        ->toContain('Dual Role Person')
+        ->not->toContain('risk')
+        ->not->toContain('voicemail');
+
+    app(OrganisationContext::class)->run($fixture['organisation'], fn () => expect(RestrictedAccessGrant::query()->count())->toBe(2));
+});
+
+it('fails closed when a restricted-access audit cannot be persisted', function () {
+    $fixture = caseConfidentialityFixture();
+    $this->mock(RecordTenantAuditEvent::class, function (MockInterface $mock): void {
+        $mock->shouldReceive('handle')->once()->andThrow(new RuntimeException('Audit unavailable.'));
+    });
+
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): void {
+        expect(fn () => app(GrantRestrictedAccess::class)->handle(
+            $fixture['case'],
+            $fixture['managerMembership'],
+            RestrictedAccessPermission::SensitiveData,
+            'Must be audited.',
+            $fixture['manager'],
+        ))->toThrow(RuntimeException::class, 'Audit unavailable');
+        expect(RestrictedAccessGrant::query()->count())->toBe(0);
+    });
+});

--- a/tests/Feature/CommunityKindScenarioSeederTest.php
+++ b/tests/Feature/CommunityKindScenarioSeederTest.php
@@ -60,7 +60,7 @@ it('seeds the versioned synthetic scenarios deterministically', function () {
         ->map(fn (int|string $count): int => (int) $count)
         ->all();
 
-    expect(ScenarioCatalog::VERSION)->toBe('2026.3')
+    expect(ScenarioCatalog::VERSION)->toBe('2026.4')
         ->and(ScenarioCatalog::AS_OF)->toBe('2026-06-30 23:59:59')
         ->and(Date::getTestNow())->toBeNull()
         ->and(Organisation::query()->count())->toBe(2)

--- a/tests/Feature/PartyProfileTest.php
+++ b/tests/Feature/PartyProfileTest.php
@@ -1,22 +1,26 @@
 <?php
 
+use App\Actions\CaseConfidentiality\GrantRestrictedAccess;
 use App\Enums\ConsentDecision;
 use App\Enums\ConsentPurpose;
 use App\Enums\OrganisationRole;
 use App\Enums\PartyBusinessRole;
 use App\Enums\PartyKind;
+use App\Enums\RestrictedAccessPermission;
+use App\Models\IntakeRequest;
 use App\Models\Organisation;
 use App\Models\Party;
 use App\Models\PartyConsent;
 use App\Models\PartyRole;
 use App\Models\PartySafeContactInstruction;
 use App\Models\Program;
+use App\Models\ServiceCase;
 use App\Models\User;
 use App\OrganisationContext;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 
-function partyProfileFixture(OrganisationRole $role = OrganisationRole::OrganisationAdministrator): array
+function partyProfileFixture(OrganisationRole $role = OrganisationRole::ProgramManager): array
 {
     $user = User::factory()->create();
     $organisation = Organisation::factory()->active()->create();
@@ -87,13 +91,16 @@ it('preserves immutable consent grant and withdrawal history with exact provenan
     });
 });
 
-it('limits Party safe-contact content to assigned Program managers', function () {
+it('limits Party safe-contact content to service staff with explicit sensitive access', function () {
     extract(partyProfileFixture(OrganisationRole::ProgramManager));
     $administrator = User::factory()->create();
     $organisation->memberships()->create(['user_id' => $administrator->id, 'role' => OrganisationRole::OrganisationAdministrator]);
-    $party = app(OrganisationContext::class)->run($organisation, function () use ($organisation, $program): Party {
+    $party = app(OrganisationContext::class)->run($organisation, function () use ($organisation, $program, $membership, $user): Party {
         $party = Party::factory()->for($organisation)->create();
         $party->programs()->attach($program);
+        $intake = IntakeRequest::factory()->create(['program_id' => $program->id, 'party_id' => $party->id]);
+        $case = ServiceCase::factory()->create(['intake_request_id' => $intake->id, 'program_id' => $program->id, 'party_id' => $party->id]);
+        app(GrantRestrictedAccess::class)->handle($case, $membership, RestrictedAccessPermission::SensitiveData, 'Test safeguarding access.', $user);
 
         return $party;
     });


### PR DESCRIPTION
## Summary
- enforce confidential and highly restricted Case access through role, Program, assignment, and case-specific sensitive-data grants
- add encrypted risk records, protected safe-contact presentation, reasoned reclassification, immutable grant/revocation history, and fail-closed audits
- give engagement staff a supporter-safe Party projection while keeping client status, service attributes, timelines, and Program membership undiscoverable
- require explicit Program export permission and filter unauthorized highly restricted Cases before loading identifiable fields

## Review fixes
- roll back grants and risk writes when their audit event cannot be persisted
- add immediate append-only access revocations and preserve history across User deletion
- prevent administrator name-search and operational Party mutation through the administrative metadata projection
- scope relationship candidates and Party form options to the actor's authorized Programs
- exclude highly restricted exports unless the exporter also has Case-specific sensitive access

## Verification
- `composer ci:check` (287 tests, 1,384 assertions)
- focused PostgreSQL and SQLite authorization suites
- `npm test`
- `npm run build`
- seeded highly restricted Case verified locally with contact-safety and risk-detail UI; no console errors or mobile overflow

Closes #13