### PR TITLE
Monitor caseloads, waitlists, risks, and external referrals

### DIFF
--- a/app/Actions/ServiceMonitoring/BuildServiceOperationsDashboard.php
+++ b/app/Actions/ServiceMonitoring/BuildServiceOperationsDashboard.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Actions\ServiceMonitoring;
+
+use App\Authorization\CaseAccess;
+use App\Enums\CaseAssignmentStatus;
+use App\Enums\CaseTaskStatus;
+use App\Enums\ExternalReferralStatus;
+use App\Enums\IntakeStatus;
+use App\Enums\OrganisationRole;
+use App\Enums\ServiceCaseStatus;
+use App\Models\CaseRiskAssessment;
+use App\Models\CaseTask;
+use App\Models\ExternalReferral;
+use App\Models\IntakeRequest;
+use App\Models\Organisation;
+use App\Models\Program;
+use App\Models\ServiceCase;
+use App\Models\User;
+
+final class BuildServiceOperationsDashboard
+{
+    public function __construct(private CaseAccess $caseAccess) {}
+
+    /** @return array<string, mixed> */
+    public function handle(User $user, Organisation $organisation, ?int $requestedProgramId = null): array
+    {
+        $membership = $user->organisationMembership($organisation);
+
+        if ($membership === null || $membership->isHeld()) {
+            return $this->empty();
+        }
+
+        $programs = Program::query()->select(['id', 'organisation_id', 'name'])->orderBy('name')->get();
+        $managerProgramIds = $programs
+            ->filter(fn (Program $program): bool => $user->hasOrganisationRole($organisation, OrganisationRole::ProgramManager, $program) && $user->hasProgramAccess($program))
+            ->pluck('id');
+        $workerProgramIds = $programs
+            ->filter(fn (Program $program): bool => $user->hasOrganisationRole($organisation, OrganisationRole::CaseWorker, $program) && $user->hasProgramAccess($program))
+            ->pluck('id');
+        $allowedProgramIds = $managerProgramIds->merge($workerProgramIds)->unique()->values();
+        $allowedPrograms = $programs->whereIn('id', $allowedProgramIds)->values();
+
+        if ($requestedProgramId !== null) {
+            $allowedProgramIds = $allowedProgramIds->filter(fn (int $id): bool => $id === $requestedProgramId)->values();
+        }
+
+        $cases = ServiceCase::query()
+            ->select(['id', 'organisation_id', 'program_id', 'status', 'confidentiality'])
+            ->with('program:id,organisation_id,name')
+            ->whereIn('program_id', $allowedProgramIds)
+            ->whereIn('status', [ServiceCaseStatus::Open, ServiceCaseStatus::Active, ServiceCaseStatus::OnHold])
+            ->when(
+                $managerProgramIds->intersect($allowedProgramIds)->isEmpty(),
+                fn ($query) => $query->whereHas('assignments', fn ($assignment) => $assignment
+                    ->where('membership_id', $membership->id)
+                    ->where('status', CaseAssignmentStatus::Active)),
+                fn ($query) => $query->where(function ($scope) use ($managerProgramIds, $allowedProgramIds, $membership): void {
+                    $managed = $managerProgramIds->intersect($allowedProgramIds);
+                    $scope->whereIn('program_id', $managed)
+                        ->orWhereHas('assignments', fn ($assignment) => $assignment
+                            ->where('membership_id', $membership->id)
+                            ->where('status', CaseAssignmentStatus::Active));
+                }),
+            )
+            ->get()
+            ->filter(fn (ServiceCase $case): bool => $this->caseAccess->canView($user, $case))
+            ->values();
+        $caseIds = $cases->pluck('id');
+        $casePrograms = $cases->mapWithKeys(fn (ServiceCase $case): array => [$case->id => $case->program->name]);
+        $sensitiveCaseIds = $cases->filter(fn (ServiceCase $case): bool => $this->caseAccess->canViewSensitive($user, $case))->pluck('id');
+
+        $waitlist = $managerProgramIds->intersect($allowedProgramIds)->isEmpty()
+            ? collect()
+            : IntakeRequest::query()
+                ->select(['id', 'program_id', 'status', 'urgency', 'created_at'])
+                ->with('program:id,organisation_id,name')
+                ->whereIn('program_id', $managerProgramIds->intersect($allowedProgramIds))
+                ->where('status', IntakeStatus::Waitlisted)
+                ->oldest('created_at')
+                ->get()
+                ->map(fn (IntakeRequest $intake): array => [
+                    'id' => $intake->id,
+                    'program' => $intake->program->name,
+                    'status' => $intake->status->value,
+                    'urgency' => $intake->urgency->value,
+                    'since' => $intake->created_at?->toAtomString(),
+                ]);
+        $overdue = CaseTask::query()
+            ->select(['id', 'service_case_id', 'status', 'due_at'])
+            ->whereIn('service_case_id', $caseIds)
+            ->where('status', CaseTaskStatus::Open)
+            ->where('due_at', '<', now())
+            ->oldest('due_at')
+            ->get()
+            ->map(fn (CaseTask $task): array => [
+                'id' => $task->id,
+                'caseId' => $task->service_case_id,
+                'program' => $casePrograms[$task->service_case_id],
+                'dueAt' => $task->due_at?->toAtomString(),
+            ]);
+        $risks = CaseRiskAssessment::query()
+            ->select(['id', 'service_case_id', 'effective_at'])
+            ->whereIn('service_case_id', $sensitiveCaseIds)
+            ->whereNull('ended_at')
+            ->latest('effective_at')
+            ->get()
+            ->map(fn (CaseRiskAssessment $risk): array => [
+                'id' => $risk->id,
+                'caseId' => $risk->service_case_id,
+                'program' => $casePrograms[$risk->service_case_id],
+                'effectiveAt' => $risk->effective_at->toAtomString(),
+            ]);
+        $referrals = ExternalReferral::query()
+            ->select(['id', 'service_case_id', 'status', 'effective_at'])
+            ->whereIn('service_case_id', $caseIds)
+            ->whereIn('status', [ExternalReferralStatus::Draft, ExternalReferralStatus::Sent, ExternalReferralStatus::Acknowledged])
+            ->latest('effective_at')
+            ->get()
+            ->map(fn (ExternalReferral $referral): array => [
+                'id' => $referral->id,
+                'caseId' => $referral->service_case_id,
+                'program' => $casePrograms[$referral->service_case_id],
+                'status' => $referral->status->value,
+                'effectiveAt' => $referral->effective_at?->toAtomString(),
+            ]);
+
+        return [
+            'programs' => $allowedPrograms->map(fn (Program $program): array => ['id' => $program->id, 'name' => $program->name]),
+            'selectedProgramId' => $requestedProgramId,
+            'counts' => ['caseload' => $cases->count(), 'waitlist' => $waitlist->count(), 'overdue' => $overdue->count(), 'risks' => $risks->count(), 'referrals' => $referrals->count()],
+            'caseload' => $cases->map(fn (ServiceCase $case): array => ['id' => $case->id, 'program' => $case->program->name, 'status' => $case->status->value])->values(),
+            'waitlist' => $waitlist->values(),
+            'overdue' => $overdue->values(),
+            'risks' => $risks->values(),
+            'referrals' => $referrals->values(),
+        ];
+    }
+
+    /** @return array<string, mixed> */
+    private function empty(): array
+    {
+        return ['programs' => [], 'selectedProgramId' => null, 'counts' => ['caseload' => 0, 'waitlist' => 0, 'overdue' => 0, 'risks' => 0, 'referrals' => 0], 'caseload' => [], 'waitlist' => [], 'overdue' => [], 'risks' => [], 'referrals' => []];
+    }
+}

