### PR TITLE
Capture supporter consent and build saved segments

### DIFF
--- a/app/Actions/Demo/BuildDonorToRetainedSupporterScenario.php
+++ b/app/Actions/Demo/BuildDonorToRetainedSupporterScenario.php
@@ -3,22 +3,30 @@
 namespace App\Actions\Demo;
 
 use App\Actions\Donations\CreateDonation;
+use App\Actions\Parties\RecordPartyConsent;
 use App\Donations\DonationPaymentProvider;
+use App\Enums\ConsentChannel;
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
 use App\Enums\DonationFrequency;
 use App\Enums\DonationSimulationScenario;
+use App\Models\AudienceSegment;
 use App\Models\Donation;
 use App\Models\DonationFund;
 use App\Models\FundraisingCampaign;
 use App\Models\Party;
+use App\Models\PartyConsent;
+use App\Models\User;
 
 class BuildDonorToRetainedSupporterScenario
 {
     public function __construct(
         private readonly CreateDonation $createDonation,
         private readonly DonationPaymentProvider $paymentProvider,
+        private readonly RecordPartyConsent $recordPartyConsent,
     ) {}
 
-    public function handle(Party $donor): Donation
+    public function handle(Party $donor, User $actor): Donation
     {
         $campaign = FundraisingCampaign::query()->updateOrCreate(
             ['organisation_id' => $donor->organisation_id, 'slug' => 'winter-warmth-demo'],
@@ -40,6 +48,38 @@ class BuildDonorToRetainedSupporterScenario
             $idempotencyKey,
         );
         $this->paymentProvider->process($donation, DonationSimulationScenario::Success, $idempotencyKey);
+        $consent = PartyConsent::query()
+            ->where('party_id', $donor->id)
+            ->where('purpose', ConsentPurpose::SupporterUpdates)
+            ->where('channel', ConsentChannel::Email)
+            ->where('source', 'winter-warmth-demo')
+            ->first();
+        if ($consent === null) {
+            $this->recordPartyConsent->handle($donor, [
+                'purpose' => ConsentPurpose::SupporterUpdates,
+                'channel' => ConsentChannel::Email,
+                'decision' => ConsentDecision::Granted,
+                'wording_version' => 'supporter-updates-v1',
+                'wording' => 'I agree to receive simulated supporter updates by email for the Winter Warmth Demo Appeal.',
+                'source' => 'winter-warmth-demo',
+                'occurred_at' => now()->toAtomString(),
+            ], $actor);
+        }
+        AudienceSegment::query()->updateOrCreate(
+            ['organisation_id' => $donor->organisation_id, 'name' => 'Winter Warmth retained supporters'],
+            [
+                'criteria' => [
+                    'purpose' => ConsentPurpose::SupporterUpdates->value,
+                    'channel' => ConsentChannel::Email->value,
+                    'role' => 'donor',
+                    'service_area' => null,
+                    'interest' => null,
+                    'donation_activity' => true,
+                    'campaign_source' => 'showcase_fixture',
+                ],
+                'created_by_user_id' => $actor->id,
+            ],
+        );
 
         return $donation->refresh();
     }

--- a/app/Actions/Demo/BuildOrganisationScenario.php
+++ b/app/Actions/Demo/BuildOrganisationScenario.php
@@ -90,6 +90,7 @@ final class BuildOrganisationScenario
                     );
                     $this->buildDonorToRetainedSupporterScenario->handle(
                         Party::query()->where('uuid', '12000000-0000-4000-8000-000000000002')->firstOrFail(),
+                        User::query()->where('email', 'engagement@harbourkind.example.test')->firstOrFail(),
                     );
                 }
             });

--- a/app/Actions/Engagement/CreateAudienceSegment.php
+++ b/app/Actions/Engagement/CreateAudienceSegment.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Actions\Engagement;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Enums\TenantAuditEventType;
+use App\Models\AudienceSegment;
+use App\Models\Organisation;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+
+class CreateAudienceSegment
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    /** @param array{purpose: string, channel: string, role: string, service_area: string|null, interest: string|null, donation_activity: bool, campaign_source: string|null} $criteria */
+    public function handle(Organisation $organisation, string $name, array $criteria, User $actor): AudienceSegment
+    {
+        $this->context->ensureOwns($organisation->id);
+
+        return DB::transaction(function () use ($actor, $criteria, $name, $organisation): AudienceSegment {
+            $segment = AudienceSegment::query()->create([
+                'organisation_id' => $organisation->id,
+                'name' => $name,
+                'criteria' => $criteria,
+                'created_by_user_id' => $actor->id,
+            ]);
+            $this->recordAudit->handle($organisation, TenantAuditEventType::AudienceSegmentCreated, 'audience_segment', $segment->id, [
+                'segment_id' => $segment->id,
+                'name' => $segment->name,
+            ], $actor);
+
+            return $segment;
+        });
+    }
+}

--- a/app/Actions/Engagement/EvaluateAudienceSegment.php
+++ b/app/Actions/Engagement/EvaluateAudienceSegment.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Actions\Engagement;
+
+use App\Enums\ConsentDecision;
+use App\Enums\DonationPaymentStatus;
+use App\Enums\PartyContactType;
+use App\Models\AudienceSegment;
+use App\Models\Donation;
+use App\Models\Party;
+use App\Models\PartyAddress;
+use App\Models\PartyConsent;
+use App\Models\PartyInterest;
+use App\OrganisationContext;
+use Illuminate\Support\Collection;
+
+class EvaluateAudienceSegment
+{
+    public function __construct(private readonly OrganisationContext $context) {}
+
+    /** @return Collection<int, array{uuid: string, displayName: string, role: string, serviceAreas: array<int, string>, interests: array<int, string>, donationCount: int<0, max>, consentedAt: string}> */
+    public function handle(AudienceSegment $segment): Collection
+    {
+        $this->context->ensureOwns($segment->organisation_id);
+        $criteria = $segment->criteria;
+        $contactType = $criteria['channel'] === 'email' ? PartyContactType::Email : PartyContactType::Telephone;
+        $evaluatedAt = now();
+
+        return Party::query()
+            ->whereHas('businessRoles', fn ($query) => $query->where('role', $criteria['role']))
+            ->whereHas('contactPoints', fn ($query) => $query->where('type', $contactType))
+            ->with(['addresses', 'businessRoles', 'consents', 'contactPoints', 'donations.payments', 'interests', 'safeContactInstructions'])
+            ->orderBy('display_name')
+            ->orderBy('id')
+            ->get()
+            ->filter(function (Party $party) use ($criteria, $evaluatedAt): bool {
+                $latestConsent = $this->latestConsent($party, $criteria['purpose'], $criteria['channel']);
+
+                if ($latestConsent?->decision !== ConsentDecision::Granted) {
+                    return false;
+                }
+
+                if ($party->safeContactInstructions->contains(fn ($instruction): bool => $instruction->effective_at->lte($evaluatedAt) && ($instruction->ended_at === null || $instruction->ended_at->gt($evaluatedAt)))) {
+                    return false;
+                }
+
+                if ($criteria['service_area'] !== null && ! $party->addresses->contains('service_area', $criteria['service_area'])) {
+                    return false;
+                }
+
+                if ($criteria['interest'] !== null && ! $party->interests->contains('slug', $criteria['interest'])) {
+                    return false;
+                }
+
+                return (! $criteria['donation_activity'] && $criteria['campaign_source'] === null)
+                    || $this->eligibleDonations($party, $criteria['campaign_source'])->isNotEmpty();
+            })
+            ->map(function (Party $party) use ($criteria): array {
+                $consent = $this->latestConsent($party, $criteria['purpose'], $criteria['channel']);
+                $donations = $this->eligibleDonations($party, $criteria['campaign_source']);
+
+                return [
+                    'uuid' => $party->uuid,
+                    'displayName' => $party->display_name,
+                    'role' => $criteria['role'],
+                    'serviceAreas' => $party->addresses->map(fn (PartyAddress $address): ?string => $address->service_area)->filter(fn (?string $area): bool => $area !== null)->unique()->values()->all(),
+                    'interests' => $party->interests->map(fn (PartyInterest $interest): string => $interest->label)->unique()->values()->all(),
+                    'donationCount' => $donations->count(),
+                    'consentedAt' => $consent?->occurred_at->toAtomString() ?? '',
+                ];
+            })
+            ->values();
+    }
+
+    private function latestConsent(Party $party, string $purpose, string $channel): ?PartyConsent
+    {
+        return $party->consents
+            ->filter(fn (PartyConsent $consent): bool => $consent->purpose->value === $purpose && $consent->channel->value === $channel)
+            ->sortByDesc(fn (PartyConsent $consent): string => $consent->occurred_at->format('Y-m-d H:i:s.u').$consent->id)
+            ->first();
+    }
+
+    /** @return Collection<int, Donation> */
+    private function eligibleDonations(Party $party, ?string $campaignSource): Collection
+    {
+        return $party->donations->filter(fn ($donation): bool => ($campaignSource === null || $donation->source_code === $campaignSource)
+            && $donation->payments->contains('status', DonationPaymentStatus::Succeeded));
+    }
+}

