### PR TITLE
Complete a deterministic simulated donation lifecycle

### DIFF
--- a/app/Actions/Demo/BuildDonorToRetainedSupporterScenario.php
+++ b/app/Actions/Demo/BuildDonorToRetainedSupporterScenario.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Actions\Demo;
+
+use App\Actions\Donations\CreateDonation;
+use App\Donations\DonationPaymentProvider;
+use App\Enums\DonationFrequency;
+use App\Enums\DonationSimulationScenario;
+use App\Models\Donation;
+use App\Models\DonationFund;
+use App\Models\FundraisingCampaign;
+use App\Models\Party;
+
+class BuildDonorToRetainedSupporterScenario
+{
+    public function __construct(
+        private readonly CreateDonation $createDonation,
+        private readonly DonationPaymentProvider $paymentProvider,
+    ) {}
+
+    public function handle(Party $donor): Donation
+    {
+        $campaign = FundraisingCampaign::query()->updateOrCreate(
+            ['organisation_id' => $donor->organisation_id, 'slug' => 'winter-warmth-demo'],
+            ['name' => 'Winter Warmth Demo Appeal', 'is_simulated' => true],
+        );
+        $fund = DonationFund::query()->updateOrCreate(
+            ['organisation_id' => $donor->organisation_id, 'slug' => 'community-relief-demo'],
+            ['name' => 'Community Relief Demo Fund', 'is_simulated' => true],
+        );
+        $idempotencyKey = '30000000-0000-4000-8000-000000000002';
+        $donation = $this->createDonation->handle(
+            $donor,
+            $fund,
+            $campaign,
+            DonationFrequency::OneOff,
+            5000,
+            'ZAR',
+            'showcase_fixture',
+            $idempotencyKey,
+        );
+        $this->paymentProvider->process($donation, DonationSimulationScenario::Success, $idempotencyKey);
+
+        return $donation->refresh();
+    }
+}

--- a/app/Actions/Demo/BuildOrganisationScenario.php
+++ b/app/Actions/Demo/BuildOrganisationScenario.php
@@ -37,6 +37,7 @@ final class BuildOrganisationScenario
         private readonly OrganisationContext $organisationContext,
         private readonly StorePartyContact $storePartyContact,
         private readonly BuildRequestToOutcomeScenario $buildRequestToOutcomeScenario,
+        private readonly BuildDonorToRetainedSupporterScenario $buildDonorToRetainedSupporterScenario,
     ) {}
 
     /** @param ScenarioDefinition $scenario */
@@ -86,6 +87,9 @@ final class BuildOrganisationScenario
                         Party::query()->where('uuid', '12000000-0000-4000-8000-000000000001')->firstOrFail(),
                         User::query()->where('email', 'manager@harbourkind.example.test')->firstOrFail(),
                         Membership::query()->whereHas('user', fn ($query) => $query->where('email', 'caseworker@harbourkind.example.test'))->firstOrFail(),
+                    );
+                    $this->buildDonorToRetainedSupporterScenario->handle(
+                        Party::query()->where('uuid', '12000000-0000-4000-8000-000000000002')->firstOrFail(),
                     );
                 }
             });

--- a/app/Actions/Donations/CreateDonation.php
+++ b/app/Actions/Donations/CreateDonation.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Actions\Donations;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Actions\Parties\RecordPartyTimelineEvent;
+use App\Enums\DonationFrequency;
+use App\Enums\PartyBusinessRole;
+use App\Enums\PartyTimelineEventType;
+use App\Enums\TenantAuditEventType;
+use App\Models\Donation;
+use App\Models\DonationFund;
+use App\Models\FundraisingCampaign;
+use App\Models\Party;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use LogicException;
+
+class CreateDonation
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly RecordPartyTimelineEvent $recordTimeline,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    public function handle(
+        Party $party,
+        DonationFund $fund,
+        ?FundraisingCampaign $campaign,
+        DonationFrequency $frequency,
+        int $amountMinor,
+        string $currency,
+        string $sourceCode,
+        string $idempotencyKey,
+        ?User $actor = null,
+    ): Donation {
+        $this->context->ensureOwns($party->organisation_id);
+        $this->context->ensureOwns($fund->organisation_id);
+
+        if ($campaign !== null) {
+            $this->context->ensureOwns($campaign->organisation_id);
+        }
+
+        if ($amountMinor <= 0 || preg_match('/^[A-Z]{3}$/', $currency) !== 1 || blank($sourceCode) || ! Str::isUuid($idempotencyKey)) {
+            throw new LogicException('A simulated Donation requires valid immutable money, attribution, and idempotency values.');
+        }
+
+        return DB::transaction(function () use ($party, $fund, $campaign, $frequency, $amountMinor, $currency, $sourceCode, $idempotencyKey, $actor): Donation {
+            $donation = Donation::query()->firstOrCreate(
+                ['organisation_id' => $party->organisation_id, 'idempotency_key' => $idempotencyKey],
+                [
+                    'party_id' => $party->id,
+                    'fundraising_campaign_id' => $campaign?->id,
+                    'donation_fund_id' => $fund->id,
+                    'frequency' => $frequency,
+                    'amount_minor' => $amountMinor,
+                    'currency' => $currency,
+                    'source_code' => $sourceCode,
+                    'is_simulated' => true,
+                ],
+            );
+
+            $expected = [(int) $party->id, (int) $fund->id, $campaign === null ? null : (int) $campaign->id, $frequency->value, $amountMinor, $currency, $sourceCode];
+            $actual = [(int) $donation->party_id, (int) $donation->donation_fund_id, $donation->fundraising_campaign_id === null ? null : (int) $donation->fundraising_campaign_id, $donation->frequency->value, (int) $donation->amount_minor, $donation->currency, $donation->source_code];
+            if ($actual !== $expected) {
+                throw new LogicException('The Donation idempotency key was already used for different intent.');
+            }
+
+            if (! $donation->wasRecentlyCreated) {
+                return $donation;
+            }
+
+            $party->businessRoles()->firstOrCreate(
+                ['role' => PartyBusinessRole::Donor],
+                ['organisation_id' => $party->organisation_id],
+            );
+            $this->recordTimeline->handle($party, PartyTimelineEventType::DonationCreated, 'Simulated Donation intent created.', $actor, 'donation', $donation->id, ['frequency' => $frequency->value]);
+            $this->recordAudit->handle($party->organisation, TenantAuditEventType::DonationCreated, 'donation', $donation->id, ['donation_id' => $donation->id, 'frequency' => $frequency->value], $actor);
+
+            return $donation;
+        });
+    }
+}

--- a/app/Actions/Donations/CreateDonationPayment.php
+++ b/app/Actions/Donations/CreateDonationPayment.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Actions\Donations;
+
+use App\Enums\DonationPaymentStatus;
+use App\Enums\RecurringMandateStatus;
+use App\Models\Donation;
+use App\Models\DonationPayment;
+use App\Models\RecurringMandate;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use LogicException;
+use Ramsey\Uuid\Uuid;
+
+class CreateDonationPayment
+{
+    public function __construct(private readonly OrganisationContext $context) {}
+
+    public function handle(Donation $donation, string $idempotencyKey, ?RecurringMandate $mandate = null): DonationPayment
+    {
+        $this->context->ensureOwns($donation->organisation_id);
+        if (! Str::isUuid($idempotencyKey)) {
+            throw new LogicException('A Donation Payment requires a UUID idempotency key.');
+        }
+
+        return DB::transaction(function () use ($donation, $idempotencyKey, $mandate): DonationPayment {
+            $lockedDonation = Donation::query()->lockForUpdate()->findOrFail($donation->id);
+            $existing = DonationPayment::query()->where('idempotency_key', $idempotencyKey)->first();
+            if ($existing !== null) {
+                if ($existing->donation_id !== $lockedDonation->id || $existing->recurring_mandate_id !== $mandate?->id) {
+                    throw new LogicException('The Donation Payment idempotency key was already used for another attempt.');
+                }
+
+                return $existing;
+            }
+
+            if ($mandate !== null) {
+                $lockedMandate = RecurringMandate::query()->lockForUpdate()->findOrFail($mandate->id);
+                if ($lockedMandate->donation_id !== $lockedDonation->id || $lockedMandate->status === RecurringMandateStatus::Cancelled) {
+                    throw new LogicException('The Recurring Mandate cannot create this Donation Payment.');
+                }
+            }
+
+            $attemptNumber = DonationPayment::query()->where('donation_id', $lockedDonation->id)->max('attempt_number') + 1;
+
+            return DonationPayment::query()->create([
+                'organisation_id' => $lockedDonation->organisation_id,
+                'donation_id' => $lockedDonation->id,
+                'recurring_mandate_id' => $mandate?->id,
+                'attempt_number' => $attemptNumber,
+                'amount_minor' => $lockedDonation->amount_minor,
+                'currency' => $lockedDonation->currency,
+                'status' => DonationPaymentStatus::Created,
+                'version' => 1,
+                'idempotency_key' => $idempotencyKey,
+                'provider_payment_id' => 'sim_payment_'.str_replace('-', '', Uuid::uuid5($lockedDonation->id, $idempotencyKey)->toString()),
+            ]);
+        });
+    }
+}

--- a/app/Actions/Donations/CreateRecurringMandate.php
+++ b/app/Actions/Donations/CreateRecurringMandate.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Actions\Donations;
+
+use App\Enums\DonationFrequency;
+use App\Enums\RecurringMandateStatus;
+use App\Models\Donation;
+use App\Models\RecurringMandate;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class CreateRecurringMandate
+{
+    public function __construct(private readonly OrganisationContext $context) {}
+
+    public function handle(Donation $donation): RecurringMandate
+    {
+        $this->context->ensureOwns($donation->organisation_id);
+        if ($donation->frequency !== DonationFrequency::Monthly) {
+            throw new LogicException('Only a monthly Donation can create a Recurring Mandate.');
+        }
+
+        return DB::transaction(function () use ($donation): RecurringMandate {
+            $locked = Donation::query()->lockForUpdate()->findOrFail($donation->id);
+
+            return RecurringMandate::query()->firstOrCreate(
+                ['organisation_id' => $locked->organisation_id, 'donation_id' => $locked->id],
+                [
+                    'party_id' => $locked->party_id,
+                    'amount_minor' => $locked->amount_minor,
+                    'currency' => $locked->currency,
+                    'interval' => 'monthly',
+                    'status' => RecurringMandateStatus::Pending,
+                    'version' => 1,
+                    'provider_mandate_id' => 'sim_mandate_'.str_replace('-', '', $locked->id),
+                ],
+            );
+        });
+    }
+}

--- a/app/Actions/Donations/MakePublicSimulatedDonation.php
+++ b/app/Actions/Donations/MakePublicSimulatedDonation.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Actions\Donations;
+
+use App\Donations\DonationPaymentProvider;
+use App\Enums\DonationFrequency;
+use App\Enums\DonationSimulationScenario;
+use App\Enums\PartyKind;
+use App\Models\Donation;
+use App\Models\DonationFund;
+use App\Models\FundraisingCampaign;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use LogicException;
+use Ramsey\Uuid\Uuid;
+
+class MakePublicSimulatedDonation
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly CreateDonation $createDonation,
+        private readonly CreateRecurringMandate $createMandate,
+        private readonly DonationPaymentProvider $paymentProvider,
+    ) {}
+
+    public function handle(
+        Organisation $organisation,
+        DonationFund $fund,
+        ?FundraisingCampaign $campaign,
+        DonationFrequency $frequency,
+        int $amountMinor,
+        string $idempotencyKey,
+    ): Donation {
+        $this->context->ensureOwns($organisation->id);
+        if (! $fund->is_simulated || ($campaign !== null && ! $campaign->is_simulated) || ! Str::isUuid($idempotencyKey)) {
+            throw new LogicException('The public demo accepts simulated fundraising choices only.');
+        }
+
+        return DB::transaction(function () use ($organisation, $fund, $campaign, $frequency, $amountMinor, $idempotencyKey): Donation {
+            $partyUuid = Uuid::uuid5($organisation->uuid, "public-demo-donation:{$idempotencyKey}")->toString();
+            $party = Party::query()->where('uuid', $partyUuid)->first();
+            if ($party === null) {
+                $party = new Party;
+                $party->forceFill([
+                    'uuid' => $partyUuid,
+                    'organisation_id' => $organisation->id,
+                    'kind' => PartyKind::Person,
+                    'display_name' => 'Simulated Supporter '.strtoupper(substr(str_replace('-', '', $idempotencyKey), 0, 8)),
+                ])->save();
+                $party->refresh();
+            }
+            $donation = $this->createDonation->handle($party, $fund, $campaign, $frequency, $amountMinor, 'ZAR', 'public_demo', $idempotencyKey);
+
+            if ($frequency === DonationFrequency::Monthly) {
+                $this->createMandate->handle($donation);
+                $donation->unsetRelation('mandate');
+            }
+
+            $this->paymentProvider->process($donation->refresh(), DonationSimulationScenario::Success, $idempotencyKey);
+
+            return $donation->refresh()->load(['campaign', 'fund', 'mandate', 'payments.receipt', 'payments.refunds']);
+        });
+    }
+}