--- a/app/Data/Auditing/VersionedAuditPayload.php
+++ b/app/Data/Auditing/VersionedAuditPayload.php
@@ -33,6 +33,7 @@ final class VersionedAuditPayload
             'string' => is_string($value) && $value !== '',
             'nullable_string' => $value === null || (is_string($value) && $value !== ''),
             'integer' => is_int($value),
+            'nullable_integer' => $value === null || is_int($value),
             'boolean' => is_bool($value),
             'string_list' => is_array($value)
                 && array_is_list($value)

--- a/app/Enums/TenantAuditEventType.php
+++ b/app/Enums/TenantAuditEventType.php
@@ -17,6 +17,7 @@ enum TenantAuditEventType: string
     case CaseDocumentScanCompleted = 'case_document_scan_completed';
     case CaseDocumentDownloaded = 'case_document_downloaded';
     case CaseDocumentReplaced = 'case_document_replaced';
+    case ServiceOperationsExported = 'service_operations_exported';
 
     /** @return array<string, string> */
     public function payloadSchema(): array
@@ -75,6 +76,10 @@ enum TenantAuditEventType: string
                 'document_id' => 'string',
                 'generation' => 'integer',
                 'classification' => 'string',
+            ],
+            self::ServiceOperationsExported => [
+                'program_id' => 'nullable_integer',
+                'record_count' => 'integer',
             ],
         };
     }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\ServiceMonitoring\BuildServiceOperationsDashboard;