--- a/app/Actions/Parties/RecordPartyConsent.php
+++ b/app/Actions/Parties/RecordPartyConsent.php
@@ -2,6 +2,7 @@
 
 namespace App\Actions\Parties;
 
+use App\Enums\ConsentChannel;
 use App\Enums\ConsentDecision;
 use App\Enums\ConsentPurpose;
 use App\Enums\PartyTimelineEventType;
@@ -19,16 +20,18 @@ final class RecordPartyConsent
         private readonly RecordPartyTimelineEvent $recordTimelineEvent,
     ) {}
 
-    /** @param array{purpose: ConsentPurpose, decision: ConsentDecision, wording_version: string, wording: string, source: string, occurred_at: string} $attributes */
+    /** @param array{purpose: ConsentPurpose, channel?: ConsentChannel, decision: ConsentDecision, wording_version: string, wording: string, source: string, occurred_at: string} $attributes */
     public function handle(Party $party, array $attributes, User $actor): PartyConsent
     {
         $this->organisationContext->ensureOwns($party->organisation_id);
 
         return DB::transaction(function () use ($party, $attributes, $actor): PartyConsent {
             $party = Party::query()->lockForUpdate()->findOrFail($party->id);
+            $channel = $attributes['channel'] ?? ConsentChannel::NotApplicable;
             $latest = PartyConsent::query()
                 ->where('party_id', $party->id)
                 ->where('purpose', $attributes['purpose'])
+                ->where('channel', $channel)
                 ->latest('occurred_at')
                 ->latest('id')
                 ->lockForUpdate()
@@ -43,6 +46,7 @@ final class RecordPartyConsent
                 'organisation_id' => $party->organisation_id,
                 'party_id' => $party->id,
                 ...$attributes,
+                'channel' => $channel,
                 'supersedes_id' => $latest?->id,
                 'recorded_by_user_id' => $actor->id,
             ]);

--- a/app/Enums/ConsentChannel.php
+++ b/app/Enums/ConsentChannel.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum ConsentChannel: string
+{
+    case NotApplicable = 'not_applicable';
+    case Email = 'email';
+    case Sms = 'sms';
+    case Telephone = 'telephone';
+}

--- a/app/Enums/ConsentDecision.php
+++ b/app/Enums/ConsentDecision.php
@@ -6,4 +6,5 @@ enum ConsentDecision: string
 {
     case Granted = 'granted';
     case Withdrawn = 'withdrawn';
+    case Suppressed = 'suppressed';
 }

--- a/app/Enums/ConsentPurpose.php
+++ b/app/Enums/ConsentPurpose.php
@@ -7,4 +7,5 @@ enum ConsentPurpose: string
     case Service = 'service';
     case Referral = 'referral';
     case SafeContact = 'safe_contact';
+    case SupporterUpdates = 'supporter_updates';
 }

--- a/app/Enums/TenantAuditEventType.php
+++ b/app/Enums/TenantAuditEventType.php
@@ -22,6 +22,7 @@ enum TenantAuditEventType: string
     case DonationPaymentTransitioned = 'donation_payment_transitioned';
     case DonationRefunded = 'donation_refunded';
     case RecurringMandateTransitioned = 'recurring_mandate_transitioned';
+    case AudienceSegmentCreated = 'audience_segment_created';
 
     /** @return array<string, string> */
     public function payloadSchema(): array
@@ -105,6 +106,10 @@ enum TenantAuditEventType: string
                 'mandate_id' => 'string',
                 'from_status' => 'string',
                 'to_status' => 'string',
+            ],
+            self::AudienceSegmentCreated => [
+                'segment_id' => 'string',
+                'name' => 'string',
             ],
         };
     }