--- a/app/Actions/Donations/RefundDonationPayment.php
+++ b/app/Actions/Donations/RefundDonationPayment.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Actions\Donations;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Actions\Parties\RecordPartyTimelineEvent;
+use App\Enums\DonationPaymentStatus;
+use App\Enums\PartyTimelineEventType;
+use App\Enums\TenantAuditEventType;
+use App\Models\DonationPayment;
+use App\Models\DonationPaymentEvent;
+use App\Models\DonationRefund;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use LogicException;
+use Ramsey\Uuid\Uuid;
+
+class RefundDonationPayment
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly RecordPartyTimelineEvent $recordTimeline,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    public function handle(DonationPayment $payment, int $amountMinor, string $idempotencyKey, CarbonInterface $occurredAt, ?User $actor = null): DonationRefund
+    {
+        $this->context->ensureOwns($payment->organisation_id);
+        if ($amountMinor <= 0 || ! Str::isUuid($idempotencyKey)) {
+            throw new LogicException('A simulated refund requires a positive amount and UUID idempotency key.');
+        }
+
+        return DB::transaction(function () use ($payment, $amountMinor, $idempotencyKey, $occurredAt, $actor): DonationRefund {
+            $locked = DonationPayment::query()->with('donation.party')->lockForUpdate()->findOrFail($payment->id);
+            $existing = DonationRefund::query()->where('idempotency_key', $idempotencyKey)->first();
+            if ($existing !== null) {
+                if ($existing->donation_payment_id !== $locked->id || $existing->amount_minor !== $amountMinor) {
+                    throw new LogicException('The refund idempotency key conflicts with another refund.');
+                }
+
+                return $existing;
+            }
+
+            if (! in_array($locked->status, [DonationPaymentStatus::Succeeded, DonationPaymentStatus::PartiallyRefunded], true)) {
+                throw new LogicException('Only a settled Donation Payment can be refunded.');
+            }
+
+            $refundedMinor = (int) DonationRefund::query()->where('donation_payment_id', $locked->id)->sum('amount_minor');
+            if ($refundedMinor + $amountMinor > $locked->amount_minor) {
+                throw new LogicException('Refunds cannot exceed the settled Donation Payment amount.');
+            }
+
+            $refund = DonationRefund::query()->create([
+                'organisation_id' => $locked->organisation_id,
+                'donation_payment_id' => $locked->id,
+                'amount_minor' => $amountMinor,
+                'currency' => $locked->currency,
+                'idempotency_key' => $idempotencyKey,
+                'provider_refund_id' => 'sim_refund_'.str_replace('-', '', Uuid::uuid5($locked->id, $idempotencyKey)->toString()),
+                'occurred_at' => $occurredAt,
+            ]);
+            $from = $locked->status;
+            $to = $refundedMinor + $amountMinor === $locked->amount_minor
+                ? DonationPaymentStatus::Refunded
+                : DonationPaymentStatus::PartiallyRefunded;
+            $locked->forceFill(['status' => $to, 'version' => $locked->version + 1])->save();
+            DonationPaymentEvent::query()->create([
+                'organisation_id' => $locked->organisation_id,
+                'donation_payment_id' => $locked->id,
+                'idempotency_key' => $idempotencyKey,
+                'provider_event_id' => 'sim_event_'.str_replace('-', '', Uuid::uuid5($locked->id, $idempotencyKey)->toString()),
+                'from_status' => $from,
+                'to_status' => $to,
+                'occurred_at' => $occurredAt,
+            ]);
+            $this->recordTimeline->handle($locked->donation->party, PartyTimelineEventType::DonationRefunded, 'Simulated Donation Payment refund recorded.', $actor, 'donation_refund', $refund->id, ['payment_id' => $locked->id]);
+            $this->recordAudit->handle($locked->donation->party->organisation, TenantAuditEventType::DonationRefunded, 'donation_refund', $refund->id, ['donation_id' => $locked->donation_id, 'payment_id' => $locked->id, 'refund_id' => $refund->id], $actor);
+
+            return $refund;
+        });
+    }
+}

--- a/app/Actions/Donations/TransitionDonationPayment.php
+++ b/app/Actions/Donations/TransitionDonationPayment.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Actions\Donations;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Actions\Parties\RecordPartyTimelineEvent;
+use App\Enums\DonationPaymentStatus;
+use App\Enums\PartyTimelineEventType;
+use App\Enums\TenantAuditEventType;
+use App\Models\DonationPayment;
+use App\Models\DonationPaymentEvent;
+use App\Models\DonationReceipt;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use LogicException;
+use Ramsey\Uuid\Uuid;
+
+class TransitionDonationPayment
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly RecordPartyTimelineEvent $recordTimeline,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    public function handle(DonationPayment $payment, DonationPaymentStatus $to, string $idempotencyKey, CarbonInterface $occurredAt, ?User $actor = null): DonationPayment
+    {
+        $this->context->ensureOwns($payment->organisation_id);
+        if (! Str::isUuid($idempotencyKey)) {
+            throw new LogicException('A Donation Payment transition requires a UUID idempotency key.');
+        }
+
+        return DB::transaction(function () use ($payment, $to, $idempotencyKey, $occurredAt, $actor): DonationPayment {
+            $locked = DonationPayment::query()->with('donation.party')->lockForUpdate()->findOrFail($payment->id);
+            $existingEvent = DonationPaymentEvent::query()->where('idempotency_key', $idempotencyKey)->first();
+            if ($existingEvent !== null) {
+                if ($existingEvent->donation_payment_id !== $locked->id || $existingEvent->to_status !== $to) {
+                    throw new LogicException('The provider event idempotency key conflicts with another transition.');
+                }
+
+                return $locked;
+            }
+
+            if (! in_array($to, $locked->status->allowedTransitions(), true)) {
+                throw new LogicException("Cannot transition Donation Payment from {$locked->status->value} to {$to->value}.");
+            }
+
+            $from = $locked->status;
+            $locked->forceFill([
+                'status' => $to,
+                'version' => $locked->version + 1,
+                'settled_at' => $to === DonationPaymentStatus::Succeeded ? $occurredAt : $locked->settled_at,
+            ])->save();
+            DonationPaymentEvent::query()->create([
+                'organisation_id' => $locked->organisation_id,
+                'donation_payment_id' => $locked->id,
+                'idempotency_key' => $idempotencyKey,
+                'provider_event_id' => 'sim_event_'.str_replace('-', '', Uuid::uuid5($locked->id, $idempotencyKey)->toString()),
+                'from_status' => $from,
+                'to_status' => $to,
+                'occurred_at' => $occurredAt,
+            ]);
+
+            if ($to === DonationPaymentStatus::Succeeded) {
+                DonationReceipt::query()->firstOrCreate(
+                    ['organisation_id' => $locked->organisation_id, 'donation_payment_id' => $locked->id],
+                    [
+                        'donation_id' => $locked->donation_id,
+                        'receipt_number' => 'DEMO-'.strtoupper(substr(str_replace('-', '', $locked->id), 0, 20)),
+                        'amount_minor' => $locked->amount_minor,
+                        'currency' => $locked->currency,
+                        'marker' => 'Demo—Not a tax receipt',
+                        'issued_at' => $occurredAt,
+                    ],
+                );
+            }
+
+            $this->recordTimeline->handle($locked->donation->party, PartyTimelineEventType::DonationPaymentTransitioned, "Simulated Donation Payment changed from {$from->value} to {$to->value}.", $actor, 'donation_payment', $locked->id, ['status' => $to->value]);
+            $this->recordAudit->handle($locked->donation->party->organisation, TenantAuditEventType::DonationPaymentTransitioned, 'donation_payment', $locked->id, [
+                'donation_id' => $locked->donation_id,
+                'payment_id' => $locked->id,
+                'from_status' => $from->value,
+                'to_status' => $to->value,
+            ], $actor);
+
+            return $locked->refresh();
+        });
+    }
+}

--- a/app/Actions/Donations/TransitionRecurringMandate.php
+++ b/app/Actions/Donations/TransitionRecurringMandate.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Actions\Donations;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Actions\Parties\RecordPartyTimelineEvent;
+use App\Enums\DonationPaymentStatus;
+use App\Enums\PartyTimelineEventType;
+use App\Enums\RecurringMandateStatus;
+use App\Enums\TenantAuditEventType;
+use App\Models\DonationPayment;
+use App\Models\RecurringMandate;
+use App\Models\RecurringMandateEvent;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonInterface;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use LogicException;
+use Ramsey\Uuid\Uuid;
+
+class TransitionRecurringMandate
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly RecordPartyTimelineEvent $recordTimeline,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    public function handle(RecurringMandate $mandate, RecurringMandateStatus $to, string $idempotencyKey, CarbonInterface $occurredAt, ?DonationPayment $evidence = null, ?User $actor = null): RecurringMandate
+    {
+        $this->context->ensureOwns($mandate->organisation_id);
+        if (! Str::isUuid($idempotencyKey)) {
+            throw new LogicException('A Recurring Mandate transition requires a UUID idempotency key.');
+        }
+
+        return DB::transaction(function () use ($mandate, $to, $idempotencyKey, $occurredAt, $evidence, $actor): RecurringMandate {
+            $locked = RecurringMandate::query()->with('party')->lockForUpdate()->findOrFail($mandate->id);
+            $existingEvent = RecurringMandateEvent::query()->where('idempotency_key', $idempotencyKey)->first();
+            if ($existingEvent !== null) {
+                if ($existingEvent->recurring_mandate_id !== $locked->id || $existingEvent->to_status !== $to) {
+                    throw new LogicException('The provider event idempotency key conflicts with another Recurring Mandate transition.');
+                }
+
+                return $locked;
+            }
+
+            if (! in_array($to, $locked->status->allowedTransitions(), true)) {
+                throw new LogicException("Cannot transition Recurring Mandate from {$locked->status->value} to {$to->value}.");
+            }
+
+            $lockedEvidence = $evidence === null ? null : DonationPayment::query()->lockForUpdate()->findOrFail($evidence->id);
+            if ($to === RecurringMandateStatus::Active && ($lockedEvidence?->recurring_mandate_id !== $locked->id || $lockedEvidence->status !== DonationPaymentStatus::Succeeded)) {
+                throw new LogicException('Activating or recovering a Recurring Mandate requires a new successful Donation Payment.');
+            }
+            if ($to === RecurringMandateStatus::PaymentFailed && ($lockedEvidence?->recurring_mandate_id !== $locked->id || $lockedEvidence->status !== DonationPaymentStatus::Failed)) {
+                throw new LogicException('A failed Recurring Mandate requires a failed Donation Payment.');
+            }
+            $lastFailedPaymentId = $locked->events()->where('to_status', RecurringMandateStatus::PaymentFailed)->latest('occurred_at')->value('donation_payment_id');
+            $lastFailedAttempt = $lastFailedPaymentId === null ? null : DonationPayment::query()->whereKey($lastFailedPaymentId)->value('attempt_number');
+            if ($to === RecurringMandateStatus::Active && $lastFailedAttempt !== null && $lockedEvidence->attempt_number <= $lastFailedAttempt) {
+                throw new LogicException('Recurring Mandate recovery requires a successful Donation Payment after the failure.');
+            }
+
+            $from = $locked->status;
+            $locked->forceFill([
+                'status' => $to,
+                'version' => $locked->version + 1,
+                'cancelled_at' => $to === RecurringMandateStatus::Cancelled ? $occurredAt : null,
+            ])->save();
+            RecurringMandateEvent::query()->create([
+                'organisation_id' => $locked->organisation_id,
+                'recurring_mandate_id' => $locked->id,
+                'donation_payment_id' => $lockedEvidence?->id,
+                'idempotency_key' => $idempotencyKey,
+                'provider_event_id' => 'sim_event_'.str_replace('-', '', Uuid::uuid5($locked->id, $idempotencyKey)->toString()),
+                'from_status' => $from,
+                'to_status' => $to,
+                'occurred_at' => $occurredAt,
+            ]);
+            $this->recordTimeline->handle($locked->party, PartyTimelineEventType::RecurringMandateTransitioned, "Simulated Recurring Mandate changed from {$from->value} to {$to->value}.", $actor, 'recurring_mandate', $locked->id, ['status' => $to->value]);
+            $this->recordAudit->handle($locked->party->organisation, TenantAuditEventType::RecurringMandateTransitioned, 'recurring_mandate', $locked->id, [
+                'donation_id' => $locked->donation_id,
+                'mandate_id' => $locked->id,
+                'from_status' => $from->value,
+                'to_status' => $to->value,
+            ], $actor);
+
+            return $locked->refresh();
+        });
+    }
+}

--- a/app/Donations/DonationPaymentProvider.php
+++ b/app/Donations/DonationPaymentProvider.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Donations;
+
+use App\Enums\DonationSimulationScenario;
+use App\Models\Donation;
+use App\Models\DonationPayment;
+
+interface DonationPaymentProvider
+{
+    public function process(Donation $donation, DonationSimulationScenario $scenario, string $idempotencyKey): DonationPayment;
+}