+use App\Models\Organisation;
 use App\Models\OrganisationInvitation;
 use App\OrganisationContext;
 use Illuminate\Http\Request;
@@ -10,7 +12,7 @@ use Inertia\Response;
 
 class DashboardController extends Controller
 {
-    public function __invoke(Request $request): Response
+    public function __invoke(Request $request, Organisation $currentOrganisation, BuildServiceOperationsDashboard $buildDashboard): Response
     {
         $email = strtolower($request->user()->email);
 
@@ -52,6 +54,11 @@ class DashboardController extends Controller
 
         return Inertia::render('dashboard', [
             'pendingInvitations' => $pendingInvitations,
+            'serviceOperations' => $buildDashboard->handle(
+                $request->user(),
+                $currentOrganisation,
+                $request->filled('program_id') ? $request->integer('program_id') : null,
+            ),
         ]);
     }
 }

--- a/app/Http/Controllers/Organisations/ServiceOperationsExportController.php
+++ b/app/Http/Controllers/Organisations/ServiceOperationsExportController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Actions\ServiceMonitoring\BuildServiceOperationsDashboard;
+use App\Enums\TenantAuditEventType;
+use App\Http\Controllers\Controller;
+use App\Models\Organisation;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ServiceOperationsExportController extends Controller
+{
+    public function __invoke(
+        Request $request,
+        Organisation $currentOrganisation,
+        BuildServiceOperationsDashboard $buildDashboard,
+        RecordTenantAuditEvent $recordAudit,
+    ): StreamedResponse {
+        $programId = $request->filled('program_id') ? $request->integer('program_id') : null;
+        $dashboard = $buildDashboard->handle($request->user(), $currentOrganisation, $programId);
+        $recordCount = collect(['caseload', 'waitlist', 'overdue', 'risks', 'referrals'])->sum(fn (string $key): int => count($dashboard[$key]));
+        $recordAudit->handle($currentOrganisation, TenantAuditEventType::ServiceOperationsExported, 'organisation', (string) $currentOrganisation->id, [
+            'program_id' => $programId,
+            'record_count' => $recordCount,
+        ], $request->user());
+
+        return response()->streamDownload(function () use ($dashboard): void {
+            $stream = fopen('php://output', 'wb');
+
+            if ($stream === false) {
+                return;
+            }
+
+            fputcsv($stream, ['queue', 'record_id', 'case_id', 'program', 'status', 'date']);
+
+            foreach ($dashboard['caseload'] as $row) {
+                fputcsv($stream, ['caseload', $row['id'], $row['id'], $this->spreadsheetSafe($row['program']), $row['status'], '']);
+            }
+
+            foreach ($dashboard['waitlist'] as $row) {
+                fputcsv($stream, ['waitlist', $row['id'], '', $this->spreadsheetSafe($row['program']), $row['status'], $row['since']]);
+            }
+
+            foreach ($dashboard['overdue'] as $row) {
+                fputcsv($stream, ['overdue', $row['id'], $row['caseId'], $this->spreadsheetSafe($row['program']), 'open', $row['dueAt']]);
+            }
+
+            foreach ($dashboard['risks'] as $row) {
+                fputcsv($stream, ['risk', $row['id'], $row['caseId'], $this->spreadsheetSafe($row['program']), 'unresolved', $row['effectiveAt']]);
+            }
+
+            foreach ($dashboard['referrals'] as $row) {
+                fputcsv($stream, ['referral', $row['id'], $row['caseId'], $this->spreadsheetSafe($row['program']), $row['status'], $row['effectiveAt']]);
+            }
+
+            fclose($stream);
+        }, 'service-operations.csv', [
+            'Content-Type' => 'text/csv; charset=UTF-8',
+            'Cache-Control' => 'private, no-store',
+            'X-Content-Type-Options' => 'nosniff',
+        ]);
+    }
+
+    private function spreadsheetSafe(string $value): string
+    {
+        return preg_match('/^\s*[=+\-@]/u', $value) === 1 ? "'{$value}" : $value;
+    }
+}