--- a/app/Http/Controllers/Organisations/AudienceSegmentController.php
+++ b/app/Http/Controllers/Organisations/AudienceSegmentController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Engagement\CreateAudienceSegment;
+use App\Actions\Engagement\EvaluateAudienceSegment;
+use App\Enums\ConsentChannel;
+use App\Enums\ConsentPurpose;
+use App\Enums\PartyBusinessRole;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\StoreAudienceSegmentRequest;
+use App\Models\AudienceSegment;
+use App\Models\Donation;
+use App\Models\Organisation;
+use App\Models\PartyAddress;
+use App\Models\PartyInterest;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class AudienceSegmentController extends Controller
+{
+    public function index(Organisation $currentOrganisation, EvaluateAudienceSegment $evaluate): Response
+    {
+        Gate::authorize('viewAny', [AudienceSegment::class, $currentOrganisation]);
+
+        return Inertia::render('audience-segments/index', [
+            'segments' => AudienceSegment::query()->orderBy('name')->get()->map(fn (AudienceSegment $segment): array => [
+                'id' => $segment->id,
+                'name' => $segment->name,
+                'criteria' => $segment->criteria,
+                'eligibleCount' => $evaluate->handle($segment)->count(),
+            ]),
+            'options' => [
+                'purpose' => ConsentPurpose::SupporterUpdates->value,
+                'channels' => collect([ConsentChannel::Email, ConsentChannel::Sms, ConsentChannel::Telephone])->map(fn (ConsentChannel $channel): array => ['value' => $channel->value, 'label' => str($channel->value)->replace('_', ' ')->title()->toString()]),
+                'roles' => collect([PartyBusinessRole::Donor, PartyBusinessRole::Volunteer, PartyBusinessRole::PartnerContact, PartyBusinessRole::EventAttendee])->map(fn (PartyBusinessRole $role): array => ['value' => $role->value, 'label' => $role->label()]),
+                'serviceAreas' => PartyAddress::query()->whereNotNull('service_area')->distinct()->orderBy('service_area')->pluck('service_area'),
+                'interests' => PartyInterest::query()->select(['slug', 'label'])->distinct()->orderBy('label')->get(),
+                'campaignSources' => Donation::query()->distinct()->orderBy('source_code')->pluck('source_code'),
+            ],
+        ]);
+    }
+
+    public function store(StoreAudienceSegmentRequest $request, Organisation $currentOrganisation, CreateAudienceSegment $create): RedirectResponse
+    {
+        Gate::authorize('create', [AudienceSegment::class, $currentOrganisation]);
+        $validated = $request->validated();
+        $segment = $create->handle(
+            $currentOrganisation,
+            $validated['name'],
+            [
+                'purpose' => $validated['purpose'],
+                'channel' => $validated['channel'],
+                'role' => $validated['role'],
+                'service_area' => $validated['service_area'] ?? null,
+                'interest' => $validated['interest'] ?? null,
+                'donation_activity' => (bool) $validated['donation_activity'],
+                'campaign_source' => $validated['campaign_source'] ?? null,
+            ],
+            $request->user(),
+        );
+
+        return to_route('audience-segments.show', [$currentOrganisation, $segment]);
+    }
+
+    public function show(Organisation $currentOrganisation, string $audienceSegment, EvaluateAudienceSegment $evaluate): Response
+    {
+        $segment = AudienceSegment::query()->findOrFail($audienceSegment);
+        Gate::authorize('view', $segment);
+        $audience = $evaluate->handle($segment);
+
+        return Inertia::render('audience-segments/show', [
+            'segment' => ['id' => $segment->id, 'name' => $segment->name, 'criteria' => $segment->criteria],
+            'audience' => $audience,
+            'eligibleCount' => $audience->count(),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Organisations/PartyConsentController.php
+++ b/app/Http/Controllers/Organisations/PartyConsentController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Organisations;
 
 use App\Actions\Parties\RecordPartyConsent;
+use App\Enums\ConsentChannel;
 use App\Enums\ConsentDecision;
 use App\Enums\ConsentPurpose;
 use App\Http\Controllers\Controller;
@@ -22,8 +23,11 @@ class PartyConsentController extends Controller
     ): RedirectResponse {
         $party = Party::query()->where('uuid', $party)->firstOrFail();
         Gate::authorize('recordConsent', $party);
+        $purpose = ConsentPurpose::from($request->string('purpose')->toString());
+        abort_if(Gate::allows('supporterSafe', $party) && $purpose !== ConsentPurpose::SupporterUpdates, 403);
         $recordPartyConsent->handle($party, [
-            'purpose' => ConsentPurpose::from($request->string('purpose')->toString()),
+            'purpose' => $purpose,
+            'channel' => $request->filled('channel') ? ConsentChannel::from($request->string('channel')->toString()) : ConsentChannel::NotApplicable,
             'decision' => ConsentDecision::from($request->string('decision')->toString()),
             'wording_version' => $request->string('wording_version')->toString(),
             'wording' => $request->string('wording')->toString(),

--- a/app/Http/Controllers/Organisations/PartyController.php
+++ b/app/Http/Controllers/Organisations/PartyController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Organisations;
 
 use App\Actions\Parties\CreatePartyProfile;
 use App\Actions\Parties\UpdatePartyProfile;
+use App\Enums\ConsentPurpose;
 use App\Enums\OrganisationRole;
 use App\Enums\PartyBusinessRole;
 use App\Enums\PartyContactType;
@@ -137,16 +138,19 @@ class PartyController extends Controller
                     'startedAt' => $relationship->started_at?->toAtomString(),
                     'endedAt' => $relationship->ended_at?->toAtomString(),
                 ])->values() : [],
-                'consents' => $serviceProjection ? $party->consents->map(fn ($consent): array => [
-                    'id' => $consent->id,
-                    'purpose' => $consent->purpose->value,
-                    'decision' => $consent->decision->value,
-                    'wordingVersion' => $consent->wording_version,
-                    'wording' => $consent->wording,
-                    'source' => $consent->source,
-                    'occurredAt' => $consent->occurred_at->toAtomString(),
-                    'supersedesId' => $consent->supersedes_id,
-                ])->values() : [],
+                'consents' => ($serviceProjection || $supporterSafe) ? $party->consents
+                    ->when($supporterSafe, fn ($consents) => $consents->where('purpose', ConsentPurpose::SupporterUpdates))
+                    ->map(fn ($consent): array => [
+                        'id' => $consent->id,
+                        'purpose' => $consent->purpose->value,
+                        'channel' => $consent->channel->value,
+                        'decision' => $consent->decision->value,
+                        'wordingVersion' => $consent->wording_version,
+                        'wording' => $consent->wording,
+                        'source' => $consent->source,
+                        'occurredAt' => $consent->occurred_at->toAtomString(),
+                        'supersedesId' => $consent->supersedes_id,
+                    ])->values() : [],
                 'safeContactInstructions' => $canManageSafeContact
                     ? $party->safeContactInstructions->map(fn ($instruction): array => [
                         'id' => $instruction->id,

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\AudienceSegment;
 use App\Models\Donation;
 use App\Models\IntakeRequest;
 use App\Models\Organisation;
@@ -67,6 +68,8 @@ class HandleInertiaRequests extends Middleware
                 && Gate::allows('viewAny', [IntakeRequest::class, $routeOrganisation]),
             'canViewDonations' => fn (): bool => $routeOrganisation instanceof Organisation
                 && Gate::allows('viewAny', [Donation::class, $routeOrganisation]),
+            'canViewAudienceSegments' => fn (): bool => $routeOrganisation instanceof Organisation
+                && Gate::allows('viewAny', [AudienceSegment::class, $routeOrganisation]),
         ];
     }
 }

--- a/app/Http/Requests/Organisations/RecordPartyConsentRequest.php
+++ b/app/Http/Requests/Organisations/RecordPartyConsentRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Organisations;
 
+use App\Enums\ConsentChannel;
 use App\Enums\ConsentDecision;
 use App\Enums\ConsentPurpose;
 use Illuminate\Contracts\Validation\ValidationRule;
@@ -27,6 +28,7 @@ class RecordPartyConsentRequest extends FormRequest
     {
         return [
             'purpose' => ['required', Rule::enum(ConsentPurpose::class)],
+            'channel' => ['nullable', Rule::enum(ConsentChannel::class)],
             'decision' => ['required', Rule::enum(ConsentDecision::class)],
             'wording_version' => ['required', 'string', 'max:64'],
             'wording' => ['required', 'string', 'max:2000'],

--- a/app/Http/Requests/Organisations/StoreAudienceSegmentRequest.php
+++ b/app/Http/Requests/Organisations/StoreAudienceSegmentRequest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Enums\ConsentChannel;
+use App\Enums\ConsentPurpose;
+use App\Enums\PartyBusinessRole;
+use App\Models\Organisation;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreAudienceSegmentRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $organisation = $this->route('current_organisation');
+        $organisationId = $organisation instanceof Organisation ? $organisation->id : 0;
+
+        return [
+            'name' => ['required', 'string', 'max:120', Rule::unique('audience_segments', 'name')->where('organisation_id', $organisationId)],
+            'purpose' => ['required', Rule::in([ConsentPurpose::SupporterUpdates->value])],
+            'channel' => ['required', Rule::in([ConsentChannel::Email->value, ConsentChannel::Sms->value, ConsentChannel::Telephone->value])],
+            'role' => ['required', Rule::in([PartyBusinessRole::Donor->value, PartyBusinessRole::Volunteer->value, PartyBusinessRole::PartnerContact->value, PartyBusinessRole::EventAttendee->value])],
+            'service_area' => ['nullable', 'string', 'max:100', Rule::exists('party_addresses', 'service_area')->where('organisation_id', $organisationId)],
+            'interest' => ['nullable', 'string', 'max:100', Rule::exists('party_interests', 'slug')->where('organisation_id', $organisationId)],
+            'donation_activity' => ['required', 'boolean'],
+            'campaign_source' => ['nullable', 'string', 'max:64', Rule::exists('donations', 'source_code')->where('organisation_id', $organisationId)],
+        ];
+    }
+}

--- a/app/Models/AudienceSegment.php
+++ b/app/Models/AudienceSegment.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use Database\Factories\AudienceSegmentFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $name
+ * @property array{purpose: string, channel: string, role: string, service_area: string|null, interest: string|null, donation_activity: bool, campaign_source: string|null} $criteria
+ */
+#[Fillable(['organisation_id', 'name', 'criteria', 'created_by_user_id'])]
+class AudienceSegment extends Model
+{
+    /** @use HasFactory<AudienceSegmentFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected static function booted(): void
+    {
+        static::updating(function (AudienceSegment $segment): void {
+            if ($segment->isDirty(['organisation_id', 'criteria'])) {
+                throw new LogicException('Saved audience criteria are immutable; create a new definition instead.');
+            }
+        });
+    }
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['criteria' => 'array'];
+    }
+}

--- a/app/Models/Party.php
+++ b/app/Models/Party.php
@@ -112,6 +112,12 @@ class Party extends Model
         return $this->hasMany(ServiceCase::class);
     }
 
+    /** @return HasMany<Donation, $this> */
+    public function donations(): HasMany
+    {
+        return $this->hasMany(Donation::class);
+    }
+
     /** @return array<string, string> */
     protected function casts(): array
     {

--- a/app/Models/PartyConsent.php
+++ b/app/Models/PartyConsent.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\BelongsToOrganisation;
+use App\Enums\ConsentChannel;
 use App\Enums\ConsentDecision;
 use App\Enums\ConsentPurpose;
 use Database\Factories\PartyConsentFactory;
@@ -17,6 +18,7 @@ use LogicException;
 /**
  * @property string $id
  * @property ConsentPurpose $purpose
+ * @property ConsentChannel $channel
  * @property ConsentDecision $decision
  * @property string $wording_version
  * @property string $wording
@@ -24,7 +26,7 @@ use LogicException;
  * @property Carbon $occurred_at
  * @property string|null $supersedes_id
  */
-#[Fillable(['organisation_id', 'party_id', 'purpose', 'decision', 'wording_version', 'wording', 'source', 'occurred_at', 'supersedes_id', 'recorded_by_user_id'])]
+#[Fillable(['organisation_id', 'party_id', 'purpose', 'channel', 'decision', 'wording_version', 'wording', 'source', 'occurred_at', 'supersedes_id', 'recorded_by_user_id'])]
 class PartyConsent extends Model
 {
     /** @use HasFactory<PartyConsentFactory> */
@@ -61,6 +63,7 @@ class PartyConsent extends Model
     {
         return [
             'purpose' => ConsentPurpose::class,
+            'channel' => ConsentChannel::class,
             'decision' => ConsentDecision::class,
             'occurred_at' => 'datetime',
         ];

--- a/app/Models/PartyInterest.php
+++ b/app/Models/PartyInterest.php
@@ -9,6 +9,11 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * @property int $party_id
+ * @property string $slug
+ * @property string $label
+ */
 #[Fillable(['organisation_id', 'party_id', 'slug', 'label'])]
 class PartyInterest extends Model
 {

--- a/app/Policies/AudienceSegmentPolicy.php
+++ b/app/Policies/AudienceSegmentPolicy.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\OrganisationRole;
+use App\Models\AudienceSegment;
+use App\Models\Organisation;
+use App\Models\User;
+
+class AudienceSegmentPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user, Organisation $organisation): bool
+    {
+        return $user->hasOrganisationRole($organisation, OrganisationRole::EngagementOfficer);
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, AudienceSegment $audienceSegment): bool
+    {
+        return $this->viewAny($user, $audienceSegment->organisation);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user, Organisation $organisation): bool
+    {
+        return $this->viewAny($user, $organisation);
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, AudienceSegment $audienceSegment): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, AudienceSegment $audienceSegment): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, AudienceSegment $audienceSegment): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, AudienceSegment $audienceSegment): bool
+    {
+        return false;
+    }
+}

--- a/app/Policies/PartyPolicy.php
+++ b/app/Policies/PartyPolicy.php
@@ -75,7 +75,8 @@ class PartyPolicy
 
     public function recordConsent(User $user, Party $party): bool
     {
-        return $this->hasProgramManagerAccess($user, $party)
+        return $this->supporterSafe($user, $party)
+            || $this->hasProgramManagerAccess($user, $party)
             || ServiceCase::query()
                 ->where('party_id', $party->id)
                 ->get()

--- a/database/factories/AudienceSegmentFactory.php
+++ b/database/factories/AudienceSegmentFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ConsentChannel;
+use App\Enums\ConsentPurpose;
+use App\Enums\PartyBusinessRole;
+use App\Models\AudienceSegment;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AudienceSegment>
+ */
+class AudienceSegmentFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'name' => fake()->unique()->word().' '.fake()->word().' supporters',
+            'criteria' => [
+                'purpose' => ConsentPurpose::SupporterUpdates->value,
+                'channel' => ConsentChannel::Email->value,
+                'role' => PartyBusinessRole::Donor->value,
+                'service_area' => null,
+                'interest' => null,
+                'donation_activity' => true,
+                'campaign_source' => null,
+            ],
+        ];
+    }
+}

--- a/database/factories/PartyConsentFactory.php
+++ b/database/factories/PartyConsentFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\ConsentChannel;
 use App\Enums\ConsentDecision;
 use App\Enums\ConsentPurpose;
 use App\Models\Party;
@@ -25,6 +26,7 @@ class PartyConsentFactory extends Factory
             'organisation_id' => app(OrganisationContext::class)->id(),
             'party_id' => Party::factory()->state(['organisation_id' => app(OrganisationContext::class)->id()]),
             'purpose' => ConsentPurpose::Service,
+            'channel' => ConsentChannel::NotApplicable,
             'decision' => ConsentDecision::Granted,
             'wording_version' => 'v1',
             'wording' => 'I consent to receiving this service.',

--- a/database/migrations/2026_08_31_120222_add_consent_channel_and_create_audience_segments_table.php
+++ b/database/migrations/2026_08_31_120222_add_consent_channel_and_create_audience_segments_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('party_consents', function (Blueprint $table) {
+            $table->string('channel', 32)->default('not_applicable')->after('purpose');
+            $table->index(['organisation_id', 'party_id', 'purpose', 'channel', 'occurred_at'], 'party_consents_audience_lookup');
+        });
+
+        Schema::create('audience_segments', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->string('name', 120);
+            $table->json('criteria');
+            $table->foreignId('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'name']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('audience_segments');
+
+        Schema::table('party_consents', function (Blueprint $table) {
+            $table->dropIndex('party_consents_audience_lookup');
+            $table->dropColumn('channel');
+        });
+    }
+};

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -4,6 +4,7 @@ import {
     FolderGit2,
     HandCoins,
     LayoutGrid,
+    ListFilter,
     Scale,
     Settings2,
     UsersRound,
@@ -23,6 +24,7 @@ import {
     SidebarMenuItem,
 } from '@/components/ui/sidebar';
 import { dashboard } from '@/routes';
+import { index as audienceSegmentsIndex } from '@/routes/audience-segments';
 import { index as donationsIndex } from '@/routes/donations';
 import { index as intakesIndex } from '@/routes/intakes';
 import { index as partiesIndex } from '@/routes/parties';
@@ -65,6 +67,17 @@ export function AppSidebar() {
                       title: 'Simulated donations',
                       href: donationsIndex(page.props.currentOrganisation.slug),
                       icon: HandCoins,
+                  },
+              ]
+            : []),
+        ...(page.props.canViewAudienceSegments && page.props.currentOrganisation
+            ? [
+                  {
+                      title: 'Saved audiences',
+                      href: audienceSegmentsIndex(
+                          page.props.currentOrganisation.slug,
+                      ),
+                      icon: ListFilter,
                   },
               ]
             : []),