--- a/app/Donations/SimulatedDonationPaymentProvider.php
+++ b/app/Donations/SimulatedDonationPaymentProvider.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Donations;
+
+use App\Actions\Donations\CreateDonationPayment;
+use App\Actions\Donations\RefundDonationPayment;
+use App\Actions\Donations\TransitionDonationPayment;
+use App\Actions\Donations\TransitionRecurringMandate;
+use App\Enums\DonationPaymentStatus;
+use App\Enums\DonationSimulationScenario;
+use App\Enums\RecurringMandateStatus;
+use App\Models\Donation;
+use App\Models\DonationPayment;
+use App\Models\RecurringMandate;
+use LogicException;
+use Ramsey\Uuid\Uuid;
+
+class SimulatedDonationPaymentProvider implements DonationPaymentProvider
+{
+    public function __construct(
+        private readonly CreateDonationPayment $createPayment,
+        private readonly TransitionDonationPayment $transitionPayment,
+        private readonly RefundDonationPayment $refundPayment,
+        private readonly TransitionRecurringMandate $transitionMandate,
+    ) {}
+
+    public function process(Donation $donation, DonationSimulationScenario $scenario, string $idempotencyKey): DonationPayment
+    {
+        return match ($scenario) {
+            DonationSimulationScenario::Success => $this->successfulAttempt($donation, $idempotencyKey),
+            DonationSimulationScenario::Decline => $this->failedAttempt($donation, $idempotencyKey),
+            DonationSimulationScenario::TimeoutThenSuccess => $this->timeoutThenSuccess($donation, $idempotencyKey),
+            DonationSimulationScenario::PartialRefund => $this->partiallyRefundedAttempt($donation, $idempotencyKey),
+            DonationSimulationScenario::RecurringFailure => $this->recurringFailure($donation, $idempotencyKey),
+        };
+    }
+
+    private function successfulAttempt(Donation $donation, string $idempotencyKey): DonationPayment
+    {
+        $mandate = $donation->mandate;
+        $payment = $this->createPayment->handle($donation, $this->key($idempotencyKey, 'payment'), $mandate);
+        $payment = $this->transitionPayment->handle($payment, DonationPaymentStatus::Pending, $this->key($idempotencyKey, 'pending'), now());
+        $payment = $this->transitionPayment->handle($payment, DonationPaymentStatus::Succeeded, $this->key($idempotencyKey, 'succeeded'), now());
+
+        if ($mandate !== null && in_array($mandate->fresh()->status, [RecurringMandateStatus::Pending, RecurringMandateStatus::PaymentFailed], true)) {
+            $this->transitionMandate->handle($mandate->fresh(), RecurringMandateStatus::Active, $this->key($idempotencyKey, 'mandate-active'), now(), $payment);
+        }
+
+        return $payment;
+    }
+
+    private function failedAttempt(Donation $donation, string $idempotencyKey): DonationPayment
+    {
+        $payment = $this->createPayment->handle($donation, $this->key($idempotencyKey, 'payment'), $donation->mandate);
+        $payment = $this->transitionPayment->handle($payment, DonationPaymentStatus::Pending, $this->key($idempotencyKey, 'pending'), now());
+
+        return $this->transitionPayment->handle($payment, DonationPaymentStatus::Failed, $this->key($idempotencyKey, 'failed'), now());
+    }
+
+    private function timeoutThenSuccess(Donation $donation, string $idempotencyKey): DonationPayment
+    {
+        $this->failedAttempt($donation, $this->key($idempotencyKey, 'timeout-attempt'));
+
+        return $this->successfulAttempt($donation, $this->key($idempotencyKey, 'retry-attempt'));
+    }
+
+    private function partiallyRefundedAttempt(Donation $donation, string $idempotencyKey): DonationPayment
+    {
+        $payment = $this->successfulAttempt($donation, $idempotencyKey);
+        $this->refundPayment->handle($payment, max(1, intdiv($payment->amount_minor, 2)), $this->key($idempotencyKey, 'partial-refund'), now());
+
+        return $payment->refresh();
+    }
+
+    private function recurringFailure(Donation $donation, string $idempotencyKey): DonationPayment
+    {
+        $mandate = $donation->mandate;
+        if (! $mandate instanceof RecurringMandate || $mandate->status !== RecurringMandateStatus::Active) {
+            throw new LogicException('The recurring-failure scenario requires an active simulated Recurring Mandate.');
+        }
+
+        $payment = $this->failedAttempt($donation, $idempotencyKey);
+        $this->transitionMandate->handle($mandate, RecurringMandateStatus::PaymentFailed, $this->key($idempotencyKey, 'mandate-failed'), now(), $payment);
+
+        return $payment;
+    }
+
+    private function key(string $namespace, string $name): string
+    {
+        return Uuid::uuid5($namespace, $name)->toString();
+    }
+}

--- a/app/Enums/DonationFrequency.php
+++ b/app/Enums/DonationFrequency.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum DonationFrequency: string
+{
+    case OneOff = 'one_off';
+    case Monthly = 'monthly';
+}

--- a/app/Enums/DonationPaymentStatus.php
+++ b/app/Enums/DonationPaymentStatus.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Enums;
+
+enum DonationPaymentStatus: string
+{
+    case Created = 'created';
+    case Pending = 'pending';
+    case Succeeded = 'succeeded';
+    case Failed = 'failed';
+    case Cancelled = 'cancelled';
+    case PartiallyRefunded = 'partially_refunded';
+    case Refunded = 'refunded';
+
+    /** @return list<self> */
+    public function allowedTransitions(): array
+    {
+        return match ($this) {
+            self::Created => [self::Pending, self::Cancelled],
+            self::Pending => [self::Succeeded, self::Failed, self::Cancelled],
+            self::Succeeded => [self::PartiallyRefunded, self::Refunded],
+            self::PartiallyRefunded => [self::PartiallyRefunded, self::Refunded],
+            self::Failed, self::Cancelled, self::Refunded => [],
+        };
+    }
+}

--- a/app/Enums/DonationSimulationScenario.php
+++ b/app/Enums/DonationSimulationScenario.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum DonationSimulationScenario: string
+{
+    case Success = 'success';
+    case Decline = 'decline';
+    case TimeoutThenSuccess = 'timeout_then_success';
+    case PartialRefund = 'partial_refund';
+    case RecurringFailure = 'recurring_failure';
+}

--- a/app/Enums/PartyTimelineEventType.php
+++ b/app/Enums/PartyTimelineEventType.php
@@ -12,4 +12,8 @@ enum PartyTimelineEventType: string
     case InterestAdded = 'interest_added';
     case ConsentRecorded = 'consent_recorded';
     case SafeContactInstructionRecorded = 'safe_contact_instruction_recorded';
+    case DonationCreated = 'donation_created';
+    case DonationPaymentTransitioned = 'donation_payment_transitioned';
+    case DonationRefunded = 'donation_refunded';
+    case RecurringMandateTransitioned = 'recurring_mandate_transitioned';
 }

--- a/app/Enums/RecurringMandateStatus.php
+++ b/app/Enums/RecurringMandateStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Enums;
+
+enum RecurringMandateStatus: string
+{
+    case Pending = 'pending';
+    case Active = 'active';
+    case PaymentFailed = 'payment_failed';
+    case Cancelled = 'cancelled';
+
+    /** @return list<self> */
+    public function allowedTransitions(): array
+    {
+        return match ($this) {
+            self::Pending => [self::Active, self::Cancelled],
+            self::Active => [self::PaymentFailed, self::Cancelled],
+            self::PaymentFailed => [self::Active, self::Cancelled],
+            self::Cancelled => [],
+        };
+    }
+}

--- a/app/Enums/TenantAuditEventType.php
+++ b/app/Enums/TenantAuditEventType.php
@@ -18,6 +18,10 @@ enum TenantAuditEventType: string
     case CaseDocumentDownloaded = 'case_document_downloaded';
     case CaseDocumentReplaced = 'case_document_replaced';
     case ServiceOperationsExported = 'service_operations_exported';
+    case DonationCreated = 'donation_created';
+    case DonationPaymentTransitioned = 'donation_payment_transitioned';
+    case DonationRefunded = 'donation_refunded';
+    case RecurringMandateTransitioned = 'recurring_mandate_transitioned';
 
     /** @return array<string, string> */
     public function payloadSchema(): array
@@ -80,6 +84,27 @@ enum TenantAuditEventType: string
             self::ServiceOperationsExported => [
                 'program_id' => 'nullable_integer',
                 'record_count' => 'integer',
+            ],
+            self::DonationCreated => [
+                'donation_id' => 'string',
+                'frequency' => 'string',
+            ],
+            self::DonationPaymentTransitioned => [
+                'donation_id' => 'string',
+                'payment_id' => 'string',
+                'from_status' => 'string',
+                'to_status' => 'string',
+            ],
+            self::DonationRefunded => [
+                'donation_id' => 'string',
+                'payment_id' => 'string',
+                'refund_id' => 'string',
+            ],
+            self::RecurringMandateTransitioned => [
+                'donation_id' => 'string',
+                'mandate_id' => 'string',
+                'from_status' => 'string',
+                'to_status' => 'string',
             ],
         };
     }

--- a/app/Http/Controllers/Organisations/DonationController.php
+++ b/app/Http/Controllers/Organisations/DonationController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Http\Controllers\Controller;
+use App\Models\Donation;
+use App\Models\Organisation;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class DonationController extends Controller
+{
+    public function index(Organisation $currentOrganisation): Response
+    {
+        Gate::authorize('viewAny', [Donation::class, $currentOrganisation]);
+
+        return Inertia::render('donations/index', [
+            'donations' => Donation::query()
+                ->with(['party:id,uuid,display_name', 'campaign:id,name', 'fund:id,name', 'mandate:id,donation_id,status'])
+                ->withCount('payments')
+                ->latest()
+                ->paginate(25)
+                ->through(fn (Donation $donation): array => [
+                    'id' => $donation->id,
+                    'supporter' => $donation->party->display_name,
+                    'campaign' => $donation->campaign?->name,
+                    'fund' => $donation->fund->name,
+                    'frequency' => $donation->frequency->value,
+                    'amountMinor' => $donation->amount_minor,
+                    'currency' => $donation->currency,
+                    'source' => $donation->source_code,
+                    'mandateStatus' => $donation->mandate?->status->value,
+                    'paymentCount' => $donation->payments_count,
+                    'createdAt' => $donation->created_at?->toAtomString(),
+                ]),
+        ]);
+    }
+
+    public function show(Organisation $currentOrganisation, string $donation): Response
+    {
+        $donation = Donation::query()->findOrFail($donation);
+        Gate::authorize('view', $donation);
+        $donation->load([
+            'party:id,uuid,display_name',
+            'campaign:id,name',
+            'fund:id,name',
+            'mandate.events',
+            'payments' => fn ($query) => $query->orderBy('attempt_number'),
+            'payments.events',
+            'payments.refunds',
+            'payments.receipt',
+        ]);
+
+        return Inertia::render('donations/show', [
+            'donation' => [
+                'id' => $donation->id,
+                'supporter' => $donation->party->display_name,
+                'campaign' => $donation->campaign?->name,
+                'fund' => $donation->fund->name,
+                'frequency' => $donation->frequency->value,
+                'amountMinor' => $donation->amount_minor,
+                'currency' => $donation->currency,
+                'source' => $donation->source_code,
+                'createdAt' => $donation->created_at?->toAtomString(),
+                'mandate' => $donation->mandate === null ? null : [
+                    'id' => $donation->mandate->id,
+                    'status' => $donation->mandate->status->value,
+                    'providerId' => $donation->mandate->provider_mandate_id,
+                    'events' => $donation->mandate->events->map(fn ($event): array => ['from' => $event->from_status->value, 'to' => $event->to_status->value, 'occurredAt' => $event->occurred_at->toAtomString()])->values(),
+                ],
+                'payments' => $donation->payments->map(fn ($payment): array => [
+                    'id' => $payment->id,
+                    'attemptNumber' => $payment->attempt_number,
+                    'status' => $payment->status->value,
+                    'providerId' => $payment->provider_payment_id,
+                    'amountMinor' => $payment->amount_minor,
+                    'currency' => $payment->currency,
+                    'settledAt' => $payment->settled_at?->toAtomString(),
+                    'events' => $payment->events->map(fn ($event): array => ['from' => $event->from_status->value, 'to' => $event->to_status->value, 'occurredAt' => $event->occurred_at->toAtomString()])->values(),
+                    'refunds' => $payment->refunds->map(fn ($refund): array => ['id' => $refund->id, 'amountMinor' => $refund->amount_minor, 'occurredAt' => $refund->occurred_at->toAtomString()])->values(),
+                    'receipt' => $payment->receipt === null ? null : ['number' => $payment->receipt->receipt_number, 'marker' => $payment->receipt->marker, 'issuedAt' => $payment->receipt->issued_at->toAtomString()],
+                ])->values(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Public/DonationController.php
+++ b/app/Http/Controllers/Public/DonationController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\Public;
+
+use App\Actions\Donations\MakePublicSimulatedDonation;
+use App\Enums\DonationFrequency;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Public\StoreDonationRequest;
+use App\Models\DonationFund;
+use App\Models\FundraisingCampaign;
+use App\Models\Organisation;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use LogicException;
+
+class DonationController extends Controller
+{
+    public function create(Request $request): View
+    {
+        $organisation = $this->organisation($request);
+
+        return view('public.donations.create', [
+            'organisation' => $organisation,
+            'funds' => DonationFund::query()->where('is_simulated', true)->orderBy('name')->get(),
+            'campaigns' => FundraisingCampaign::query()->where('is_simulated', true)->orderBy('name')->get(),
+            'idempotencyKey' => Str::uuid()->toString(),
+        ]);
+    }
+
+    public function store(StoreDonationRequest $request, MakePublicSimulatedDonation $makeDonation): View
+    {
+        $organisation = $this->organisation($request);
+        $validated = $request->validated();
+        $fund = DonationFund::query()->findOrFail((int) $validated['fund_id']);
+        $campaign = isset($validated['campaign_id'])
+            ? FundraisingCampaign::query()->findOrFail((int) $validated['campaign_id'])
+            : null;
+        try {
+            $donation = $makeDonation->handle(
+                $organisation,
+                $fund,
+                $campaign,
+                DonationFrequency::from((string) $validated['frequency']),
+                (int) $validated['amount_minor'],
+                (string) $validated['idempotency_key'],
+            );
+        } catch (LogicException $exception) {
+            abort(409, $exception->getMessage());
+        }
+
+        return view('public.donations.show', ['organisation' => $organisation, 'donation' => $donation]);
+    }
+
+    private function organisation(Request $request): Organisation
+    {
+        $organisation = $request->attributes->get('public_organisation');
+        abort_unless($organisation instanceof Organisation, 404);
+
+        return $organisation;
+    }
+}

--- a/app/Http/Controllers/Public/OrganisationController.php
+++ b/app/Http/Controllers/Public/OrganisationController.php
@@ -24,6 +24,7 @@ class OrganisationController extends Controller
                 'public_organisation' => $organisation->slug,
             ]),
             'sourceUrl' => rtrim((string) config('app.url'), '/').'/source-and-licence',
+            'donationUrl' => route('public.donations.create', ['public_organisation' => $organisation->slug]),
         ]);
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\Donation;
 use App\Models\IntakeRequest;
 use App\Models\Organisation;
 use App\Models\Party;
@@ -64,6 +65,8 @@ class HandleInertiaRequests extends Middleware
                 && Gate::allows('viewAny', [Program::class, $routeOrganisation]),
             'canViewIntakes' => fn (): bool => $routeOrganisation instanceof Organisation
                 && Gate::allows('viewAny', [IntakeRequest::class, $routeOrganisation]),
+            'canViewDonations' => fn (): bool => $routeOrganisation instanceof Organisation
+                && Gate::allows('viewAny', [Donation::class, $routeOrganisation]),
         ];
     }
 }