--- a/resources/js/dashboard.test.tsx
+++ b/resources/js/dashboard.test.tsx
@@ -1,0 +1,72 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import type { ComponentProps, ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import Dashboard from './pages/dashboard';
+
+vi.mock('@inertiajs/react', () => ({
+    Form: ({ children, ...props }: ComponentProps<'form'>) => (
+        <form {...props}>{children}</form>
+    ),
+    Head: () => null,
+    Link: ({ children, ...props }: ComponentProps<'a'>) => (
+        <a {...props}>{children}</a>
+    ),
+    usePage: () => ({
+        props: { currentOrganisation: { slug: 'harbour-kind' } },
+    }),
+}));
+
+vi.mock('@/components/pending-invitations-modal', () => ({
+    default: ({ children }: { children?: ReactNode }) => children ?? null,
+}));
+
+describe('Service operations dashboard', () => {
+    it('exposes labelled, keyboard-focusable controls and work links', () => {
+        render(
+            <Dashboard
+                serviceOperations={{
+                    programs: [{ id: 7, name: 'Family Support' }],
+                    selectedProgramId: null,
+                    counts: {
+                        caseload: 1,
+                        waitlist: 0,
+                        overdue: 0,
+                        risks: 0,
+                        referrals: 0,
+                    },
+                    caseload: [
+                        {
+                            id: 'case-1',
+                            program: 'Family Support',
+                            status: 'active',
+                        },
+                    ],
+                    waitlist: [],
+                    overdue: [],
+                    risks: [],
+                    referrals: [],
+                }}
+            />,
+        );
+
+        expect(
+            screen.getByRole('combobox', { name: 'Filter by program' }),
+        ).toHaveAccessibleName('Filter by program');
+        expect(
+            screen.getByRole('region', { name: 'Work queue counts' }),
+        ).toBeVisible();
+
+        const interactiveElements = [
+            ...screen.getAllByRole('button'),
+            ...screen.getAllByRole('link'),
+            screen.getByRole('combobox'),
+        ];
+
+        for (const element of interactiveElements) {
+            expect(element.tabIndex).toBe(0);
+            element.focus();
+            expect(element).toHaveFocus();
+        }
+    });
+});

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -1,18 +1,58 @@
-import { Head } from '@inertiajs/react';
+import { Form, Head, Link, usePage } from '@inertiajs/react';
 import { useState } from 'react';
 import PendingInvitationsModal from '@/components/pending-invitations-modal';
-import { PlaceholderPattern } from '@/components/ui/placeholder-pattern';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { dashboard } from '@/routes';
+import { show as showCase } from '@/routes/cases';
+import { show as showIntake } from '@/routes/intakes';
+import { exportMethod as exportServiceOperations } from '@/routes/dashboard/service-operations';
 import type { DashboardInvitation } from '@/types';
 
 type Props = {
     pendingInvitations?: DashboardInvitation[];
+    serviceOperations: ServiceOperations;
 };
 
-export default function Dashboard({ pendingInvitations = [] }: Props) {
+type ServiceOperationsRow = {
+    id: number | string;
+    caseId?: string;
+    program: string;
+    status?: string;
+    urgency?: string;
+    dueAt?: string | null;
+};
+
+type ServiceOperations = {
+    programs: Array<{ id: number; name: string }>;
+    selectedProgramId: number | null;
+    counts: Record<QueueKey, number>;
+    caseload: ServiceOperationsRow[];
+    waitlist: ServiceOperationsRow[];
+    overdue: ServiceOperationsRow[];
+    risks: ServiceOperationsRow[];
+    referrals: ServiceOperationsRow[];
+};
+
+const queueDefinitions = [
+    { key: 'caseload', label: 'Active caseload' },
+    { key: 'waitlist', label: 'Waitlist' },
+    { key: 'overdue', label: 'Overdue actions' },
+    { key: 'risks', label: 'Unresolved risks' },
+    { key: 'referrals', label: 'External referrals' },
+] as const;
+
+type QueueKey = (typeof queueDefinitions)[number]['key'];
+
+export default function Dashboard({
+    pendingInvitations = [],
+    serviceOperations,
+}: Props) {
     const [showInvitations, setShowInvitations] = useState(
         pendingInvitations.length > 0,
     );
+    const organisation = usePage().props.currentOrganisation!;
 
     return (
         <>
@@ -22,22 +62,172 @@ export default function Dashboard({ pendingInvitations = [] }: Props) {
                 open={pendingInvitations.length > 0 && showInvitations}
                 onOpenChange={setShowInvitations}
             />
-            <div className="flex h-full flex-1 flex-col gap-4 overflow-x-auto rounded-xl p-4">
-                <div className="grid auto-rows-min gap-4 md:grid-cols-3">
-                    <div className="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border">
-                        <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
+            <main className="flex h-full flex-1 flex-col gap-6 overflow-x-auto rounded-xl p-4">
+                <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+                    <div>
+                        <h1 className="text-2xl font-semibold">
+                            Service operations
+                        </h1>
+                        <p className="text-muted-foreground mt-1 text-sm">
+                            Work requiring attention within your current scope.
+                        </p>
                     </div>
-                    <div className="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border">
-                        <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
-                    </div>
-                    <div className="border-sidebar-border/70 dark:border-sidebar-border relative aspect-video overflow-hidden rounded-xl border">
-                        <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
+                    <div className="flex flex-wrap gap-2">
+                        <Form
+                            action={dashboard.url(organisation.slug)}
+                            method="get"
+                            className="flex gap-2"
+                        >
+                            <label className="sr-only" htmlFor="program-filter">
+                                Filter by program
+                            </label>
+                            <select
+                                id="program-filter"
+                                name="program_id"
+                                defaultValue={
+                                    serviceOperations.selectedProgramId ?? ''
+                                }
+                                className="h-9 rounded-md border bg-transparent px-3"
+                            >
+                                <option value="">
+                                    All authorised programs
+                                </option>
+                                {serviceOperations.programs.map((program) => (
+                                    <option key={program.id} value={program.id}>
+                                        {program.name}
+                                    </option>
+                                ))}
+                            </select>
+                            <Button variant="outline">Apply</Button>
+                        </Form>
+                        <Button asChild variant="outline">
+                            <a
+                                href={exportServiceOperations.url(
+                                    organisation.slug,
+                                    serviceOperations.selectedProgramId
+                                        ? {
+                                              query: {
+                                                  program_id:
+                                                      serviceOperations.selectedProgramId,
+                                              },
+                                          }
+                                        : undefined,
+                                )}
+                            >
+                                Export safe worklist
+                            </a>
+                        </Button>
                     </div>
                 </div>
-                <div className="border-sidebar-border/70 dark:border-sidebar-border relative min-h-[100vh] flex-1 overflow-hidden rounded-xl border md:min-h-min">
-                    <PlaceholderPattern className="absolute inset-0 size-full stroke-neutral-900/20 dark:stroke-neutral-100/20" />
+
+                <section
+                    aria-label="Work queue counts"
+                    className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5"
+                >
+                    {queueDefinitions.map(({ key, label }) => (
+                        <Card key={key}>
+                            <CardHeader className="pb-2">
+                                <CardTitle className="text-sm font-medium">
+                                    {label}
+                                </CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <p
+                                    className="text-3xl font-semibold"
+                                    aria-live="polite"
+                                >
+                                    {serviceOperations.counts[key]}
+                                </p>
+                            </CardContent>
+                        </Card>
+                    ))}
+                </section>
+
+                <div className="grid gap-5 xl:grid-cols-2">
+                    {queueDefinitions.map(({ key, label }) => {
+                        const rows = serviceOperations[key] ?? [];
+
+                        return (
+                            <Card key={key}>
+                                <CardHeader>
+                                    <CardTitle>{label}</CardTitle>
+                                </CardHeader>
+                                <CardContent>
+                                    {rows.length === 0 ? (
+                                        <p className="text-muted-foreground text-sm">
+                                            No accessible work in this queue.
+                                        </p>
+                                    ) : (
+                                        <ul
+                                            className="divide-y"
+                                            aria-label={label}
+                                        >
+                                            {rows.map((row) => (
+                                                <li
+                                                    key={row.id}
+                                                    className="flex items-center justify-between gap-3 py-3"
+                                                >
+                                                    <div>
+                                                        <p className="font-medium">
+                                                            {row.program}
+                                                        </p>
+                                                        <p className="text-muted-foreground text-sm">
+                                                            {row.status?.replaceAll(
+                                                                '_',
+                                                                ' ',
+                                                            ) ??
+                                                                (key === 'risks'
+                                                                    ? 'Safeguarding review'
+                                                                    : 'Action required')}
+                                                            {row.dueAt
+                                                                ? ` · due ${new Date(row.dueAt).toLocaleString()}`
+                                                                : ''}
+                                                        </p>
+                                                    </div>
+                                                    <div className="flex items-center gap-2">
+                                                        {row.urgency ? (
+                                                            <Badge variant="outline">
+                                                                {row.urgency}
+                                                            </Badge>
+                                                        ) : null}
+                                                        <Button
+                                                            asChild
+                                                            size="sm"
+                                                            variant="outline"
+                                                        >
+                                                            <Link
+                                                                href={
+                                                                    key ===
+                                                                    'waitlist'
+                                                                        ? showIntake.url(
+                                                                              [
+                                                                                  organisation.slug,
+                                                                                  row.id,
+                                                                              ],
+                                                                          )
+                                                                        : showCase.url(
+                                                                              [
+                                                                                  organisation.slug,
+                                                                                  row.caseId ??
+                                                                                      row.id,
+                                                                              ],
+                                                                          )
+                                                                }
+                                                            >
+                                                                Open
+                                                            </Link>
+                                                        </Button>
+                                                    </div>
+                                                </li>
+                                            ))}
+                                        </ul>
+                                    )}
+                                </CardContent>
+                            </Card>
+                        );
+                    })}
                 </div>
-            </div>
+            </main>
         </>
     );
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\Organisations\PartyRelationshipController;
 use App\Http\Controllers\Organisations\PartySafeContactInstructionController;
 use App\Http\Controllers\Organisations\ProgramController;
 use App\Http\Controllers\Organisations\ServiceCaseController;
+use App\Http\Controllers\Organisations\ServiceOperationsExportController;
 use App\Http\Controllers\Public\OrganisationController as PublicOrganisationController;
 use App\Http\Middleware\EnsureOrganisationAccess;
 use App\Http\Middleware\EnsureOrganisationMembership;
@@ -84,6 +85,7 @@ Route::prefix('{current_organisation}')
     ->middleware(['auth', 'verified', EnsureStaffSecurityRequirements::class, EnsureOrganisationMembership::class, UseOrganisationContext::class, EnsureOrganisationAccess::class.':full'])
     ->group(function () {
         Route::get('dashboard', DashboardController::class)->name('dashboard');
+        Route::get('dashboard/service-operations/export', ServiceOperationsExportController::class)->name('dashboard.service-operations.export');
         Route::get('programs', [ProgramController::class, 'index'])->name('programs.index');
         Route::resource('parties', PartyController::class)->only(['index', 'store', 'show', 'update']);
         Route::resource('intakes', IntakeRequestController::class)

--- a/tests/Feature/ServiceOperationsDashboardTest.php
+++ b/tests/Feature/ServiceOperationsDashboardTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use App\Actions\CaseConfidentiality\GrantRestrictedAccess;
+use App\Actions\Intake\AssignCaseWorker;
+use App\Enums\ExternalReferralStatus;
+use App\Enums\IntakeStatus;
+use App\Enums\OrganisationRole;
+use App\Enums\RestrictedAccessPermission;
+use App\Enums\TenantAuditEventType;
+use App\Models\CaseRiskAssessment;
+use App\Models\CaseTask;
+use App\Models\ExternalReferral;
+use App\Models\IntakeRequest;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\Program;
+use App\Models\ServiceCase;
+use App\Models\TenantAuditEvent;
+use App\Models\User;
+use App\OrganisationContext;
+use Inertia\Testing\AssertableInertia as Assert;
+
+function monitoringCase(Organisation $organisation, Program $program, string $partyName): ServiceCase
+{
+    return app(OrganisationContext::class)->run($organisation, function () use ($organisation, $partyName, $program): ServiceCase {
+        $party = Party::factory()->for($organisation)->create(['display_name' => $partyName]);
+        $intake = IntakeRequest::factory()->create(['program_id' => $program->id, 'party_id' => $party->id]);
+
+        return ServiceCase::factory()->create(['intake_request_id' => $intake->id, 'program_id' => $program->id, 'party_id' => $party->id]);
+    });
+}
+
+it('reconciles role-scoped service work without exposing inaccessible or sensitive records', function () {
+    $organisation = Organisation::factory()->active()->create();
+    $manager = User::factory()->create();
+    $worker = User::factory()->create();
+    $managerMembership = $organisation->memberships()->create(['user_id' => $manager->id, 'role' => OrganisationRole::ProgramManager]);
+    $workerMembership = $organisation->memberships()->create(['user_id' => $worker->id, 'role' => OrganisationRole::CaseWorker]);
+
+    [$visibleProgram, $secondVisibleProgram, $hiddenProgram] = app(OrganisationContext::class)->run($organisation, fn (): array => [
+        Program::factory()->for($organisation)->create(['name' => '=Visible Support']),
+        Program::factory()->for($organisation)->create(['name' => 'Second Visible Support']),
+        Program::factory()->for($organisation)->create(['name' => 'Hidden Support']),
+    ]);
+    app(OrganisationContext::class)->run($organisation, function () use ($managerMembership, $secondVisibleProgram, $visibleProgram, $workerMembership): void {
+        $managerMembership->programs()->attach([$visibleProgram->id, $secondVisibleProgram->id]);
+        $workerMembership->programs()->attach($visibleProgram);
+    });
+    $visibleCase = monitoringCase($organisation, $visibleProgram, 'Visible Client Name');
+    $unassignedCase = monitoringCase($organisation, $visibleProgram, 'Unassigned Client Name');
+    $hiddenCase = monitoringCase($organisation, $hiddenProgram, 'Hidden Client Name');
+
+    app(OrganisationContext::class)->run($organisation, function () use ($hiddenCase, $manager, $visibleCase, $visibleProgram, $workerMembership): void {
+        app(AssignCaseWorker::class)->handle($visibleCase, $workerMembership, $manager);
+        CaseTask::factory()->create(['service_case_id' => $visibleCase->id, 'due_at' => now()->subDay()]);
+        ExternalReferral::factory()->create(['service_case_id' => $visibleCase->id, 'status' => ExternalReferralStatus::Sent, 'effective_at' => now()->subHour()]);
+        CaseRiskAssessment::factory()->create(['service_case_id' => $visibleCase->id, 'encrypted_content' => 'Protected visible risk narrative.']);
+        CaseTask::factory()->create(['service_case_id' => $hiddenCase->id, 'due_at' => now()->subDay()]);
+        $waitlistParty = Party::factory()->for($visibleProgram->organisation)->create(['display_name' => 'Waitlisted Client Name']);
+        IntakeRequest::factory()->create(['program_id' => $visibleProgram->id, 'party_id' => $waitlistParty->id, 'status' => IntakeStatus::Waitlisted]);
+    });
+
+    $this->actingAs($manager)
+        ->get(route('dashboard', $organisation))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('serviceOperations.counts.caseload', 2)
+            ->where('serviceOperations.counts.waitlist', 1)
+            ->where('serviceOperations.counts.overdue', 1)
+            ->where('serviceOperations.counts.risks', 0)
+            ->where('serviceOperations.counts.referrals', 1)
+            ->has('serviceOperations.caseload', 2));
+    $this->actingAs($worker)
+        ->get(route('dashboard', $organisation))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('serviceOperations.counts.caseload', 1)
+            ->where('serviceOperations.counts.waitlist', 0)
+            ->where('serviceOperations.counts.overdue', 1)
+            ->where('serviceOperations.counts.risks', 0)
+            ->where('serviceOperations.counts.referrals', 1)
+            ->where('serviceOperations.caseload.0.id', $visibleCase->id)
+            ->missing('serviceOperations.caseload.1'));
+
+    app(OrganisationContext::class)->run($organisation, fn () => app(GrantRestrictedAccess::class)->handle(
+        $visibleCase, $managerMembership, RestrictedAccessPermission::SensitiveData, 'Safeguarding dashboard.', $manager,
+    ));
+    $this->actingAs($manager)
+        ->get(route('dashboard', [$organisation, 'program_id' => $visibleProgram->id]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('serviceOperations.selectedProgramId', $visibleProgram->id)
+            ->has('serviceOperations.programs', 2)
+            ->where('serviceOperations.counts.risks', 1));
+    $this->actingAs($manager)
+        ->get(route('dashboard', [$organisation, 'program_id' => $hiddenProgram->id]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('serviceOperations.counts.caseload', 0)
+            ->has('serviceOperations.programs', 2));
+
+    $export = $this->actingAs($manager)->get(route('dashboard.service-operations.export', $organisation))->assertOk();
+    expect($export->streamedContent())
+        ->toContain($visibleCase->id)
+        ->toContain($unassignedCase->id)
+        ->not->toContain($hiddenCase->id)
+        ->not->toContain('Visible Client Name')
+        ->not->toContain('Unassigned Client Name')
+        ->not->toContain('Hidden Client Name')
+        ->not->toContain('risk narrative')
+        ->toContain("'=Visible Support")
+        ->not->toContain(',=Visible Support');
+    app(OrganisationContext::class)->run($organisation, fn () => expect(TenantAuditEvent::query()->where('type', TenantAuditEventType::ServiceOperationsExported)->sole()->payload['record_count'])->toBe(6));
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,14 @@
 import react from '@vitejs/plugin-react';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
     plugins: [react()],
+    resolve: {
+        alias: {
+            '@': fileURLToPath(new URL('./resources/js', import.meta.url)),
+        },
+    },
     test: {
         environment: 'jsdom',
         include: ['resources/js/**/*.test.{ts,tsx}'],


### PR DESCRIPTION
## Summary
- add role-scoped service operations queues for caseloads, waitlists, overdue actions, unresolved risks, and external referrals
- preserve case confidentiality and sensitive-risk grants across dashboard counts, links, filters, and safe CSV exports
- add accessible, keyboard-focusable dashboard controls and automated frontend coverage

## Review fixes
- preserve all authorised Program choices when a filter is active
- use explicit assignment status enums and typed frontend data
- neutralise spreadsheet formulas in exported Program names
- keep frontend tests out of production page bundles
- verify case workers cannot see unassigned work in an otherwise-authorised Program

## Verification
- composer ci:check (297 tests, 1,523 assertions)
- npm test (2 tests)
- npm run build
- npm run licenses:check

Stacked on #55.

Closes #15