--- a/resources/js/pages/audience-segments/index.tsx
+++ b/resources/js/pages/audience-segments/index.tsx
@@ -1,0 +1,188 @@
+import { Form, Head, Link, usePage } from '@inertiajs/react';
+import Heading from '@/components/heading';
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { index, show, store } from '@/routes/audience-segments';
+
+type Segment = {
+    id: string;
+    name: string;
+    criteria: Record<string, string | boolean | null>;
+    eligibleCount: number;
+};
+type Option = { value: string; label: string };
+type Props = {
+    segments: Segment[];
+    options: {
+        purpose: string;
+        channels: Option[];
+        roles: Option[];
+        serviceAreas: string[];
+        interests: Array<{ slug: string; label: string }>;
+        campaignSources: string[];
+    };
+};
+
+export default function AudienceSegmentsIndex({ segments, options }: Props) {
+    const organisation = usePage().props.currentOrganisation!;
+
+    return (
+        <>
+            <Head title="Saved audiences" />
+            <div className="space-y-6 p-4">
+                <Heading
+                    title="Saved audiences"
+                    description="Reproducible supporter-only audiences. Active safe-contact restrictions, withdrawn consent, and suppression always win over segment criteria."
+                />
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Create saved audience</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <Form
+                            {...store.form(organisation.slug)}
+                            className="grid gap-4 md:grid-cols-2"
+                        >
+                            {({ errors, processing }) => (
+                                <>
+                                    <label className="grid gap-1">
+                                        <span>Name</span>
+                                        <input
+                                            name="name"
+                                            required
+                                            className="h-9 rounded-md border bg-transparent px-3"
+                                        />
+                                        <InputError message={errors.name} />
+                                    </label>
+                                    <input
+                                        type="hidden"
+                                        name="purpose"
+                                        value={options.purpose}
+                                    />
+                                    <Select
+                                        name="channel"
+                                        label="Consent channel"
+                                        options={options.channels}
+                                    />
+                                    <Select
+                                        name="role"
+                                        label="Supporter role"
+                                        options={options.roles}
+                                    />
+                                    <Select
+                                        name="service_area"
+                                        label="Service area (optional)"
+                                        options={options.serviceAreas.map(
+                                            (value) => ({
+                                                value,
+                                                label: value,
+                                            }),
+                                        )}
+                                        optional
+                                    />
+                                    <Select
+                                        name="interest"
+                                        label="Interest (optional)"
+                                        options={options.interests.map(
+                                            (interest) => ({
+                                                value: interest.slug,
+                                                label: interest.label,
+                                            }),
+                                        )}
+                                        optional
+                                    />
+                                    <Select
+                                        name="campaign_source"
+                                        label="Donation source (optional)"
+                                        options={options.campaignSources.map(
+                                            (value) => ({
+                                                value,
+                                                label: value,
+                                            }),
+                                        )}
+                                        optional
+                                    />
+                                    <label className="flex items-center gap-2">
+                                        <input
+                                            type="hidden"
+                                            name="donation_activity"
+                                            value="0"
+                                        />
+                                        <input
+                                            type="checkbox"
+                                            name="donation_activity"
+                                            value="1"
+                                        />
+                                        Require a successful simulated donation
+                                    </label>
+                                    <Button type="submit" disabled={processing}>
+                                        Save and preview
+                                    </Button>
+                                </>
+                            )}
+                        </Form>
+                    </CardContent>
+                </Card>
+                <section aria-labelledby="saved-segments" className="space-y-3">
+                    <h2 id="saved-segments" className="text-xl font-semibold">
+                        Saved definitions
+                    </h2>
+                    {segments.map((segment) => (
+                        <Link
+                            key={segment.id}
+                            href={show([organisation.slug, segment.id])}
+                            className="hover:bg-muted/50 block rounded-lg border p-4"
+                        >
+                            <strong>{segment.name}</strong>
+                            <p className="text-muted-foreground text-sm">
+                                {segment.eligibleCount} currently eligible
+                            </p>
+                        </Link>
+                    ))}
+                </section>
+            </div>
+        </>
+    );
+}
+
+function Select({
+    name,
+    label,
+    options,
+    optional = false,
+}: {
+    name: string;
+    label: string;
+    options: Option[];
+    optional?: boolean;
+}) {
+    return (
+        <label className="grid gap-1">
+            <span>{label}</span>
+            <select
+                name={name}
+                className="h-9 rounded-md border bg-transparent px-3"
+                required={!optional}
+            >
+                {optional ? <option value="">Any</option> : null}
+                {options.map((option) => (
+                    <option key={option.value} value={option.value}>
+                        {option.label}
+                    </option>
+                ))}
+            </select>
+        </label>
+    );
+}
+
+AudienceSegmentsIndex.layout = (props: {
+    currentOrganisation: { slug: string };
+}) => ({
+    breadcrumbs: [
+        {
+            title: 'Saved audiences',
+            href: index(props.currentOrganisation.slug),
+        },
+    ],
+});