--- a/app/Http/Requests/Public/StoreDonationRequest.php
+++ b/app/Http/Requests/Public/StoreDonationRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests\Public;
+
+use App\Enums\DonationFrequency;
+use App\Models\Organisation;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreDonationRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->attributes->get('public_organisation') instanceof Organisation;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $organisation = $this->attributes->get('public_organisation');
+        $organisationId = $organisation instanceof Organisation ? $organisation->id : 0;
+
+        return [
+            'amount_minor' => ['required', 'integer', Rule::in([2500, 5000, 10000])],
+            'frequency' => ['required', Rule::enum(DonationFrequency::class)],
+            'fund_id' => ['required', 'integer', Rule::exists('donation_funds', 'id')->where(fn ($query) => $query->where('organisation_id', $organisationId)->where('is_simulated', true))],
+            'campaign_id' => ['nullable', 'integer', Rule::exists('fundraising_campaigns', 'id')->where(fn ($query) => $query->where('organisation_id', $organisationId)->where('is_simulated', true))],
+            'idempotency_key' => ['required', 'uuid'],
+            'name' => ['prohibited'],
+            'email' => ['prohibited'],
+            'telephone' => ['prohibited'],
+            'card_number' => ['prohibited'],
+            'bank_account' => ['prohibited'],
+        ];
+    }
+}

--- a/app/Models/Donation.php
+++ b/app/Models/Donation.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\DonationFrequency;
+use Database\Factories\DonationFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property int $party_id
+ * @property int|null $fundraising_campaign_id
+ * @property int $donation_fund_id
+ * @property DonationFrequency $frequency
+ * @property int $amount_minor
+ * @property string $currency
+ * @property string $source_code
+ * @property string $idempotency_key
+ * @property bool $is_simulated
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Organisation $organisation
+ * @property-read Party $party
+ * @property-read FundraisingCampaign|null $campaign
+ * @property-read DonationFund $fund
+ * @property-read RecurringMandate|null $mandate
+ * @property-read int $payments_count
+ */
+class Donation extends Model
+{
+    /** @use HasFactory<DonationFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(function (Donation $donation): void {
+            if ($donation->isDirty(['organisation_id', 'party_id', 'amount_minor', 'currency', 'frequency'])) {
+                throw new LogicException('Donation identity and money fields are immutable.');
+            }
+        });
+        static::deleting(fn () => throw new LogicException('Donation history is immutable.'));
+    }
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return BelongsTo<Party, $this> */
+    public function party(): BelongsTo
+    {
+        return $this->belongsTo(Party::class);
+    }
+
+    /** @return BelongsTo<FundraisingCampaign, $this> */
+    public function campaign(): BelongsTo
+    {
+        return $this->belongsTo(FundraisingCampaign::class, 'fundraising_campaign_id');
+    }
+
+    /** @return BelongsTo<DonationFund, $this> */
+    public function fund(): BelongsTo
+    {
+        return $this->belongsTo(DonationFund::class, 'donation_fund_id');
+    }
+
+    /** @return HasOne<RecurringMandate, $this> */
+    public function mandate(): HasOne
+    {
+        return $this->hasOne(RecurringMandate::class);
+    }
+
+    /** @return HasMany<DonationPayment, $this> */
+    public function payments(): HasMany
+    {
+        return $this->hasMany(DonationPayment::class);
+    }
+
+    /** @return HasMany<DonationReceipt, $this> */
+    public function receipts(): HasMany
+    {
+        return $this->hasMany(DonationReceipt::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['frequency' => DonationFrequency::class, 'is_simulated' => 'boolean'];
+    }
+}

--- a/app/Models/DonationFund.php
+++ b/app/Models/DonationFund.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use Database\Factories\DonationFundFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int $organisation_id
+ * @property string $name
+ * @property string $slug
+ * @property bool $is_simulated
+ */
+#[Fillable(['organisation_id', 'name', 'slug', 'is_simulated'])]
+class DonationFund extends Model
+{
+    /** @use HasFactory<DonationFundFactory> */
+    use BelongsToOrganisation, HasFactory;
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return HasMany<Donation, $this> */
+    public function donations(): HasMany
+    {
+        return $this->hasMany(Donation::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['is_simulated' => 'boolean'];
+    }
+}

--- a/app/Models/DonationPayment.php
+++ b/app/Models/DonationPayment.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\DonationPaymentStatus;
+use Database\Factories\DonationPaymentFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $donation_id
+ * @property string|null $recurring_mandate_id
+ * @property int $attempt_number
+ * @property int $amount_minor
+ * @property string $currency
+ * @property DonationPaymentStatus $status
+ * @property int $version
+ * @property string $idempotency_key
+ * @property string $provider_payment_id
+ * @property Carbon|null $settled_at
+ * @property-read Donation $donation
+ * @property-read RecurringMandate|null $mandate
+ * @property-read DonationReceipt|null $receipt
+ */
+class DonationPayment extends Model
+{
+    /** @use HasFactory<DonationPaymentFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(function (DonationPayment $payment): void {
+            if ($payment->isDirty(['organisation_id', 'donation_id', 'recurring_mandate_id', 'attempt_number', 'provider_payment_id'])) {
+                throw new LogicException('Donation Payment identity fields are immutable.');
+            }
+
+            if ($payment->isDirty(['amount_minor', 'currency'])
+                && ($payment->getRawOriginal('status') !== DonationPaymentStatus::Created->value || $payment->status !== DonationPaymentStatus::Created)) {
+                throw new LogicException('Donation Payment money fields are immutable after collection begins.');
+            }
+        });
+        static::deleting(fn () => throw new LogicException('Donation Payment history is immutable.'));
+    }
+
+    /** @return BelongsTo<Donation, $this> */
+    public function donation(): BelongsTo
+    {
+        return $this->belongsTo(Donation::class);
+    }
+
+    /** @return BelongsTo<RecurringMandate, $this> */
+    public function mandate(): BelongsTo
+    {
+        return $this->belongsTo(RecurringMandate::class, 'recurring_mandate_id');
+    }
+
+    /** @return HasMany<DonationPaymentEvent, $this> */
+    public function events(): HasMany
+    {
+        return $this->hasMany(DonationPaymentEvent::class);
+    }
+
+    /** @return HasMany<DonationRefund, $this> */
+    public function refunds(): HasMany
+    {
+        return $this->hasMany(DonationRefund::class);
+    }
+
+    /** @return HasOne<DonationReceipt, $this> */
+    public function receipt(): HasOne
+    {
+        return $this->hasOne(DonationReceipt::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['status' => DonationPaymentStatus::class, 'settled_at' => 'datetime'];
+    }
+}

--- a/app/Models/DonationPaymentEvent.php
+++ b/app/Models/DonationPaymentEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\DonationPaymentStatus;
+use Database\Factories\DonationPaymentEventFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $donation_payment_id
+ * @property string $idempotency_key
+ * @property string $provider_event_id
+ * @property DonationPaymentStatus $from_status
+ * @property DonationPaymentStatus $to_status
+ * @property Carbon $occurred_at
+ */
+class DonationPaymentEvent extends Model
+{
+    /** @use HasFactory<DonationPaymentEventFactory> */
+    use BelongsToOrganisation, HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Donation Payment events are append-only.'));
+        static::deleting(fn () => throw new LogicException('Donation Payment events are append-only.'));
+    }
+
+    /** @return BelongsTo<DonationPayment, $this> */
+    public function payment(): BelongsTo
+    {
+        return $this->belongsTo(DonationPayment::class, 'donation_payment_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['from_status' => DonationPaymentStatus::class, 'to_status' => DonationPaymentStatus::class, 'occurred_at' => 'datetime'];
+    }
+}

--- a/app/Models/DonationReceipt.php
+++ b/app/Models/DonationReceipt.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use Database\Factories\DonationReceiptFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $donation_id
+ * @property string $donation_payment_id
+ * @property string $receipt_number
+ * @property int $amount_minor
+ * @property string $currency
+ * @property string $marker
+ * @property Carbon $issued_at
+ */
+class DonationReceipt extends Model
+{
+    /** @use HasFactory<DonationReceiptFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    public $timestamps = false;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Donation receipts are append-only.'));
+        static::deleting(fn () => throw new LogicException('Donation receipts are append-only.'));
+    }
+
+    /** @return BelongsTo<Donation, $this> */
+    public function donation(): BelongsTo
+    {
+        return $this->belongsTo(Donation::class);
+    }
+
+    /** @return BelongsTo<DonationPayment, $this> */
+    public function payment(): BelongsTo
+    {
+        return $this->belongsTo(DonationPayment::class, 'donation_payment_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['issued_at' => 'datetime'];
+    }
+}

--- a/app/Models/DonationRefund.php
+++ b/app/Models/DonationRefund.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use Database\Factories\DonationRefundFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $donation_payment_id
+ * @property int $amount_minor
+ * @property string $currency
+ * @property string $idempotency_key
+ * @property string $provider_refund_id
+ * @property Carbon $occurred_at
+ */
+class DonationRefund extends Model
+{
+    /** @use HasFactory<DonationRefundFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    public $timestamps = false;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Donation refunds are append-only.'));
+        static::deleting(fn () => throw new LogicException('Donation refunds are append-only.'));
+    }
+
+    /** @return BelongsTo<DonationPayment, $this> */
+    public function payment(): BelongsTo
+    {
+        return $this->belongsTo(DonationPayment::class, 'donation_payment_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['occurred_at' => 'datetime'];
+    }
+}

--- a/app/Models/FundraisingCampaign.php
+++ b/app/Models/FundraisingCampaign.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use Database\Factories\FundraisingCampaignFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int $organisation_id
+ * @property string $name
+ * @property string $slug
+ * @property bool $is_simulated
+ */
+#[Fillable(['organisation_id', 'name', 'slug', 'is_simulated'])]
+class FundraisingCampaign extends Model
+{
+    /** @use HasFactory<FundraisingCampaignFactory> */
+    use BelongsToOrganisation, HasFactory;
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return HasMany<Donation, $this> */
+    public function donations(): HasMany
+    {
+        return $this->hasMany(Donation::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['is_simulated' => 'boolean'];
+    }
+}

--- a/app/Models/RecurringMandate.php
+++ b/app/Models/RecurringMandate.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\RecurringMandateStatus;
+use Database\Factories\RecurringMandateFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $donation_id
+ * @property int $party_id
+ * @property int $amount_minor
+ * @property string $currency
+ * @property string $interval
+ * @property RecurringMandateStatus $status
+ * @property int $version
+ * @property string $provider_mandate_id
+ * @property Carbon|null $cancelled_at
+ * @property-read Donation $donation
+ * @property-read Party $party
+ */
+class RecurringMandate extends Model
+{
+    /** @use HasFactory<RecurringMandateFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(function (RecurringMandate $mandate): void {
+            if ($mandate->isDirty(['organisation_id', 'donation_id', 'party_id', 'amount_minor', 'currency', 'interval', 'provider_mandate_id'])) {
+                throw new LogicException('Recurring Mandate identity and money fields are immutable.');
+            }
+        });
+        static::deleting(fn () => throw new LogicException('Recurring Mandate history is immutable.'));
+    }
+
+    /** @return BelongsTo<Donation, $this> */
+    public function donation(): BelongsTo
+    {
+        return $this->belongsTo(Donation::class);
+    }
+
+    /** @return BelongsTo<Party, $this> */
+    public function party(): BelongsTo
+    {
+        return $this->belongsTo(Party::class);
+    }
+
+    /** @return HasMany<DonationPayment, $this> */
+    public function payments(): HasMany
+    {
+        return $this->hasMany(DonationPayment::class);
+    }
+
+    /** @return HasMany<RecurringMandateEvent, $this> */
+    public function events(): HasMany
+    {
+        return $this->hasMany(RecurringMandateEvent::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['status' => RecurringMandateStatus::class, 'cancelled_at' => 'datetime'];
+    }
+}

--- a/app/Models/RecurringMandateEvent.php
+++ b/app/Models/RecurringMandateEvent.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\RecurringMandateStatus;
+use Database\Factories\RecurringMandateEventFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $recurring_mandate_id
+ * @property string|null $donation_payment_id
+ * @property string $idempotency_key
+ * @property string $provider_event_id
+ * @property RecurringMandateStatus $from_status
+ * @property RecurringMandateStatus $to_status
+ * @property Carbon $occurred_at
+ */
+class RecurringMandateEvent extends Model
+{
+    /** @use HasFactory<RecurringMandateEventFactory> */
+    use BelongsToOrganisation, HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    protected $guarded = ['organisation_id'];
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Recurring Mandate events are append-only.'));
+        static::deleting(fn () => throw new LogicException('Recurring Mandate events are append-only.'));
+    }
+
+    /** @return BelongsTo<RecurringMandate, $this> */
+    public function mandate(): BelongsTo
+    {
+        return $this->belongsTo(RecurringMandate::class, 'recurring_mandate_id');
+    }
+
+    /** @return BelongsTo<DonationPayment, $this> */
+    public function payment(): BelongsTo
+    {
+        return $this->belongsTo(DonationPayment::class, 'donation_payment_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['from_status' => RecurringMandateStatus::class, 'to_status' => RecurringMandateStatus::class, 'occurred_at' => 'datetime'];
+    }
+}

--- a/app/Policies/DonationPolicy.php
+++ b/app/Policies/DonationPolicy.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\OrganisationRole;
+use App\Models\Donation;
+use App\Models\Organisation;
+use App\Models\User;
+
+class DonationPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user, Organisation $organisation): bool
+    {
+        $membership = $user->organisationMembership($organisation);
+
+        return $membership !== null
+            && ! $membership->isHeld()
+            && $membership->roleAssignments()->whereNull('ended_at')->where('role', OrganisationRole::EngagementOfficer)->exists();
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, Donation $donation): bool
+    {
+        return $this->viewAny($user, $donation->organisation);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,8 @@ use App\Contracts\MalwareScanner;
 use App\Cryptography\ClassifiedDataEncrypter;
 use App\Cryptography\ContactBlindIndexer;
 use App\Cryptography\VersionedKeyRing;
+use App\Donations\DonationPaymentProvider;
+use App\Donations\SimulatedDonationPaymentProvider;
 use App\Scanning\ClamdMalwareScanner;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Date;
@@ -22,6 +24,7 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->bind(MalwareScanner::class, ClamdMalwareScanner::class);
+        $this->app->bind(DonationPaymentProvider::class, SimulatedDonationPaymentProvider::class);
         $this->app->bind(
             ClassifiedDataEncrypter::class,
             fn () => new ClassifiedDataEncrypter(new VersionedKeyRing('classified_data.encryption')),

--- a/database/factories/DonationFactory.php
+++ b/database/factories/DonationFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\DonationFrequency;
+use App\Models\Donation;
+use App\Models\DonationFund;
+use App\Models\Party;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Donation>
+ */
+class DonationFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'party_id' => Party::factory(),
+            'fundraising_campaign_id' => null,
+            'donation_fund_id' => DonationFund::factory(),
+            'frequency' => DonationFrequency::OneOff,
+            'amount_minor' => fake()->randomElement([2500, 5000, 10000]),
+            'currency' => 'ZAR',
+            'source_code' => 'demo_fixture',
+            'idempotency_key' => Str::uuid()->toString(),
+            'is_simulated' => true,
+        ];
+    }
+}

--- a/database/factories/DonationFundFactory.php
+++ b/database/factories/DonationFundFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DonationFund;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DonationFund>
+ */
+class DonationFundFactory extends Factory
+{
+    public function definition(): array
+    {
+        $name = fake()->unique()->word().' '.fake()->word();
+
+        return ['organisation_id' => app(OrganisationContext::class)->id(), 'name' => ucfirst($name), 'slug' => str($name)->slug(), 'is_simulated' => true];
+    }
+}

--- a/database/factories/DonationPaymentEventFactory.php
+++ b/database/factories/DonationPaymentEventFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\DonationPaymentStatus;
+use App\Models\DonationPayment;
+use App\Models\DonationPaymentEvent;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<DonationPaymentEvent>
+ */
+class DonationPaymentEventFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'donation_payment_id' => DonationPayment::factory(),
+            'idempotency_key' => Str::uuid()->toString(),
+            'provider_event_id' => 'sim_event_'.Str::uuid(),
+            'from_status' => DonationPaymentStatus::Created,
+            'to_status' => DonationPaymentStatus::Pending,
+            'occurred_at' => now(),
+        ];
+    }
+}

--- a/database/factories/DonationPaymentFactory.php
+++ b/database/factories/DonationPaymentFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\DonationPaymentStatus;
+use App\Models\Donation;
+use App\Models\DonationPayment;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<DonationPayment>
+ */
+class DonationPaymentFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'donation_id' => Donation::factory(),
+            'recurring_mandate_id' => null,
+            'attempt_number' => 1,
+            'amount_minor' => fn (array $attributes): int => Donation::query()->whereKey($attributes['donation_id'])->firstOrFail()->amount_minor,
+            'currency' => fn (array $attributes): string => Donation::query()->whereKey($attributes['donation_id'])->firstOrFail()->currency,
+            'status' => DonationPaymentStatus::Created,
+            'version' => 1,
+            'idempotency_key' => Str::uuid()->toString(),
+            'provider_payment_id' => 'sim_payment_'.Str::uuid(),
+        ];
+    }
+}