--- a/resources/js/pages/audience-segments/show.tsx
+++ b/resources/js/pages/audience-segments/show.tsx
@@ -1,0 +1,125 @@
+import { Head } from '@inertiajs/react';
+import Heading from '@/components/heading';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { index, show } from '@/routes/audience-segments';
+
+type Member = {
+    uuid: string;
+    displayName: string;
+    role: string;
+    serviceAreas: string[];
+    interests: string[];
+    donationCount: number;
+    consentedAt: string;
+};
+
+export default function AudienceSegmentShow({
+    segment,
+    audience,
+    eligibleCount,
+}: {
+    segment: {
+        id: string;
+        name: string;
+        criteria: Record<string, string | boolean | null>;
+    };
+    audience: Member[];
+    eligibleCount: number;
+}) {
+    return (
+        <>
+            <Head title={segment.name} />
+            <div className="space-y-6 p-4">
+                <Heading
+                    title={segment.name}
+                    description={`${eligibleCount} currently eligible supporter(s). This preview contains no service-case or client-role fields.`}
+                />
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Saved criteria</CardTitle>
+                    </CardHeader>
+                    <CardContent className="flex flex-wrap gap-2">
+                        {Object.entries(segment.criteria).map(([key, value]) =>
+                            value !== null ? (
+                                <Badge key={key} variant="outline">
+                                    {key.replaceAll('_', ' ')}: {String(value)}
+                                </Badge>
+                            ) : null,
+                        )}
+                    </CardContent>
+                </Card>
+                <section
+                    aria-labelledby="eligible-supporters"
+                    className="space-y-3"
+                >
+                    <h2
+                        id="eligible-supporters"
+                        className="text-xl font-semibold"
+                    >
+                        Eligible supporters
+                    </h2>
+                    {audience.length === 0 ? (
+                        <p className="text-muted-foreground">
+                            No supporters currently meet every safety and
+                            consent rule.
+                        </p>
+                    ) : (
+                        audience.map((member) => (
+                            <Card key={member.uuid}>
+                                <CardContent className="grid gap-2 p-4 sm:grid-cols-2">
+                                    <div>
+                                        <strong>{member.displayName}</strong>
+                                        <p className="text-muted-foreground text-sm">
+                                            {member.role.replaceAll('_', ' ')}
+                                        </p>
+                                    </div>
+                                    <div className="text-sm">
+                                        <p>
+                                            {member.donationCount} matching
+                                            donation(s)
+                                        </p>
+                                        <p>
+                                            Consent:{' '}
+                                            {new Date(
+                                                member.consentedAt,
+                                            ).toLocaleString()}
+                                        </p>
+                                    </div>
+                                    {member.serviceAreas.length > 0 ? (
+                                        <p className="text-sm">
+                                            Areas:{' '}
+                                            {member.serviceAreas.join(', ')}
+                                        </p>
+                                    ) : null}
+                                    {member.interests.length > 0 ? (
+                                        <p className="text-sm">
+                                            Interests:{' '}
+                                            {member.interests.join(', ')}
+                                        </p>
+                                    ) : null}
+                                </CardContent>
+                            </Card>
+                        ))
+                    )}
+                </section>
+            </div>
+        </>
+    );
+}
+
+AudienceSegmentShow.layout = (props: {
+    currentOrganisation: { slug: string };
+    segment: { id: string; name: string };
+}) => ({
+    breadcrumbs: [
+        {
+            title: 'Saved audiences',
+            href: index(props.currentOrganisation.slug),
+        },
+        {
+            title: props.segment.name,
+            href: show([props.currentOrganisation.slug, props.segment.id]),
+        },
+    ],
+});