--- a/database/factories/DonationReceiptFactory.php
+++ b/database/factories/DonationReceiptFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DonationPayment;
+use App\Models\DonationReceipt;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<DonationReceipt>
+ */
+class DonationReceiptFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'donation_payment_id' => DonationPayment::factory(),
+            'donation_id' => fn (array $attributes): string => DonationPayment::query()->whereKey($attributes['donation_payment_id'])->firstOrFail()->donation_id,
+            'receipt_number' => 'DEMO-'.strtoupper(Str::random(12)),
+            'amount_minor' => fn (array $attributes): int => DonationPayment::query()->whereKey($attributes['donation_payment_id'])->firstOrFail()->amount_minor,
+            'currency' => fn (array $attributes): string => DonationPayment::query()->whereKey($attributes['donation_payment_id'])->firstOrFail()->currency,
+            'marker' => 'Demo—Not a tax receipt',
+            'issued_at' => now(),
+        ];
+    }
+}

--- a/database/factories/DonationRefundFactory.php
+++ b/database/factories/DonationRefundFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DonationPayment;
+use App\Models\DonationRefund;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<DonationRefund>
+ */
+class DonationRefundFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'donation_payment_id' => DonationPayment::factory(),
+            'amount_minor' => 100,
+            'currency' => fn (array $attributes): string => DonationPayment::query()->whereKey($attributes['donation_payment_id'])->firstOrFail()->currency,
+            'idempotency_key' => Str::uuid()->toString(),
+            'provider_refund_id' => 'sim_refund_'.Str::uuid(),
+            'occurred_at' => now(),
+        ];
+    }
+}

--- a/database/factories/FundraisingCampaignFactory.php
+++ b/database/factories/FundraisingCampaignFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\FundraisingCampaign;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<FundraisingCampaign>
+ */
+class FundraisingCampaignFactory extends Factory
+{
+    public function definition(): array
+    {
+        $name = fake()->unique()->word().' '.fake()->word().' '.fake()->word();
+
+        return ['organisation_id' => app(OrganisationContext::class)->id(), 'name' => ucfirst($name), 'slug' => str($name)->slug(), 'is_simulated' => true];
+    }
+}

--- a/database/factories/RecurringMandateEventFactory.php
+++ b/database/factories/RecurringMandateEventFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\RecurringMandateStatus;
+use App\Models\RecurringMandate;
+use App\Models\RecurringMandateEvent;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<RecurringMandateEvent>
+ */
+class RecurringMandateEventFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'recurring_mandate_id' => RecurringMandate::factory(),
+            'donation_payment_id' => null,
+            'idempotency_key' => Str::uuid()->toString(),
+            'provider_event_id' => 'sim_event_'.Str::uuid(),
+            'from_status' => RecurringMandateStatus::Pending,
+            'to_status' => RecurringMandateStatus::Active,
+            'occurred_at' => now(),
+        ];
+    }
+}

--- a/database/factories/RecurringMandateFactory.php
+++ b/database/factories/RecurringMandateFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\RecurringMandateStatus;
+use App\Models\Donation;
+use App\Models\RecurringMandate;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<RecurringMandate>
+ */
+class RecurringMandateFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'donation_id' => Donation::factory(),
+            'party_id' => fn (array $attributes): int => Donation::query()->whereKey($attributes['donation_id'])->firstOrFail()->party_id,
+            'amount_minor' => fn (array $attributes): int => Donation::query()->whereKey($attributes['donation_id'])->firstOrFail()->amount_minor,
+            'currency' => fn (array $attributes): string => Donation::query()->whereKey($attributes['donation_id'])->firstOrFail()->currency,
+            'interval' => 'monthly',
+            'status' => RecurringMandateStatus::Pending,
+            'version' => 1,
+            'provider_mandate_id' => 'sim_mandate_'.Str::uuid(),
+        ];
+    }
+}

--- a/database/migrations/2026_08_31_094522_create_donation_lifecycle_tables.php
+++ b/database/migrations/2026_08_31_094522_create_donation_lifecycle_tables.php
@@ -1,0 +1,178 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('fundraising_campaigns', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('slug');
+            $table->boolean('is_simulated')->default(true);
+            $table->timestamps();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'slug']);
+        });
+
+        Schema::create('donation_funds', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->string('name');
+            $table->string('slug');
+            $table->boolean('is_simulated')->default(true);
+            $table->timestamps();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'slug']);
+        });
+
+        Schema::create('donations', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('party_id');
+            $table->foreignId('fundraising_campaign_id')->nullable();
+            $table->foreignId('donation_fund_id');
+            $table->string('frequency', 32);
+            $table->unsignedBigInteger('amount_minor');
+            $table->char('currency', 3);
+            $table->string('source_code', 64);
+            $table->uuid('idempotency_key');
+            $table->boolean('is_simulated')->default(true);
+            $table->timestamps();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'idempotency_key']);
+            $table->foreign(['organisation_id', 'party_id'])->references(['organisation_id', 'id'])->on('parties')->restrictOnDelete();
+            $table->foreign(['organisation_id', 'fundraising_campaign_id'])->references(['organisation_id', 'id'])->on('fundraising_campaigns')->restrictOnDelete();
+            $table->foreign(['organisation_id', 'donation_fund_id'])->references(['organisation_id', 'id'])->on('donation_funds')->restrictOnDelete();
+            $table->index(['organisation_id', 'fundraising_campaign_id', 'created_at']);
+        });
+
+        Schema::create('recurring_mandates', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->uuid('donation_id');
+            $table->foreignId('party_id');
+            $table->unsignedBigInteger('amount_minor');
+            $table->char('currency', 3);
+            $table->string('interval', 32)->default('monthly');
+            $table->string('status', 32)->default('pending');
+            $table->unsignedInteger('version')->default(1);
+            $table->string('provider_mandate_id')->unique();
+            $table->timestamp('cancelled_at')->nullable();
+            $table->timestamps();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'donation_id']);
+            $table->foreign(['organisation_id', 'donation_id'])->references(['organisation_id', 'id'])->on('donations')->restrictOnDelete();
+            $table->foreign(['organisation_id', 'party_id'])->references(['organisation_id', 'id'])->on('parties')->restrictOnDelete();
+            $table->index(['organisation_id', 'status']);
+        });
+
+        Schema::create('donation_payments', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->uuid('donation_id');
+            $table->uuid('recurring_mandate_id')->nullable();
+            $table->unsignedInteger('attempt_number');
+            $table->unsignedBigInteger('amount_minor');
+            $table->char('currency', 3);
+            $table->string('status', 32)->default('created');
+            $table->unsignedInteger('version')->default(1);
+            $table->uuid('idempotency_key');
+            $table->string('provider_payment_id')->unique();
+            $table->timestamp('settled_at')->nullable();
+            $table->timestamps();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'idempotency_key']);
+            $table->unique(['organisation_id', 'donation_id', 'attempt_number']);
+            $table->foreign(['organisation_id', 'donation_id'])->references(['organisation_id', 'id'])->on('donations')->restrictOnDelete();
+            $table->foreign(['organisation_id', 'recurring_mandate_id'])->references(['organisation_id', 'id'])->on('recurring_mandates')->restrictOnDelete();
+            $table->index(['organisation_id', 'status', 'settled_at']);
+        });
+
+        Schema::create('donation_payment_events', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->uuid('donation_payment_id');
+            $table->uuid('idempotency_key');
+            $table->string('provider_event_id')->unique();
+            $table->string('from_status', 32);
+            $table->string('to_status', 32);
+            $table->timestamp('occurred_at');
+            $table->unique(['organisation_id', 'idempotency_key']);
+            $table->foreign(['organisation_id', 'donation_payment_id'])->references(['organisation_id', 'id'])->on('donation_payments')->restrictOnDelete();
+            $table->index(['organisation_id', 'donation_payment_id', 'occurred_at']);
+        });
+
+        Schema::create('recurring_mandate_events', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->uuid('recurring_mandate_id');
+            $table->uuid('donation_payment_id')->nullable();
+            $table->uuid('idempotency_key');
+            $table->string('provider_event_id')->unique();
+            $table->string('from_status', 32);
+            $table->string('to_status', 32);
+            $table->timestamp('occurred_at');
+            $table->unique(['organisation_id', 'idempotency_key']);
+            $table->foreign(['organisation_id', 'recurring_mandate_id'])->references(['organisation_id', 'id'])->on('recurring_mandates')->restrictOnDelete();
+            $table->foreign(['organisation_id', 'donation_payment_id'])->references(['organisation_id', 'id'])->on('donation_payments')->restrictOnDelete();
+            $table->index(['organisation_id', 'recurring_mandate_id', 'occurred_at']);
+        });
+
+        Schema::create('donation_refunds', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->uuid('donation_payment_id');
+            $table->unsignedBigInteger('amount_minor');
+            $table->char('currency', 3);
+            $table->uuid('idempotency_key');
+            $table->string('provider_refund_id')->unique();
+            $table->timestamp('occurred_at');
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'idempotency_key']);
+            $table->foreign(['organisation_id', 'donation_payment_id'])->references(['organisation_id', 'id'])->on('donation_payments')->restrictOnDelete();
+            $table->index(['organisation_id', 'donation_payment_id', 'occurred_at']);
+        });
+
+        Schema::create('donation_receipts', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->uuid('donation_id');
+            $table->uuid('donation_payment_id');
+            $table->string('receipt_number')->unique();
+            $table->unsignedBigInteger('amount_minor');
+            $table->char('currency', 3);
+            $table->string('marker')->default('Demo—Not a tax receipt');
+            $table->timestamp('issued_at');
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'donation_payment_id']);
+            $table->foreign(['organisation_id', 'donation_id'])->references(['organisation_id', 'id'])->on('donations')->restrictOnDelete();
+            $table->foreign(['organisation_id', 'donation_payment_id'])->references(['organisation_id', 'id'])->on('donation_payments')->restrictOnDelete();
+        });
+
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('ALTER TABLE donations ADD CONSTRAINT donations_amount_positive CHECK (amount_minor > 0), ADD CONSTRAINT donations_simulated_only CHECK (is_simulated = true)');
+            DB::statement("ALTER TABLE donation_payments ADD CONSTRAINT donation_payments_amount_positive CHECK (amount_minor > 0), ADD CONSTRAINT donation_payments_provider_simulated CHECK (left(provider_payment_id, 4) = 'sim_')");
+            DB::statement("ALTER TABLE recurring_mandates ADD CONSTRAINT recurring_mandates_amount_positive CHECK (amount_minor > 0), ADD CONSTRAINT recurring_mandates_provider_simulated CHECK (left(provider_mandate_id, 4) = 'sim_')");
+            DB::statement("ALTER TABLE donation_refunds ADD CONSTRAINT donation_refunds_amount_positive CHECK (amount_minor > 0), ADD CONSTRAINT donation_refunds_provider_simulated CHECK (left(provider_refund_id, 4) = 'sim_')");
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('donation_receipts');
+        Schema::dropIfExists('donation_refunds');
+        Schema::dropIfExists('recurring_mandate_events');
+        Schema::dropIfExists('donation_payment_events');
+        Schema::dropIfExists('donation_payments');
+        Schema::dropIfExists('recurring_mandates');
+        Schema::dropIfExists('donations');
+        Schema::dropIfExists('donation_funds');
+        Schema::dropIfExists('fundraising_campaigns');
+    }
+};

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -2,6 +2,7 @@ import { Link, usePage } from '@inertiajs/react';
 import {
     ClipboardList,
     FolderGit2,
+    HandCoins,
     LayoutGrid,
     Scale,
     Settings2,
@@ -22,6 +23,7 @@ import {
     SidebarMenuItem,
 } from '@/components/ui/sidebar';
 import { dashboard } from '@/routes';
+import { index as donationsIndex } from '@/routes/donations';
 import { index as intakesIndex } from '@/routes/intakes';
 import { index as partiesIndex } from '@/routes/parties';
 import { index as programsIndex } from '@/routes/programs';
@@ -54,6 +56,15 @@ export function AppSidebar() {
                       title: 'Service requests',
                       href: intakesIndex(page.props.currentOrganisation.slug),
                       icon: ClipboardList,
+                  },
+              ]
+            : []),
+        ...(page.props.canViewDonations && page.props.currentOrganisation
+            ? [
+                  {
+                      title: 'Simulated donations',
+                      href: donationsIndex(page.props.currentOrganisation.slug),
+                      icon: HandCoins,
                   },
               ]
             : []),

--- a/resources/js/pages/donations/index.tsx
+++ b/resources/js/pages/donations/index.tsx
@@ -1,0 +1,139 @@
+import { Head, Link, usePage } from '@inertiajs/react';
+import Heading from '@/components/heading';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent } from '@/components/ui/card';
+import { index, show } from '@/routes/donations';
+
+type DonationSummary = {
+    id: string;
+    supporter: string;
+    campaign: string | null;
+    fund: string;
+    frequency: string;
+    amountMinor: number;
+    currency: string;
+    source: string;
+    mandateStatus: string | null;
+    paymentCount: number;
+    createdAt: string | null;
+};
+
+type Props = {
+    donations: {
+        data: DonationSummary[];
+        links: Array<{ url: string | null; label: string; active: boolean }>;
+    };
+};
+
+const money = (currency: string, amountMinor: number) =>
+    new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency,
+    }).format(amountMinor / 100);
+
+export default function DonationsIndex({ donations }: Props) {
+    const organisation = usePage().props.currentOrganisation!;
+
+    return (
+        <>
+            <Head title="Simulated donations" />
+            <div className="space-y-6 p-4">
+                <Heading
+                    title="Simulated donations"
+                    description="Demo-only fundraising intent, payment attempts, mandates, refunds, receipts, and attribution. No real money or contact data is used."
+                />
+                <div
+                    role="note"
+                    className="rounded-lg border-2 border-amber-600 p-4 text-sm"
+                >
+                    <strong>Simulation data only.</strong> Provider identifiers
+                    begin with sim_ and every receipt is marked as a non-tax
+                    demo receipt.
+                </div>
+                {donations.data.length === 0 ? (
+                    <Card>
+                        <CardContent className="text-muted-foreground p-6">
+                            No simulated donations yet.
+                        </CardContent>
+                    </Card>
+                ) : (
+                    <div className="grid gap-3">
+                        {donations.data.map((donation) => (
+                            <Link
+                                key={donation.id}
+                                href={show.url([
+                                    organisation.slug,
+                                    donation.id,
+                                ])}
+                                className="hover:bg-muted/50 focus-visible:ring-ring rounded-lg border p-4 transition-colors focus-visible:ring-2 focus-visible:outline-none"
+                            >
+                                <div className="flex flex-wrap items-start justify-between gap-3">
+                                    <div>
+                                        <p className="font-semibold">
+                                            {donation.supporter}
+                                        </p>
+                                        <p className="text-muted-foreground text-sm">
+                                            {donation.campaign ?? 'No campaign'}{' '}
+                                            · {donation.fund} ·{' '}
+                                            {donation.source}
+                                        </p>
+                                    </div>
+                                    <div className="text-right">
+                                        <p className="font-semibold">
+                                            {money(
+                                                donation.currency,
+                                                donation.amountMinor,
+                                            )}
+                                        </p>
+                                        <div className="mt-1 flex gap-1">
+                                            <Badge variant="outline">
+                                                {donation.frequency.replaceAll(
+                                                    '_',
+                                                    ' ',
+                                                )}
+                                            </Badge>
+                                            {donation.mandateStatus ? (
+                                                <Badge variant="outline">
+                                                    {donation.mandateStatus.replaceAll(
+                                                        '_',
+                                                        ' ',
+                                                    )}
+                                                </Badge>
+                                            ) : null}
+                                        </div>
+                                    </div>
+                                </div>
+                                <p className="text-muted-foreground mt-3 text-xs">
+                                    {donation.paymentCount} simulated payment
+                                    attempt(s) · transaction {donation.id}
+                                </p>
+                            </Link>
+                        ))}
+                    </div>
+                )}
+                <nav aria-label="Donation pages" className="flex gap-2">
+                    {donations.links.map((link) =>
+                        link.url ? (
+                            <Link
+                                key={link.label}
+                                href={link.url}
+                                className="rounded border px-3 py-1 text-sm"
+                                aria-current={link.active ? 'page' : undefined}
+                                dangerouslySetInnerHTML={{ __html: link.label }}
+                            />
+                        ) : null,
+                    )}
+                </nav>
+            </div>
+        </>
+    );
+}
+
+DonationsIndex.layout = (props: { currentOrganisation: { slug: string } }) => ({
+    breadcrumbs: [
+        {
+            title: 'Simulated donations',
+            href: index(props.currentOrganisation.slug),
+        },
+    ],
+});