--- a/resources/js/pages/parties/show.tsx
+++ b/resources/js/pages/parties/show.tsx
@@ -291,6 +291,9 @@ export default function PartyShow({
                                     <div className="flex gap-2">
                                         <Badge>{consent.purpose}</Badge>
                                         <Badge variant="outline">
+                                            {consent.channel}
+                                        </Badge>
+                                        <Badge variant="outline">
                                             {consent.decision}
                                         </Badge>
                                     </div>
@@ -344,14 +347,34 @@ export default function PartyShow({
                                             name="purpose"
                                             className="h-9 rounded-md border bg-transparent px-3"
                                         >
-                                            <option value="service">
-                                                Service
+                                            {!party.supporterSafe ? (
+                                                <>
+                                                    <option value="service">
+                                                        Service
+                                                    </option>
+                                                    <option value="referral">
+                                                        Referral
+                                                    </option>
+                                                    <option value="safe_contact">
+                                                        Safe contact
+                                                    </option>
+                                                </>
+                                            ) : null}
+                                            <option value="supporter_updates">
+                                                Supporter updates
                                             </option>
-                                            <option value="referral">
-                                                Referral
+                                        </select>
+                                        <select
+                                            name="channel"
+                                            className="h-9 rounded-md border bg-transparent px-3"
+                                        >
+                                            <option value="not_applicable">
+                                                Not applicable
                                             </option>
-                                            <option value="safe_contact">
-                                                Safe contact
+                                            <option value="email">Email</option>
+                                            <option value="sms">SMS</option>
+                                            <option value="telephone">
+                                                Telephone
                                             </option>
                                         </select>
                                         <select
@@ -363,6 +386,9 @@ export default function PartyShow({
                                             </option>
                                             <option value="withdrawn">
                                                 Withdrawn
+                                            </option>
+                                            <option value="suppressed">
+                                                Suppressed
                                             </option>
                                         </select>
                                         <Input

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -18,6 +18,7 @@ declare module '@inertiajs/core' {
             canViewPrograms: boolean;
             canViewIntakes: boolean;
             canViewDonations: boolean;
+            canViewAudienceSegments: boolean;
             currentOrganisation: Organisation | null;
             organisations: Organisation[];
             [key: string]: unknown;

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\Organisations\AudienceSegmentController;
 use App\Http\Controllers\Organisations\CaseAssignmentController;
 use App\Http\Controllers\Organisations\CaseConfidentialityController;
 use App\Http\Controllers\Organisations\CaseDocumentController;
@@ -92,6 +93,7 @@ Route::prefix('{current_organisation}')
         Route::get('dashboard/service-operations/export', ServiceOperationsExportController::class)->name('dashboard.service-operations.export');
         Route::get('programs', [ProgramController::class, 'index'])->name('programs.index');
         Route::resource('donations', DonationController::class)->only(['index', 'show']);
+        Route::resource('audience-segments', AudienceSegmentController::class)->only(['index', 'store', 'show']);
         Route::resource('parties', PartyController::class)->only(['index', 'store', 'show', 'update']);
         Route::resource('intakes', IntakeRequestController::class)
             ->parameters(['intakes' => 'intake'])

--- a/tests/Feature/AudienceSegmentTest.php
+++ b/tests/Feature/AudienceSegmentTest.php
@@ -1,0 +1,177 @@
+<?php
+
+use App\Actions\Donations\CreateDonation;
+use App\Actions\Engagement\EvaluateAudienceSegment;
+use App\Actions\Parties\RecordPartyConsent;
+use App\Actions\Parties\StorePartyContact;
+use App\Donations\DonationPaymentProvider;
+use App\Enums\ConsentChannel;
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use App\Enums\DonationFrequency;
+use App\Enums\DonationSimulationScenario;
+use App\Enums\OrganisationRole;
+use App\Enums\PartyBusinessRole;
+use App\Enums\PartyContactType;
+use App\Enums\TenantAuditEventType;
+use App\Models\AudienceSegment;
+use App\Models\DonationFund;
+use App\Models\FundraisingCampaign;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\PartyAddress;
+use App\Models\PartyInterest;
+use App\Models\PartySafeContactInstruction;
+use App\Models\TenantAuditEvent;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia as Assert;
+
+beforeEach(function () {
+    $key = 'base64:'.base64_encode(str_repeat('s', 32));
+    config([
+        'classified_data.encryption.current_version' => 'segment-data-v1',
+        'classified_data.encryption.keys' => ['segment-data-v1' => $key],
+        'classified_data.contact_index.current_version' => 'segment-index-v1',
+        'classified_data.contact_index.previous_version' => null,
+        'classified_data.contact_index.keys' => ['segment-index-v1' => $key],
+    ]);
+});
+
+it('builds a reproducible supporter-safe audience and excludes every safety failure', function () {
+    $organisation = Organisation::factory()->active()->create(['slug' => 'harbourkind']);
+    $otherOrganisation = Organisation::factory()->active()->create();
+    $engagement = User::factory()->create();
+    $caseWorker = User::factory()->create();
+    $organisation->memberships()->create(['user_id' => $engagement->id, 'role' => OrganisationRole::EngagementOfficer]);
+    $organisation->memberships()->create(['user_id' => $caseWorker->id, 'role' => OrganisationRole::CaseWorker]);
+
+    [$segment, $eligible] = app(OrganisationContext::class)->run($organisation, function () use ($engagement, $organisation): array {
+        $fund = DonationFund::factory()->for($organisation)->create();
+        $campaign = FundraisingCampaign::factory()->for($organisation)->create();
+        $makeSupporter = function (string $name, ConsentDecision $decision, bool $unsafe = false, string $source = 'showcase_fixture') use ($campaign, $engagement, $fund, $organisation): Party {
+            $party = Party::factory()->for($organisation)->create(['display_name' => $name]);
+            $party->businessRoles()->create(['organisation_id' => $organisation->id, 'role' => PartyBusinessRole::Donor]);
+            app(StorePartyContact::class)->handle($party, PartyContactType::Email, Str::slug($name).'-safe@example.test');
+            PartyAddress::factory()->for($party)->create(['service_area' => 'Harbour Ward']);
+            PartyInterest::factory()->for($party)->create(['slug' => 'winter-relief', 'label' => 'Winter relief']);
+            $donation = app(CreateDonation::class)->handle($party, $fund, $campaign, DonationFrequency::OneOff, 5000, 'ZAR', $source, Str::uuid()->toString());
+            app(DonationPaymentProvider::class)->process($donation, DonationSimulationScenario::Success, Str::uuid()->toString());
+            app(RecordPartyConsent::class)->handle($party, [
+                'purpose' => ConsentPurpose::SupporterUpdates,
+                'channel' => ConsentChannel::Email,
+                'decision' => ConsentDecision::Granted,
+                'wording_version' => 'v1',
+                'wording' => 'I agree to simulated supporter email updates.',
+                'source' => 'winter-warmth-demo',
+                'occurred_at' => now()->subMinute()->toAtomString(),
+            ], $engagement);
+
+            if ($decision !== ConsentDecision::Granted) {
+                app(RecordPartyConsent::class)->handle($party, [
+                    'purpose' => ConsentPurpose::SupporterUpdates,
+                    'channel' => ConsentChannel::Email,
+                    'decision' => $decision,
+                    'wording_version' => 'v1',
+                    'wording' => 'Do not send simulated supporter email updates.',
+                    'source' => 'preference-centre-demo',
+                    'occurred_at' => now()->toAtomString(),
+                ], $engagement);
+            }
+
+            if ($unsafe) {
+                PartySafeContactInstruction::factory()->for($party)->create(['effective_at' => now()->subMinute()]);
+            }
+
+            return $party;
+        };
+
+        $eligible = $makeSupporter('Eligible Rowan', ConsentDecision::Granted);
+        $eligible->businessRoles()->create(['organisation_id' => $organisation->id, 'role' => PartyBusinessRole::Client]);
+        $makeSupporter('Withdrawn Supporter', ConsentDecision::Withdrawn);
+        $makeSupporter('Suppressed Supporter', ConsentDecision::Suppressed);
+        $makeSupporter('Unsafe Supporter', ConsentDecision::Granted, true);
+        $makeSupporter('Wrong Source Supporter', ConsentDecision::Granted, false, 'another_source');
+        $segment = AudienceSegment::factory()->create([
+            'name' => 'Winter Ward donors',
+            'criteria' => [
+                'purpose' => ConsentPurpose::SupporterUpdates->value,
+                'channel' => ConsentChannel::Email->value,
+                'role' => PartyBusinessRole::Donor->value,
+                'service_area' => 'Harbour Ward',
+                'interest' => 'winter-relief',
+                'donation_activity' => true,
+                'campaign_source' => 'showcase_fixture',
+            ],
+            'created_by_user_id' => $engagement->id,
+        ]);
+
+        return [$segment, $eligible];
+    });
+
+    app(OrganisationContext::class)->run($otherOrganisation, function () use ($otherOrganisation): void {
+        $party = Party::factory()->for($otherOrganisation)->create(['display_name' => 'Other tenant supporter']);
+        $party->businessRoles()->create(['organisation_id' => $otherOrganisation->id, 'role' => PartyBusinessRole::Donor]);
+    });
+
+    $audience = app(OrganisationContext::class)->run($organisation, fn () => app(EvaluateAudienceSegment::class)->handle($segment));
+    $sourceOnlyAudience = app(OrganisationContext::class)->run($organisation, function () use ($segment): Collection {
+        $sourceOnly = AudienceSegment::factory()->create([
+            'name' => 'Campaign-source-only donors',
+            'criteria' => [...$segment->criteria, 'donation_activity' => false],
+        ]);
+
+        return app(EvaluateAudienceSegment::class)->handle($sourceOnly);
+    });
+    expect($audience)->toHaveCount(1)
+        ->and($sourceOnlyAudience)->toHaveCount(1)
+        ->and($audience->sole()['uuid'])->toBe($eligible->uuid)
+        ->and($audience->sole())->not->toHaveKeys(['serviceCases', 'programs', 'clientRole']);
+
+    app(OrganisationContext::class)->run($organisation, fn () => app(RecordPartyConsent::class)->handle($eligible, [
+        'purpose' => ConsentPurpose::Service,
+        'decision' => ConsentDecision::Granted,
+        'wording_version' => 'service-v1',
+        'wording' => 'Synthetic service consent that engagement staff must not see.',
+        'source' => 'service-intake',
+        'occurred_at' => now()->toAtomString(),
+    ], $engagement));
+    $this->actingAs($engagement)
+        ->get(route('parties.show', [$organisation, $eligible]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->has('party.consents', 1)
+            ->where('party.consents.0.purpose', ConsentPurpose::SupporterUpdates->value));
+    $this->actingAs($engagement)->post(route('parties.consents.store', [$organisation, $eligible]), [
+        'purpose' => ConsentPurpose::Service->value,
+        'channel' => ConsentChannel::NotApplicable->value,
+        'decision' => ConsentDecision::Granted->value,
+        'wording_version' => 'service-v2',
+        'wording' => 'An engagement officer must not record this.',
+        'source' => 'staff-screen',
+        'occurred_at' => now()->toAtomString(),
+    ])->assertForbidden();
+
+    $this->actingAs($engagement)
+        ->get(route('audience-segments.show', [$organisation, $segment]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('audience-segments/show')
+            ->where('eligibleCount', 1)
+            ->where('audience.0.uuid', $eligible->uuid));
+    $this->actingAs($engagement)->post(route('audience-segments.store', $organisation), [
+        'name' => 'All consented donors',
+        'purpose' => ConsentPurpose::SupporterUpdates->value,
+        'channel' => ConsentChannel::Email->value,
+        'role' => PartyBusinessRole::Donor->value,
+        'service_area' => null,
+        'interest' => null,
+        'donation_activity' => false,
+        'campaign_source' => null,
+    ])->assertRedirect();
+    expect(app(OrganisationContext::class)->run($organisation, fn (): bool => AudienceSegment::query()->where('name', 'All consented donors')->exists()))->toBeTrue()
+        ->and(app(OrganisationContext::class)->run($organisation, fn (): bool => TenantAuditEvent::query()->where('type', TenantAuditEventType::AudienceSegmentCreated)->exists()))->toBeTrue();
+    $this->actingAs($caseWorker)->get(route('audience-segments.index', $organisation))->assertForbidden();
+    $this->actingAs($caseWorker)->get(route('audience-segments.show', [$organisation, $segment]))->assertForbidden();
+});

--- a/tests/Feature/CommunityKindScenarioSeederTest.php
+++ b/tests/Feature/CommunityKindScenarioSeederTest.php
@@ -1,11 +1,14 @@
 <?php
 
 use App\Actions\Demo\BuildOrganisationScenario;
+use App\Actions\Engagement\EvaluateAudienceSegment;
 use App\Actions\Programs\BuildProgramReport;
 use App\Actions\Programs\SearchPrograms;
 use App\Data\Demo\ScenarioCatalog;
+use App\Enums\ConsentPurpose;
 use App\Enums\DonationPaymentStatus;
 use App\Enums\OrganisationStatus;
+use App\Models\AudienceSegment;
 use App\Models\Donation;
 use App\Models\DonationFund;
 use App\Models\DonationPayment;
@@ -15,6 +18,7 @@ use App\Models\Membership;
 use App\Models\MetricEvent;
 use App\Models\Organisation;
 use App\Models\Party;
+use App\Models\PartyConsent;
 use App\Models\PartyContactPoint;
 use App\Models\Program;
 use App\Models\RoleAssignment;
@@ -85,6 +89,8 @@ it('seeds the versioned synthetic scenarios deterministically', function () {
         ->and(DonationPayment::withoutGlobalScopes()->count())->toBe(1)
         ->and(DonationPayment::withoutGlobalScopes()->sole()->status)->toBe(DonationPaymentStatus::Succeeded)
         ->and(DonationReceipt::withoutGlobalScopes()->sole()->marker)->toBe('Demo—Not a tax receipt')
+        ->and(AudienceSegment::withoutGlobalScopes()->count())->toBe(1)
+        ->and(PartyConsent::withoutGlobalScopes()->where('purpose', ConsentPurpose::SupporterUpdates)->count())->toBe(1)
         ->and($showcaseCase->opened_at->toDateTimeString())->toBe('2026-06-02 06:00:00')
         ->and($showcaseCase->closed_at?->toDateTimeString())->toBe('2026-06-28 13:00:00')
         ->and($serviceMetric->occurred_at->toDateTimeString())->toBe('2026-06-10 10:00:00')
@@ -110,7 +116,12 @@ it('seeds the versioned synthetic scenarios deterministically', function () {
         ->and(DonationFund::withoutGlobalScopes()->count())->toBe(1)
         ->and(Donation::withoutGlobalScopes()->count())->toBe(1)
         ->and(DonationPayment::withoutGlobalScopes()->count())->toBe(1)
-        ->and(DonationReceipt::withoutGlobalScopes()->count())->toBe(1);
+        ->and(DonationReceipt::withoutGlobalScopes()->count())->toBe(1)
+        ->and(AudienceSegment::withoutGlobalScopes()->count())->toBe(1)
+        ->and(PartyConsent::withoutGlobalScopes()->where('purpose', ConsentPurpose::SupporterUpdates)->count())->toBe(1);
+
+    $harbourKind = Organisation::query()->findOrFail($harbourKindId);
+    expect(app(OrganisationContext::class)->run($harbourKind, fn () => app(EvaluateAudienceSegment::class)->handle(AudienceSegment::query()->sole())->count()))->toBe(1);
 });
 
 it('keeps every scenario identity and reserved showcase explicitly synthetic', function () {


### PR DESCRIPTION
Closes #17

## Summary
- extend append-only consent history with explicit delivery channels and suppression
- let engagement officers record and view only supporter-update consent without exposing service consent
- add immutable, audited saved-audience definitions across role, geography, interest, successful donation activity, and source
- evaluate previews through tenant, consent, contact, suppression, withdrawal, and safe-contact boundaries
- seed a reproducible Winter Warmth retained-supporter audience for Rowan

## Review fixes
- campaign-source criteria always require a matching successful donation
- use one frozen safety timestamp per evaluation
- restrict engagement mutations and projections to supporter-update consent
- audit saved-audience creation transactionally

## Verification
- PostgreSQL: 302 tests, 1658 assertions
- PHPStan, Pint, frontend formatting, TypeScript, Vitest, licence policy, and production build pass
- commit is GPG verified and includes DCO sign-off