--- a/resources/js/pages/donations/show.tsx
+++ b/resources/js/pages/donations/show.tsx
@@ -1,0 +1,186 @@
+import { Head } from '@inertiajs/react';
+import Heading from '@/components/heading';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { index, show } from '@/routes/donations';
+
+type Transition = { from: string; to: string; occurredAt: string };
+type Payment = {
+    id: string;
+    attemptNumber: number;
+    status: string;
+    providerId: string;
+    amountMinor: number;
+    currency: string;
+    settledAt: string | null;
+    events: Transition[];
+    refunds: Array<{ id: string; amountMinor: number; occurredAt: string }>;
+    receipt: { number: string; marker: string; issuedAt: string } | null;
+};
+type DonationDetail = {
+    id: string;
+    supporter: string;
+    campaign: string | null;
+    fund: string;
+    frequency: string;
+    amountMinor: number;
+    currency: string;
+    source: string;
+    createdAt: string | null;
+    mandate: {
+        id: string;
+        status: string;
+        providerId: string;
+        events: Transition[];
+    } | null;
+    payments: Payment[];
+};
+
+const money = (currency: string, amountMinor: number) =>
+    new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency,
+    }).format(amountMinor / 100);
+
+export default function DonationShow({
+    donation,
+}: {
+    donation: DonationDetail;
+}) {
+    return (
+        <>
+            <Head title="Simulated donation" />
+            <div className="space-y-6 p-4">
+                <Heading
+                    title="Simulated donation"
+                    description={`Transaction ${donation.id} · demo data only; no money moved and no real person was contacted.`}
+                />
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Intent and attribution</CardTitle>
+                    </CardHeader>
+                    <CardContent className="grid gap-3 sm:grid-cols-2">
+                        <Detail
+                            label="Synthetic supporter"
+                            value={donation.supporter}
+                        />
+                        <Detail
+                            label="Demo amount"
+                            value={money(
+                                donation.currency,
+                                donation.amountMinor,
+                            )}
+                        />
+                        <Detail label="Frequency" value={donation.frequency} />
+                        <Detail label="Fund" value={donation.fund} />
+                        <Detail
+                            label="Campaign"
+                            value={donation.campaign ?? 'None'}
+                        />
+                        <Detail label="Source" value={donation.source} />
+                    </CardContent>
+                </Card>
+                {donation.mandate ? (
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Simulated recurring mandate</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-3">
+                            <Badge>{donation.mandate.status}</Badge>
+                            <p className="font-mono text-xs">
+                                {donation.mandate.providerId}
+                            </p>
+                            <Transitions events={donation.mandate.events} />
+                        </CardContent>
+                    </Card>
+                ) : null}
+                <section
+                    aria-labelledby="payment-attempts"
+                    className="space-y-3"
+                >
+                    <h2 id="payment-attempts" className="text-xl font-semibold">
+                        Simulated payment attempts
+                    </h2>
+                    {donation.payments.map((payment) => (
+                        <Card key={payment.id}>
+                            <CardHeader>
+                                <CardTitle className="flex items-center justify-between gap-2">
+                                    Attempt {payment.attemptNumber}
+                                    <Badge>{payment.status}</Badge>
+                                </CardTitle>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                                <p className="font-mono text-xs">
+                                    {payment.providerId}
+                                </p>
+                                <Transitions events={payment.events} />
+                                {payment.refunds.map((refund) => (
+                                    <p key={refund.id}>
+                                        Demo refund:{' '}
+                                        {money(
+                                            payment.currency,
+                                            refund.amountMinor,
+                                        )}
+                                    </p>
+                                ))}
+                                {payment.receipt ? (
+                                    <div className="rounded border-2 border-dashed border-amber-600 p-4">
+                                        <strong>
+                                            {payment.receipt.marker}
+                                        </strong>
+                                        <p>Receipt {payment.receipt.number}</p>
+                                    </div>
+                                ) : (
+                                    <p className="text-muted-foreground text-sm">
+                                        No receipt: this attempt has no eligible
+                                        settled value.
+                                    </p>
+                                )}
+                            </CardContent>
+                        </Card>
+                    ))}
+                </section>
+            </div>
+        </>
+    );
+}
+
+function Detail({ label, value }: { label: string; value: string }) {
+    return (
+        <div>
+            <p className="text-muted-foreground text-sm">{label}</p>
+            <p>{value.replaceAll('_', ' ')}</p>
+        </div>
+    );
+}
+
+function Transitions({ events }: { events: Transition[] }) {
+    return events.length === 0 ? (
+        <p className="text-muted-foreground text-sm">No transitions.</p>
+    ) : (
+        <ol className="space-y-1 text-sm" aria-label="Transition history">
+            {events.map((event, indexNumber) => (
+                <li key={`${event.occurredAt}-${indexNumber}`}>
+                    {event.from.replaceAll('_', ' ')} →{' '}
+                    {event.to.replaceAll('_', ' ')}
+                </li>
+            ))}
+        </ol>
+    );
+}
+
+DonationShow.layout = (props: {
+    currentOrganisation: { slug: string };
+    donation: DonationDetail;
+}) => ({
+    breadcrumbs: [
+        {
+            title: 'Simulated donations',
+            href: index(props.currentOrganisation.slug),
+        },
+        {
+            title: 'Transaction',
+            href: show([props.currentOrganisation.slug, props.donation.id]),
+        },
+    ],
+});

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -17,6 +17,7 @@ declare module '@inertiajs/core' {
             canViewParties: boolean;
             canViewPrograms: boolean;
             canViewIntakes: boolean;
+            canViewDonations: boolean;
             currentOrganisation: Organisation | null;
             organisations: Organisation[];
             [key: string]: unknown;

--- a/resources/views/public/donations/create.blade.php
+++ b/resources/views/public/donations/create.blade.php
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Simulated donation · {{ $organisation->name }}</title>
+        <style>
+            :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, sans-serif; line-height: 1.6; }
+            body { margin: 0; background: Canvas; color: CanvasText; }
+            main { width: min(42rem, calc(100% - 2rem)); margin: 3rem auto; }
+            .notice { border: 2px solid #b45309; border-radius: .75rem; padding: 1rem; }
+            form { display: grid; gap: 1rem; margin-top: 2rem; }
+            label { display: grid; gap: .35rem; font-weight: 700; }
+            select, button { font: inherit; padding: .7rem; }
+            button { cursor: pointer; font-weight: 700; }
+            .errors { color: #b91c1c; }
+        </style>
+    </head>
+    <body>
+        <main>
+            <p><a href="{{ route('public.organisations.show', ['public_organisation' => $organisation->slug]) }}">← {{ $organisation->name }}</a></p>
+            <h1>Make a simulated donation</h1>
+            <div class="notice" role="note">
+                <strong>Demo only—no money will move.</strong>
+                Do not enter real names, card numbers, bank details, email addresses, or telephone numbers. This form does not request or transmit them.
+            </div>
+            @if ($errors->any())
+                <div class="errors" role="alert">Please choose valid demo options.</div>
+            @endif
+            <form method="post" action="{{ route('public.donations.store', ['public_organisation' => $organisation->slug]) }}">
+                @csrf
+                <input type="hidden" name="idempotency_key" value="{{ old('idempotency_key', $idempotencyKey) }}">
+                <label>Demo amount
+                    <select name="amount_minor" required>
+                        <option value="2500">ZAR 25.00</option>
+                        <option value="5000">ZAR 50.00</option>
+                        <option value="10000">ZAR 100.00</option>
+                    </select>
+                </label>
+                <label>Frequency
+                    <select name="frequency" required>
+                        <option value="one_off">One-off simulation</option>
+                        <option value="monthly">Monthly simulation</option>
+                    </select>
+                </label>
+                <label>Demo fund
+                    <select name="fund_id" required>
+                        @foreach ($funds as $fund)
+                            <option value="{{ $fund->id }}">{{ $fund->name }}</option>
+                        @endforeach
+                    </select>
+                </label>
+                <label>Demo campaign
+                    <select name="campaign_id">
+                        <option value="">No campaign</option>
+                        @foreach ($campaigns as $campaign)
+                            <option value="{{ $campaign->id }}">{{ $campaign->name }}</option>
+                        @endforeach
+                    </select>
+                </label>
+                <button type="submit" @disabled($funds->isEmpty())>Simulate donation</button>
+            </form>
+        </main>
+    </body>
+</html>

--- a/resources/views/public/donations/show.blade.php
+++ b/resources/views/public/donations/show.blade.php
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+    <head>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <title>Demo receipt · {{ $organisation->name }}</title>
+        <style>
+            :root { color-scheme: light dark; font-family: ui-sans-serif, system-ui, sans-serif; line-height: 1.6; }
+            body { margin: 0; background: Canvas; color: CanvasText; }
+            main { width: min(42rem, calc(100% - 2rem)); margin: 3rem auto; }
+            .receipt { border: 3px dashed #b45309; border-radius: .75rem; padding: 1.5rem; }
+            dt { font-weight: 700; } dd { margin: 0 0 1rem; }
+        </style>
+    </head>
+    <body>
+        <main>
+            <p><a href="{{ route('public.organisations.show', ['public_organisation' => $organisation->slug]) }}">← {{ $organisation->name }}</a></p>
+            <h1>Simulation complete</h1>
+            <p>No money moved and no person or payment details were collected or contacted.</p>
+            @php($payment = $donation->payments->last())
+            @php($receipt = $payment?->receipt)
+            <section class="receipt" aria-label="Demo receipt">
+                <h2>{{ $receipt?->marker ?? 'Demo—No receipt issued' }}</h2>
+                <dl>
+                    <dt>Simulation transaction</dt><dd>{{ $donation->id }}</dd>
+                    <dt>Status</dt><dd>{{ str($payment?->status?->value ?? 'not_processed')->replace('_', ' ')->title() }}</dd>
+                    <dt>Demo amount</dt><dd>{{ $donation->currency }} {{ number_format($donation->amount_minor / 100, 2) }}</dd>
+                    <dt>Frequency</dt><dd>{{ str($donation->frequency->value)->replace('_', ' ')->title() }}</dd>
+                    <dt>Demo fund</dt><dd>{{ $donation->fund->name }}</dd>
+                    <dt>Demo campaign</dt><dd>{{ $donation->campaign?->name ?? 'None' }}</dd>
+                    @if ($receipt)
+                        <dt>Demo receipt number</dt><dd>{{ $receipt->receipt_number }}</dd>
+                    @endif
+                </dl>
+            </section>
+        </main>
+    </body>
+</html>

--- a/resources/views/public/organisation.blade.php
+++ b/resources/views/public/organisation.blade.php
@@ -17,6 +17,7 @@
             <p class="eyebrow">CommunityKind organisation</p>
             <h1>{{ $organisationName }}</h1>
             <p>This is the verified public home of {{ $organisationName }}.</p>
+            <p><a href="{{ $donationUrl }}">Make a simulated donation</a></p>
             <p><a href="{{ $sourceUrl }}">Source and licence</a></p>
         </main>
     </body>

--- a/routes/web.php
+++ b/routes/web.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\Organisations\CaseDocumentController;
 use App\Http\Controllers\Organisations\CaseExportController;
 use App\Http\Controllers\Organisations\CaseItemController;
 use App\Http\Controllers\Organisations\CaseWorkflowController;
+use App\Http\Controllers\Organisations\DonationController;
 use App\Http\Controllers\Organisations\IntakeRequestController;
 use App\Http\Controllers\Organisations\IntakeTransitionController;
 use App\Http\Controllers\Organisations\OrganisationInvitationController;
@@ -19,6 +20,7 @@ use App\Http\Controllers\Organisations\PartySafeContactInstructionController;
 use App\Http\Controllers\Organisations\ProgramController;
 use App\Http\Controllers\Organisations\ServiceCaseController;
 use App\Http\Controllers\Organisations\ServiceOperationsExportController;
+use App\Http\Controllers\Public\DonationController as PublicDonationController;
 use App\Http\Controllers\Public\OrganisationController as PublicOrganisationController;
 use App\Http\Middleware\EnsureOrganisationAccess;
 use App\Http\Middleware\EnsureOrganisationMembership;
@@ -60,6 +62,8 @@ Route::domain('{public_organisation}.'.config('organisations.public_domain'))
     ->middleware(ResolvePublicOrganisation::class)
     ->group(function () use ($securityPolicy, $securityText): void {
         Route::get('/', PublicOrganisationController::class)->name('public.organisations.show');
+        Route::get('/donate', [PublicDonationController::class, 'create'])->name('public.donations.create');
+        Route::post('/donate', [PublicDonationController::class, 'store'])->middleware('throttle:10,1')->name('public.donations.store');
         Route::get('/.well-known/security.txt', $securityText)->name('public.security.txt');
         Route::get('/security-policy', $securityPolicy)->name('public.security.policy');
     });
@@ -87,6 +91,7 @@ Route::prefix('{current_organisation}')
         Route::get('dashboard', DashboardController::class)->name('dashboard');
         Route::get('dashboard/service-operations/export', ServiceOperationsExportController::class)->name('dashboard.service-operations.export');
         Route::get('programs', [ProgramController::class, 'index'])->name('programs.index');
+        Route::resource('donations', DonationController::class)->only(['index', 'show']);
         Route::resource('parties', PartyController::class)->only(['index', 'store', 'show', 'update']);
         Route::resource('intakes', IntakeRequestController::class)
             ->parameters(['intakes' => 'intake'])

--- a/tests/Feature/CommunityKindScenarioSeederTest.php
+++ b/tests/Feature/CommunityKindScenarioSeederTest.php
@@ -4,7 +4,13 @@ use App\Actions\Demo\BuildOrganisationScenario;
 use App\Actions\Programs\BuildProgramReport;
 use App\Actions\Programs\SearchPrograms;
 use App\Data\Demo\ScenarioCatalog;
+use App\Enums\DonationPaymentStatus;
 use App\Enums\OrganisationStatus;
+use App\Models\Donation;
+use App\Models\DonationFund;
+use App\Models\DonationPayment;
+use App\Models\DonationReceipt;
+use App\Models\FundraisingCampaign;
 use App\Models\Membership;
 use App\Models\MetricEvent;
 use App\Models\Organisation;
@@ -73,6 +79,12 @@ it('seeds the versioned synthetic scenarios deterministically', function () {
         ->and(DB::table('membership_program')->count())->toBe(6)
         ->and(ServiceCase::withoutGlobalScopes()->count())->toBe(1)
         ->and(MetricEvent::withoutGlobalScopes()->count())->toBe(5)
+        ->and(FundraisingCampaign::withoutGlobalScopes()->count())->toBe(1)
+        ->and(DonationFund::withoutGlobalScopes()->count())->toBe(1)
+        ->and(Donation::withoutGlobalScopes()->count())->toBe(1)
+        ->and(DonationPayment::withoutGlobalScopes()->count())->toBe(1)
+        ->and(DonationPayment::withoutGlobalScopes()->sole()->status)->toBe(DonationPaymentStatus::Succeeded)
+        ->and(DonationReceipt::withoutGlobalScopes()->sole()->marker)->toBe('Demo—Not a tax receipt')
         ->and($showcaseCase->opened_at->toDateTimeString())->toBe('2026-06-02 06:00:00')
         ->and($showcaseCase->closed_at?->toDateTimeString())->toBe('2026-06-28 13:00:00')
         ->and($serviceMetric->occurred_at->toDateTimeString())->toBe('2026-06-10 10:00:00')
@@ -93,7 +105,12 @@ it('seeds the versioned synthetic scenarios deterministically', function () {
         ->and(PartyContactPoint::withoutGlobalScopes()->orderBy('id')->pluck('id')->all())->toBe($contactIds)
         ->and(Party::withoutGlobalScopes()->orderBy('uuid')->pluck('id', 'uuid')->all())->toBe($partyIds)
         ->and(ServiceCase::withoutGlobalScopes()->count())->toBe(1)
-        ->and(MetricEvent::withoutGlobalScopes()->count())->toBe(5);
+        ->and(MetricEvent::withoutGlobalScopes()->count())->toBe(5)
+        ->and(FundraisingCampaign::withoutGlobalScopes()->count())->toBe(1)
+        ->and(DonationFund::withoutGlobalScopes()->count())->toBe(1)
+        ->and(Donation::withoutGlobalScopes()->count())->toBe(1)
+        ->and(DonationPayment::withoutGlobalScopes()->count())->toBe(1)
+        ->and(DonationReceipt::withoutGlobalScopes()->count())->toBe(1);
 });
 
 it('keeps every scenario identity and reserved showcase explicitly synthetic', function () {

--- a/tests/Feature/DonationLifecycleTest.php
+++ b/tests/Feature/DonationLifecycleTest.php
@@ -1,0 +1,179 @@
+<?php
+
+use App\Actions\Donations\CreateDonation;
+use App\Actions\Donations\CreateDonationPayment;
+use App\Actions\Donations\CreateRecurringMandate;
+use App\Actions\Donations\RefundDonationPayment;
+use App\Actions\Donations\TransitionDonationPayment;
+use App\Actions\Donations\TransitionRecurringMandate;
+use App\Donations\DonationPaymentProvider;
+use App\Enums\DonationFrequency;
+use App\Enums\DonationPaymentStatus;
+use App\Enums\DonationSimulationScenario;
+use App\Enums\OrganisationRole;
+use App\Enums\RecurringMandateStatus;
+use App\Models\Donation;
+use App\Models\DonationFund;
+use App\Models\DonationPaymentEvent;
+use App\Models\DonationReceipt;
+use App\Models\DonationRefund;
+use App\Models\FundraisingCampaign;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\PartyContactPoint;
+use App\Models\RecurringMandateEvent;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/** @return array{Organisation, Party, DonationFund, FundraisingCampaign} */
+function donationFixture(): array
+{
+    $organisation = Organisation::factory()->active()->create(['name' => 'HarbourKind', 'slug' => 'harbourkind']);
+
+    return app(OrganisationContext::class)->run($organisation, fn (): array => [
+        $organisation,
+        Party::factory()->for($organisation)->create(['display_name' => 'Synthetic Donor Example']),
+        DonationFund::factory()->for($organisation)->create(['name' => 'Demo Relief Fund', 'slug' => 'demo-relief']),
+        FundraisingCampaign::factory()->for($organisation)->create(['name' => 'Demo Winter Appeal', 'slug' => 'demo-winter']),
+    ]);
+}
+
+it('accepts only fixed public simulation choices and idempotently issues a marked demo receipt', function () {
+    [$organisation, , $fund, $campaign] = donationFixture();
+    $url = 'https://harbourkind.community-kind.test/donate';
+
+    $this->get($url)
+        ->assertOk()
+        ->assertSee('Demo only—no money will move')
+        ->assertDontSee('name="card_number"', false)
+        ->assertDontSee('name="email"', false);
+
+    $prohibited = ['amount_minor' => 5000, 'frequency' => 'one_off', 'fund_id' => $fund->id, 'campaign_id' => $campaign->id, 'idempotency_key' => Str::uuid()->toString(), 'card_number' => '4111111111111111'];
+    $this->from($url)->post($url, $prohibited)->assertRedirect($url)->assertSessionHasErrors('card_number');
+    expect(Donation::withoutGlobalScopes()->count())->toBe(0);
+
+    $idempotencyKey = Str::uuid()->toString();
+    $payload = ['amount_minor' => 5000, 'frequency' => 'monthly', 'fund_id' => $fund->id, 'campaign_id' => $campaign->id, 'idempotency_key' => $idempotencyKey];
+    $this->post($url, $payload)
+        ->assertOk()
+        ->assertSee('Simulation complete')
+        ->assertSee('Demo—Not a tax receipt')
+        ->assertSee('No money moved')
+        ->assertDontSee('4111111111111111');
+    $this->post($url, $payload)->assertOk()->assertSee('Demo—Not a tax receipt');
+    $this->post($url, [...$payload, 'amount_minor' => 10000])->assertConflict();
+
+    app(OrganisationContext::class)->run($organisation, function (): void {
+        $donation = Donation::query()->sole();
+        expect($donation->is_simulated)->toBeTrue()
+            ->and($donation->party->display_name)->toStartWith('Simulated Supporter ')
+            ->and($donation->payments()->count())->toBe(1)
+            ->and($donation->payments()->sole()->status)->toBe(DonationPaymentStatus::Succeeded)
+            ->and($donation->mandate?->status)->toBe(RecurringMandateStatus::Active)
+            ->and($donation->receipts()->sole()->marker)->toBe('Demo—Not a tax receipt')
+            ->and(PartyContactPoint::query()->count())->toBe(0);
+    });
+});
+
+it('reconciles retries duplicates out-of-order events refunds receipts and immutable money', function () {
+    [$organisation, $party, $fund, $campaign] = donationFixture();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($campaign, $fund, $party): void {
+        $donation = app(CreateDonation::class)->handle($party, $fund, $campaign, DonationFrequency::OneOff, 5000, 'ZAR', 'fixture', Str::uuid()->toString());
+        $provider = app(DonationPaymentProvider::class);
+        $declined = $provider->process($donation, DonationSimulationScenario::Decline, Str::uuid()->toString());
+        expect($declined->status)->toBe(DonationPaymentStatus::Failed)
+            ->and($declined->receipt)->toBeNull();
+
+        $retryKey = Str::uuid()->toString();
+        $succeeded = $provider->process($donation, DonationSimulationScenario::TimeoutThenSuccess, $retryKey);
+        $provider->process($donation, DonationSimulationScenario::TimeoutThenSuccess, $retryKey);
+        expect($succeeded->status)->toBe(DonationPaymentStatus::Succeeded)
+            ->and($succeeded->receipt?->marker)->toBe('Demo—Not a tax receipt')
+            ->and($donation->payments()->count())->toBe(3)
+            ->and(DonationReceipt::query()->count())->toBe(1);
+
+        $outOfOrder = app(CreateDonationPayment::class)->handle($donation, Str::uuid()->toString());
+        $eventCount = DonationPaymentEvent::query()->count();
+        expect(fn () => app(TransitionDonationPayment::class)->handle($outOfOrder, DonationPaymentStatus::Succeeded, Str::uuid()->toString(), now()))
+            ->toThrow(LogicException::class, 'Cannot transition');
+        expect($outOfOrder->refresh()->status)->toBe(DonationPaymentStatus::Created)
+            ->and(DonationPaymentEvent::query()->count())->toBe($eventCount);
+
+        $pendingKey = Str::uuid()->toString();
+        $pending = app(TransitionDonationPayment::class)->handle($outOfOrder, DonationPaymentStatus::Pending, $pendingKey, now());
+        app(TransitionDonationPayment::class)->handle($pending, DonationPaymentStatus::Pending, $pendingKey, now());
+        expect($pending->events()->count())->toBe(1)
+            ->and(fn () => $pending->update(['amount_minor' => 6000]))->toThrow(LogicException::class, 'money fields are immutable')
+            ->and(fn () => $donation->update(['amount_minor' => 6000]))->toThrow(LogicException::class, 'money fields are immutable');
+
+        $partialKey = Str::uuid()->toString();
+        $partial = app(RefundDonationPayment::class)->handle($succeeded, 2000, $partialKey, now());
+        $duplicate = app(RefundDonationPayment::class)->handle($succeeded->refresh(), 2000, $partialKey, now());
+        expect($duplicate->is($partial))->toBeTrue()
+            ->and($succeeded->refresh()->status)->toBe(DonationPaymentStatus::PartiallyRefunded)
+            ->and(fn () => app(RefundDonationPayment::class)->handle($succeeded, 3001, Str::uuid()->toString(), now()))->toThrow(LogicException::class, 'cannot exceed');
+        app(RefundDonationPayment::class)->handle($succeeded->refresh(), 3000, Str::uuid()->toString(), now());
+        expect($succeeded->refresh()->status)->toBe(DonationPaymentStatus::Refunded)
+            ->and(DonationRefund::query()->count())->toBe(2)
+            ->and(DonationReceipt::query()->count())->toBe(1);
+    });
+});
+
+it('requires new payment evidence for recurring failure recovery and prevents attempts after cancellation', function () {
+    [$organisation, $party, $fund, $campaign] = donationFixture();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($campaign, $fund, $party): void {
+        $donation = app(CreateDonation::class)->handle($party, $fund, $campaign, DonationFrequency::Monthly, 2500, 'ZAR', 'fixture', Str::uuid()->toString());
+        $mandate = app(CreateRecurringMandate::class)->handle($donation);
+        $provider = app(DonationPaymentProvider::class);
+        $firstSuccess = $provider->process($donation->refresh(), DonationSimulationScenario::Success, Str::uuid()->toString());
+        expect($mandate->refresh()->status)->toBe(RecurringMandateStatus::Active);
+
+        $failed = $provider->process($donation->refresh(), DonationSimulationScenario::RecurringFailure, Str::uuid()->toString());
+        expect($failed->status)->toBe(DonationPaymentStatus::Failed)
+            ->and($mandate->refresh()->status)->toBe(RecurringMandateStatus::PaymentFailed)
+            ->and(fn () => app(TransitionRecurringMandate::class)->handle($mandate, RecurringMandateStatus::Active, Str::uuid()->toString(), now(), $firstSuccess))
+            ->toThrow(LogicException::class, 'after the failure');
+
+        $provider->process($donation->refresh(), DonationSimulationScenario::Success, Str::uuid()->toString());
+        expect($mandate->refresh()->status)->toBe(RecurringMandateStatus::Active);
+
+        $cancelKey = Str::uuid()->toString();
+        app(TransitionRecurringMandate::class)->handle($mandate, RecurringMandateStatus::Cancelled, $cancelKey, now());
+        app(TransitionRecurringMandate::class)->handle($mandate->refresh(), RecurringMandateStatus::Cancelled, $cancelKey, now());
+        expect($mandate->refresh()->status)->toBe(RecurringMandateStatus::Cancelled)
+            ->and(RecurringMandateEvent::query()->where('to_status', RecurringMandateStatus::Cancelled)->count())->toBe(1)
+            ->and(fn () => app(CreateDonationPayment::class)->handle($donation, Str::uuid()->toString(), $mandate))
+            ->toThrow(LogicException::class, 'cannot create');
+    });
+});
+
+it('allows only engagement officers to follow supporter-safe simulated donation records', function () {
+    [$organisation, $party, $fund, $campaign] = donationFixture();
+    $engagement = User::factory()->create();
+    $caseWorker = User::factory()->create();
+    $organisation->memberships()->create(['user_id' => $engagement->id, 'role' => OrganisationRole::EngagementOfficer]);
+    $organisation->memberships()->create(['user_id' => $caseWorker->id, 'role' => OrganisationRole::CaseWorker]);
+    $donation = app(OrganisationContext::class)->run($organisation, function () use ($campaign, $fund, $party): Donation {
+        $donation = app(CreateDonation::class)->handle($party, $fund, $campaign, DonationFrequency::OneOff, 5000, 'ZAR', 'fixture', Str::uuid()->toString());
+        app(DonationPaymentProvider::class)->process($donation, DonationSimulationScenario::Success, Str::uuid()->toString());
+
+        return $donation;
+    });
+
+    $this->actingAs($engagement)->get(route('donations.index', $organisation))->assertOk()->assertSee('Simulated donations');
+    $showUrl = '/'.$organisation->slug.'/donations/'.$donation->getKey();
+    expect($donation->getKey())->toBeString()->not->toBeEmpty()
+        ->and($showUrl)->toEndWith((string) $donation->getKey());
+    $this->actingAs($engagement)
+        ->get($showUrl)
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('donations/show')
+            ->where('donation.payments.0.receipt.marker', 'Demo—Not a tax receipt'));
+    $this->actingAs($caseWorker)->get(route('donations.index', $organisation))->assertForbidden();
+    $this->actingAs($caseWorker)->get($showUrl)->assertForbidden();
+});

--- a/tests/Feature/DonationLifecycleTest.php
+++ b/tests/Feature/DonationLifecycleTest.php
@@ -164,7 +164,12 @@ it('allows only engagement officers to follow supporter-safe simulated donation 
         return $donation;
     });
 
-    $this->actingAs($engagement)->get(route('donations.index', $organisation))->assertOk()->assertSee('Simulated donations');
+    $this->actingAs($engagement)
+        ->get(route('donations.index', $organisation))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('donations/index')
+            ->has('donations.data', 1));
     $showUrl = '/'.$organisation->slug.'/donations/'.$donation->getKey();
     expect($donation->getKey())->toBeString()->not->toBeEmpty()
         ->and($showUrl)->toEndWith((string) $donation->getKey());


### PR DESCRIPTION
Closes #16

## Summary
- add tenant-scoped simulated donation, payment, mandate, refund, receipt, fund, and campaign records
- provide a public demo-only donation flow and engagement-officer lifecycle views
- seed HarbourKind with an idempotent donor-to-retained-supporter scenario
- enforce immutable money, deterministic transitions, retry safety, recovery evidence, and refund bounds

## Safety
- collects no name, email, telephone, card, or bank details
- all provider identifiers use the sim_ namespace
- every public and staff surface marks the lifecycle and receipt as simulation-only

## Verification
- self-reviewed against codex/issue-15-service-monitoring and fixed idempotency and provider-ID collision issues
- PostgreSQL: 301 tests, 1611 assertions
- PHPStan, Pint, frontend formatting, TypeScript, Vitest, licence policy, and production build pass

Signed commits include GPG verification and DCO sign-off.