### PR TITLE
Run a suppressed, local-only supporter welcome journey

### DIFF
--- a/app/Actions/Engagement/ApproveSupporterJourney.php
+++ b/app/Actions/Engagement/ApproveSupporterJourney.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Actions\Engagement;
+
+use App\Enums\SupporterJourneyStatus;
+use App\Models\SupporterJourney;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class ApproveSupporterJourney
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly EvaluateAudienceSegment $evaluate,
+    ) {}
+
+    public function handle(SupporterJourney $journey, User $actor): SupporterJourney
+    {
+        $this->context->ensureOwns($journey->organisation_id);
+
+        return DB::transaction(function () use ($actor, $journey): SupporterJourney {
+            $locked = SupporterJourney::query()->lockForUpdate()->findOrFail($journey->id);
+
+            if ($locked->status !== SupporterJourneyStatus::Draft) {
+                return $locked;
+            }
+
+            $snapshot = $this->evaluate->handle($locked->audienceSegment)
+                ->map(fn (array $supporter): array => [
+                    'uuid' => $supporter['uuid'],
+                    'displayName' => $supporter['displayName'],
+                    'donationCount' => $supporter['donationCount'],
+                ])->values()->all();
+            $locked->update([
+                'status' => SupporterJourneyStatus::Approved,
+                'audience_snapshot' => $snapshot,
+                'approval_hash' => hash('sha256', json_encode([
+                    'subject' => $locked->subject,
+                    'body' => $locked->body,
+                    'audience' => array_column($snapshot, 'uuid'),
+                ], JSON_THROW_ON_ERROR)),
+                'approved_at' => now(),
+                'approved_by_user_id' => $actor->id,
+            ]);
+
+            if ($locked->audience_snapshot === null) {
+                throw new LogicException('The approved audience snapshot could not be frozen.');
+            }
+
+            return $locked->fresh();
+        });
+    }
+}

--- a/app/Actions/Engagement/DispatchSupporterJourney.php
+++ b/app/Actions/Engagement/DispatchSupporterJourney.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Actions\Engagement;
+
+use App\Enums\SupporterJourneyEventType;
+use App\Enums\SupporterJourneyRecipientStatus;
+use App\Enums\SupporterJourneyStatus;
+use App\Models\Party;
+use App\Models\SupporterJourney;
+use App\Models\SupporterJourneyRecipient;
+use App\OrganisationContext;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+use Ramsey\Uuid\Uuid;
+
+class DispatchSupporterJourney
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly EvaluateAudienceSegment $evaluate,
+        private readonly TransitionSupporterJourneyRecipient $transition,
+    ) {}
+
+    /** @return Collection<int, SupporterJourneyRecipient> */
+    public function handle(SupporterJourney $journey): Collection
+    {
+        $this->context->ensureOwns($journey->organisation_id);
+
+        if (! config('engagement.simulation_only') || ! app()->environment(['local', 'testing'])) {
+            throw new LogicException('Supporter journeys are restricted to local simulation.');
+        }
+
+        if ($journey->status === SupporterJourneyStatus::Draft || $journey->audience_snapshot === null) {
+            throw new LogicException('Only an approved journey can be simulated.');
+        }
+
+        $eligibleUuids = $this->evaluate->handle($journey->audienceSegment)->pluck('uuid');
+        $snapshotUuids = collect($journey->audience_snapshot)->pluck('uuid');
+        $parties = Party::query()->withTrashed()->whereIn('uuid', $snapshotUuids)->get()->keyBy('uuid');
+
+        return DB::transaction(function () use ($eligibleUuids, $journey, $parties, $snapshotUuids): Collection {
+            return $snapshotUuids->map(function (string $uuid) use ($eligibleUuids, $journey, $parties): SupporterJourneyRecipient {
+                /** @var Party $party */
+                $party = $parties->get($uuid);
+                $recipient = SupporterJourneyRecipient::query()->firstOrCreate(
+                    ['supporter_journey_id' => $journey->id, 'party_id' => $party->id],
+                    [
+                        'organisation_id' => $journey->organisation_id,
+                        'status' => SupporterJourneyRecipientStatus::Queued,
+                    ],
+                );
+                $eligible = $eligibleUuids->contains($uuid) && ! $this->frequencyCapped($recipient);
+                $type = $eligible ? SupporterJourneyEventType::Queued : SupporterJourneyEventType::Cancelled;
+
+                return $this->transition->handle(
+                    $recipient,
+                    $type,
+                    Uuid::uuid5($journey->id, "dispatch:{$party->uuid}:{$type->value}")->toString(),
+                );
+            });
+        });
+    }
+
+    private function frequencyCapped(SupporterJourneyRecipient $recipient): bool
+    {
+        return SupporterJourneyRecipient::query()
+            ->where('party_id', $recipient->party_id)
+            ->where('supporter_journey_id', '!=', $recipient->supporter_journey_id)
+            ->where('status', SupporterJourneyRecipientStatus::Delivered)
+            ->where('updated_at', '>=', now()->subDays(config('engagement.frequency_cap_days')))
+            ->exists();
+    }
+}

--- a/app/Actions/Engagement/TransitionSupporterJourneyRecipient.php
+++ b/app/Actions/Engagement/TransitionSupporterJourneyRecipient.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Actions\Engagement;
+
+use App\Actions\Parties\RecordPartyConsent;
+use App\Actions\Parties\RecordPartyTimelineEvent;
+use App\Enums\ConsentChannel;
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use App\Enums\PartyTimelineEventType;
+use App\Enums\SupporterJourneyEventType;
+use App\Enums\SupporterJourneyRecipientStatus;
+use App\Models\SupporterJourneyEvent;
+use App\Models\SupporterJourneyRecipient;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use LogicException;
+
+class TransitionSupporterJourneyRecipient
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly RecordPartyTimelineEvent $recordTimelineEvent,
+        private readonly RecordPartyConsent $recordConsent,
+    ) {}
+
+    public function handle(SupporterJourneyRecipient $recipient, SupporterJourneyEventType $type, string $idempotencyKey, ?User $actor = null): SupporterJourneyRecipient
+    {
+        $this->context->ensureOwns($recipient->organisation_id);
+
+        if (! Str::isUuid($idempotencyKey)) {
+            throw new LogicException('A journey transition requires a UUID idempotency key.');
+        }
+
+        return DB::transaction(function () use ($actor, $idempotencyKey, $recipient, $type): SupporterJourneyRecipient {
+            $existing = SupporterJourneyEvent::query()->where('idempotency_key', $idempotencyKey)->first();
+
+            if ($existing !== null) {
+                if ($existing->supporter_journey_recipient_id !== $recipient->id || $existing->type !== $type) {
+                    throw new LogicException('The journey event idempotency key conflicts with another transition.');
+                }
+
+                return $recipient->fresh();
+            }
+
+            $locked = SupporterJourneyRecipient::query()->lockForUpdate()->findOrFail($recipient->id);
+            $from = $locked->status;
+            $to = $this->destination($from, $type);
+            $attemptCount = $locked->attempt_count + ($type === SupporterJourneyEventType::Retried ? 1 : 0);
+            $locked->update([
+                'status' => $to,
+                'attempt_count' => $attemptCount,
+                'last_attempted_at' => in_array($type, [SupporterJourneyEventType::Delivered, SupporterJourneyEventType::Bounced, SupporterJourneyEventType::Retried], true) ? now() : $locked->last_attempted_at,
+            ]);
+            SupporterJourneyEvent::query()->create([
+                'organisation_id' => $locked->organisation_id,
+                'supporter_journey_recipient_id' => $locked->id,
+                'idempotency_key' => $idempotencyKey,
+                'type' => $type,
+                'from_status' => $from->value,
+                'to_status' => $to,
+                'metadata' => ['simulation' => true],
+                'occurred_at' => now(),
+            ]);
+
+            if ($type === SupporterJourneyEventType::Unsubscribed) {
+                if ($actor === null) {
+                    throw new LogicException('An actor is required to record an unsubscribe.');
+                }
+
+                $this->recordConsent->handle($locked->party, [
+                    'purpose' => ConsentPurpose::SupporterUpdates,
+                    'channel' => ConsentChannel::from($locked->journey->audienceSegment->criteria['channel']),
+                    'decision' => ConsentDecision::Suppressed,
+                    'wording_version' => 'simulated-unsubscribe-v1',
+                    'wording' => 'Supporter requested no further simulated email updates.',
+                    'source' => 'local-welcome-journey',
+                    'occurred_at' => now()->toAtomString(),
+                ], $actor);
+            }
+
+            $this->recordTimelineEvent->handle(
+                $locked->party,
+                PartyTimelineEventType::SupporterJourneyTransitioned,
+                'Local supporter journey '.$type->value,
+                $actor,
+                'supporter_journey_recipient',
+                $locked->id,
+                ['journey_id' => $locked->supporter_journey_id, 'outcome' => $type->value, 'simulation' => true],
+            );
+
+            return $locked->fresh();
+        });
+    }
+
+    private function destination(SupporterJourneyRecipientStatus $from, SupporterJourneyEventType $type): SupporterJourneyRecipientStatus
+    {
+        $allowed = match ($from) {
+            SupporterJourneyRecipientStatus::Queued => [
+                SupporterJourneyEventType::Queued->value => SupporterJourneyRecipientStatus::Queued,
+                SupporterJourneyEventType::Delivered->value => SupporterJourneyRecipientStatus::Delivered,
+                SupporterJourneyEventType::Bounced->value => SupporterJourneyRecipientStatus::Bounced,
+                SupporterJourneyEventType::Cancelled->value => SupporterJourneyRecipientStatus::Cancelled,
+            ],
+            SupporterJourneyRecipientStatus::Bounced => [SupporterJourneyEventType::Retried->value => SupporterJourneyRecipientStatus::Queued],
+            SupporterJourneyRecipientStatus::Delivered => [
+                SupporterJourneyEventType::MeaningfulAction->value => SupporterJourneyRecipientStatus::Delivered,
+                SupporterJourneyEventType::Unsubscribed->value => SupporterJourneyRecipientStatus::Unsubscribed,
+            ],
+            default => [],
+        };
+
+        return $allowed[$type->value] ?? throw new LogicException("Cannot apply {$type->value} to a {$from->value} journey recipient.");
+    }
+}

--- a/app/Enums/PartyTimelineEventType.php
+++ b/app/Enums/PartyTimelineEventType.php
@@ -16,4 +16,5 @@ enum PartyTimelineEventType: string
     case DonationPaymentTransitioned = 'donation_payment_transitioned';
     case DonationRefunded = 'donation_refunded';
     case RecurringMandateTransitioned = 'recurring_mandate_transitioned';
+    case SupporterJourneyTransitioned = 'supporter_journey_transitioned';
 }

--- a/app/Enums/SupporterJourneyEventType.php
+++ b/app/Enums/SupporterJourneyEventType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums;
+
+enum SupporterJourneyEventType: string
+{
+    case Queued = 'queued';
+    case Delivered = 'delivered';
+    case Bounced = 'bounced';
+    case Retried = 'retried';
+    case Unsubscribed = 'unsubscribed';
+    case Cancelled = 'cancelled';
+    case MeaningfulAction = 'meaningful_action';
+}

--- a/app/Enums/SupporterJourneyRecipientStatus.php
+++ b/app/Enums/SupporterJourneyRecipientStatus.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enums;
+
+enum SupporterJourneyRecipientStatus: string
+{
+    case Queued = 'queued';
+    case Delivered = 'delivered';
+    case Bounced = 'bounced';
+    case Unsubscribed = 'unsubscribed';
+    case Cancelled = 'cancelled';
+}

--- a/app/Enums/SupporterJourneyStatus.php
+++ b/app/Enums/SupporterJourneyStatus.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum SupporterJourneyStatus: string
+{
+    case Draft = 'draft';
+    case Approved = 'approved';
+}

--- a/app/Http/Controllers/Organisations/SupporterJourneyController.php
+++ b/app/Http/Controllers/Organisations/SupporterJourneyController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Engagement\ApproveSupporterJourney;
+use App\Actions\Engagement\DispatchSupporterJourney;
+use App\Actions\Engagement\EvaluateAudienceSegment;
+use App\Actions\Engagement\TransitionSupporterJourneyRecipient;
+use App\Enums\SupporterJourneyEventType;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\StoreSupporterJourneyRequest;
+use App\Http\Requests\Organisations\TransitionSupporterJourneyRecipientRequest;
+use App\Models\AudienceSegment;
+use App\Models\Organisation;
+use App\Models\SupporterJourney;
+use App\Models\SupporterJourneyEvent;
+use App\Models\SupporterJourneyRecipient;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class SupporterJourneyController extends Controller
+{
+    public function index(Organisation $currentOrganisation): Response
+    {
+        Gate::authorize('viewAny', [SupporterJourney::class, $currentOrganisation]);
+
+        return Inertia::render('supporter-journeys/index', [
+            'journeys' => SupporterJourney::query()->withCount('recipients')->latest()->get()->map(fn (SupporterJourney $journey): array => [
+                'id' => $journey->id,
+                'name' => $journey->name,
+                'status' => $journey->status->value,
+                'recipientCount' => $journey->recipients_count,
+            ]),
+            'segments' => AudienceSegment::query()->orderBy('name')->get(['id', 'name']),
+        ]);
+    }
+
+    public function store(StoreSupporterJourneyRequest $request, Organisation $currentOrganisation): RedirectResponse
+    {
+        Gate::authorize('create', [SupporterJourney::class, $currentOrganisation]);
+        $journey = SupporterJourney::query()->create([
+            'organisation_id' => $currentOrganisation->id,
+            ...$request->validated(),
+            'created_by_user_id' => $request->user()->id,
+        ]);
+
+        return to_route('supporter-journeys.show', [$currentOrganisation, $journey]);
+    }
+
+    public function show(Organisation $currentOrganisation, string $supporterJourney, EvaluateAudienceSegment $evaluate): Response
+    {
+        $journey = SupporterJourney::query()->with(['audienceSegment', 'recipients.party', 'recipients.events'])->findOrFail($supporterJourney);
+        Gate::authorize('view', $journey);
+        $previewAudience = $journey->audience_snapshot ?? $evaluate->handle($journey->audienceSegment)
+            ->map(fn (array $supporter): array => [
+                'uuid' => $supporter['uuid'],
+                'displayName' => $supporter['displayName'],
+                'donationCount' => $supporter['donationCount'],
+            ])->values()->all();
+
+        return Inertia::render('supporter-journeys/show', [
+            'journey' => [
+                'id' => $journey->id,
+                'name' => $journey->name,
+                'subject' => $journey->subject,
+                'body' => $journey->body,
+                'status' => $journey->status->value,
+                'audienceName' => $journey->audienceSegment->name,
+                'audienceSnapshot' => $previewAudience,
+                'approvalHash' => $journey->approval_hash,
+                'recipients' => $journey->recipients->map(fn (SupporterJourneyRecipient $recipient): array => [
+                    'id' => $recipient->id,
+                    'displayName' => $recipient->party->display_name,
+                    'status' => $recipient->status->value,
+                    'attemptCount' => $recipient->attempt_count,
+                    'events' => $recipient->events->map(fn (SupporterJourneyEvent $event): array => ['id' => $event->id, 'type' => $event->type->value]),
+                    'actionKeys' => collect(SupporterJourneyEventType::cases())->mapWithKeys(fn (SupporterJourneyEventType $type): array => [$type->value => Str::uuid()->toString()]),
+                ]),
+            ],
+            'simulationOnly' => config('engagement.simulation_only') && app()->environment(['local', 'testing']),
+        ]);
+    }
+
+    public function approve(Organisation $currentOrganisation, string $supporterJourney, ApproveSupporterJourney $approve): RedirectResponse
+    {
+        $journey = SupporterJourney::query()->findOrFail($supporterJourney);
+        Gate::authorize('update', $journey);
+        $approve->handle($journey, request()->user());
+
+        return back();
+    }
+
+    public function dispatch(Organisation $currentOrganisation, string $supporterJourney, DispatchSupporterJourney $dispatch): RedirectResponse
+    {
+        $journey = SupporterJourney::query()->findOrFail($supporterJourney);
+        Gate::authorize('update', $journey);
+        $dispatch->handle($journey);
+
+        return back();
+    }
+
+    public function transition(TransitionSupporterJourneyRecipientRequest $request, Organisation $currentOrganisation, string $supporterJourney, string $recipient, TransitionSupporterJourneyRecipient $transition): RedirectResponse
+    {
+        $journey = SupporterJourney::query()->findOrFail($supporterJourney);
+        Gate::authorize('update', $journey);
+        $journeyRecipient = SupporterJourneyRecipient::query()->where('supporter_journey_id', $journey->id)->findOrFail($recipient);
+        $transition->handle($journeyRecipient, SupporterJourneyEventType::from($request->validated('type')), $request->validated('idempotency_key'), $request->user());
+
+        return back();
+    }
+}

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -8,6 +8,7 @@ use App\Models\IntakeRequest;
 use App\Models\Organisation;
 use App\Models\Party;
 use App\Models\Program;
+use App\Models\SupporterJourney;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
@@ -70,6 +71,8 @@ class HandleInertiaRequests extends Middleware
                 && Gate::allows('viewAny', [Donation::class, $routeOrganisation]),
             'canViewAudienceSegments' => fn (): bool => $routeOrganisation instanceof Organisation
                 && Gate::allows('viewAny', [AudienceSegment::class, $routeOrganisation]),
+            'canViewSupporterJourneys' => fn (): bool => $routeOrganisation instanceof Organisation
+                && Gate::allows('viewAny', [SupporterJourney::class, $routeOrganisation]),
         ];
     }
 }

--- a/app/Http/Requests/Organisations/StoreSupporterJourneyRequest.php
+++ b/app/Http/Requests/Organisations/StoreSupporterJourneyRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Models\Organisation;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+
+class StoreSupporterJourneyRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $organisation = $this->route('current_organisation');
+        $organisationId = $organisation instanceof Organisation ? $organisation->id : 0;
+
+        return [
+            'audience_segment_id' => ['required', 'uuid', Rule::exists('audience_segments', 'id')->where('organisation_id', $organisationId)],
+            'name' => ['required', 'string', 'max:120', Rule::unique('supporter_journeys', 'name')->where('organisation_id', $organisationId)],
+            'subject' => ['required', 'string', 'max:160'],
+            'body' => ['required', 'string', 'max:4000'],
+        ];
+    }
+
+    /** @return array<int, callable(Validator): void> */
+    public function after(): array
+    {
+        return [function (Validator $validator): void {
+            foreach (['subject', 'body'] as $field) {
+                $template = (string) $this->input($field);
+                $remainder = str_replace(['{{ supporter_name }}', '{{ donation_count }}'], '', $template);
+
+                if (str_contains($remainder, '{{') || str_contains($remainder, '}}')) {
+                    $validator->errors()->add($field, 'Only the supporter_name and donation_count placeholders are available.');
+                }
+            }
+        }];
+    }
+}

--- a/app/Http/Requests/Organisations/TransitionSupporterJourneyRecipientRequest.php
+++ b/app/Http/Requests/Organisations/TransitionSupporterJourneyRecipientRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Enums\SupporterJourneyEventType;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TransitionSupporterJourneyRecipientRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'type' => ['required', Rule::enum(SupporterJourneyEventType::class)],
+            'idempotency_key' => ['required', 'uuid'],
+        ];
+    }
+}

--- a/app/Models/SupporterJourney.php
+++ b/app/Models/SupporterJourney.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\SupporterJourneyStatus;
+use Database\Factories\SupporterJourneyFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $audience_segment_id
+ * @property string $name
+ * @property string $subject
+ * @property string $body
+ * @property SupporterJourneyStatus $status
+ * @property list<array{uuid: string, displayName: string, donationCount: int<0, max>}>|null $audience_snapshot
+ * @property string|null $approval_hash
+ * @property-read AudienceSegment $audienceSegment
+ * @property-read int $recipients_count
+ */
+#[Fillable(['organisation_id', 'audience_segment_id', 'name', 'subject', 'body', 'status', 'audience_snapshot', 'approval_hash', 'approved_at', 'approved_by_user_id', 'created_by_user_id'])]
+class SupporterJourney extends Model
+{
+    /** @use HasFactory<SupporterJourneyFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected static function booted(): void
+    {
+        static::updating(function (SupporterJourney $journey): void {
+            $originalStatus = $journey->getRawOriginal('status');
+
+            if ($originalStatus !== SupporterJourneyStatus::Draft->value
+                && $journey->isDirty(['audience_segment_id', 'subject', 'body', 'status', 'audience_snapshot', 'approval_hash'])) {
+                throw new LogicException('Approved journey content and audience are immutable.');
+            }
+
+            if ($originalStatus === SupporterJourneyStatus::Draft->value
+                && $journey->isDirty('status')
+                && ($journey->status !== SupporterJourneyStatus::Approved || $journey->audience_snapshot === null || $journey->approval_hash === null)) {
+                throw new LogicException('A journey can only leave draft through a complete approval.');
+            }
+        });
+    }
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return BelongsTo<AudienceSegment, $this> */
+    public function audienceSegment(): BelongsTo
+    {
+        return $this->belongsTo(AudienceSegment::class);
+    }
+
+    /** @return HasMany<SupporterJourneyRecipient, $this> */
+    public function recipients(): HasMany
+    {
+        return $this->hasMany(SupporterJourneyRecipient::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'status' => SupporterJourneyStatus::class,
+            'audience_snapshot' => 'array',
+            'approved_at' => 'immutable_datetime',
+        ];
+    }
+}

--- a/app/Models/SupporterJourneyEvent.php
+++ b/app/Models/SupporterJourneyEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\SupporterJourneyEventType;
+use Database\Factories\SupporterJourneyEventFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $supporter_journey_recipient_id
+ * @property string $idempotency_key
+ * @property SupporterJourneyEventType $type
+ */
+#[Fillable(['organisation_id', 'supporter_journey_recipient_id', 'idempotency_key', 'type', 'from_status', 'to_status', 'metadata', 'occurred_at'])]
+class SupporterJourneyEvent extends Model
+{
+    /** @use HasFactory<SupporterJourneyEventFactory> */
+    use BelongsToOrganisation, HasFactory, HasUlids;
+
+    public $timestamps = false;
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Journey events are append-only.'));
+        static::deleting(fn () => throw new LogicException('Journey events are append-only.'));
+    }
+
+    /** @return BelongsTo<SupporterJourneyRecipient, $this> */
+    public function recipient(): BelongsTo
+    {
+        return $this->belongsTo(SupporterJourneyRecipient::class, 'supporter_journey_recipient_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'type' => SupporterJourneyEventType::class,
+            'metadata' => 'array',
+            'occurred_at' => 'immutable_datetime',
+        ];
+    }
+}

--- a/app/Models/SupporterJourneyRecipient.php
+++ b/app/Models/SupporterJourneyRecipient.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\SupporterJourneyRecipientStatus;
+use Database\Factories\SupporterJourneyRecipientFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $supporter_journey_id
+ * @property int $party_id
+ * @property SupporterJourneyRecipientStatus $status
+ * @property int $attempt_count
+ * @property-read Party $party
+ */
+#[Fillable(['organisation_id', 'supporter_journey_id', 'party_id', 'status', 'attempt_count', 'last_attempted_at'])]
+class SupporterJourneyRecipient extends Model
+{
+    /** @use HasFactory<SupporterJourneyRecipientFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    /** @return BelongsTo<SupporterJourney, $this> */
+    public function journey(): BelongsTo
+    {
+        return $this->belongsTo(SupporterJourney::class, 'supporter_journey_id');
+    }
+
+    /** @return BelongsTo<Party, $this> */
+    public function party(): BelongsTo
+    {
+        return $this->belongsTo(Party::class);
+    }
+
+    /** @return HasMany<SupporterJourneyEvent, $this> */
+    public function events(): HasMany
+    {
+        return $this->hasMany(SupporterJourneyEvent::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'status' => SupporterJourneyRecipientStatus::class,
+            'last_attempted_at' => 'immutable_datetime',
+        ];
+    }
+}

--- a/app/Policies/SupporterJourneyPolicy.php
+++ b/app/Policies/SupporterJourneyPolicy.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\SupporterJourney;
+use App\Models\User;
+
+class SupporterJourneyPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user, Organisation $organisation): bool
+    {
+        return $user->hasOrganisationRole($organisation, OrganisationRole::EngagementOfficer);
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, SupporterJourney $supporterJourney): bool
+    {
+        return $this->viewAny($user, $supporterJourney->organisation);
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user, Organisation $organisation): bool
+    {
+        return $this->viewAny($user, $organisation);
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, SupporterJourney $supporterJourney): bool
+    {
+        return $this->view($user, $supporterJourney);
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, SupporterJourney $supporterJourney): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, SupporterJourney $supporterJourney): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, SupporterJourney $supporterJourney): bool
+    {
+        return false;
+    }
+}

--- a/config/engagement.php
+++ b/config/engagement.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'simulation_only' => env('ENGAGEMENT_SIMULATION_ONLY', true),
+    'frequency_cap_days' => (int) env('ENGAGEMENT_FREQUENCY_CAP_DAYS', 7),
+];

--- a/database/factories/SupporterJourneyEventFactory.php
+++ b/database/factories/SupporterJourneyEventFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\SupporterJourneyEventType;
+use App\Enums\SupporterJourneyRecipientStatus;
+use App\Models\SupporterJourneyEvent;
+use App\Models\SupporterJourneyRecipient;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<SupporterJourneyEvent>
+ */
+class SupporterJourneyEventFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'supporter_journey_recipient_id' => SupporterJourneyRecipient::factory(),
+            'idempotency_key' => Str::uuid()->toString(),
+            'type' => SupporterJourneyEventType::Queued,
+            'from_status' => SupporterJourneyRecipientStatus::Queued->value,
+            'to_status' => SupporterJourneyRecipientStatus::Queued->value,
+            'metadata' => ['simulation' => true],
+            'occurred_at' => now(),
+        ];
+    }
+}

--- a/database/factories/SupporterJourneyFactory.php
+++ b/database/factories/SupporterJourneyFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\SupporterJourneyStatus;
+use App\Models\AudienceSegment;
+use App\Models\SupporterJourney;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SupporterJourney>
+ */
+class SupporterJourneyFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'audience_segment_id' => AudienceSegment::factory(),
+            'name' => fake()->unique()->words(3, true),
+            'subject' => 'Thank you, {{ supporter_name }}',
+            'body' => 'Your {{ donation_count }} contribution(s) make a difference.',
+            'status' => SupporterJourneyStatus::Draft,
+        ];
+    }
+}

--- a/database/factories/SupporterJourneyRecipientFactory.php
+++ b/database/factories/SupporterJourneyRecipientFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\SupporterJourneyRecipientStatus;
+use App\Models\Party;
+use App\Models\SupporterJourney;
+use App\Models\SupporterJourneyRecipient;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SupporterJourneyRecipient>
+ */
+class SupporterJourneyRecipientFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'supporter_journey_id' => SupporterJourney::factory(),
+            'party_id' => Party::factory(),
+            'status' => SupporterJourneyRecipientStatus::Queued,
+        ];
+    }
+}

--- a/database/migrations/2026_08_31_134345_create_supporter_journeys_table.php
+++ b/database/migrations/2026_08_31_134345_create_supporter_journeys_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('supporter_journeys', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('audience_segment_id')->constrained()->restrictOnDelete();
+            $table->string('name', 120);
+            $table->string('subject', 160);
+            $table->text('body');
+            $table->string('status', 24)->default('draft');
+            $table->json('audience_snapshot')->nullable();
+            $table->string('approval_hash', 64)->nullable();
+            $table->timestampTz('approved_at')->nullable();
+            $table->foreignId('approved_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'name']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('supporter_journeys');
+    }
+};

--- a/database/migrations/2026_08_31_134346_create_supporter_journey_recipients_table.php
+++ b/database/migrations/2026_08_31_134346_create_supporter_journey_recipients_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('supporter_journey_recipients', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('supporter_journey_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('party_id')->constrained()->restrictOnDelete();
+            $table->string('status', 24)->default('queued');
+            $table->unsignedSmallInteger('attempt_count')->default(0);
+            $table->timestampTz('last_attempted_at')->nullable();
+            $table->timestamps();
+            $table->unique(['supporter_journey_id', 'party_id']);
+            $table->index(['organisation_id', 'party_id', 'status', 'updated_at'], 'journey_recipient_frequency_lookup');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('supporter_journey_recipients');
+    }
+};

--- a/database/migrations/2026_08_31_134347_create_supporter_journey_events_table.php
+++ b/database/migrations/2026_08_31_134347_create_supporter_journey_events_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('supporter_journey_events', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignUuid('supporter_journey_recipient_id')->constrained()->cascadeOnDelete();
+            $table->uuid('idempotency_key');
+            $table->string('type', 32);
+            $table->string('from_status', 24)->nullable();
+            $table->string('to_status', 24);
+            $table->json('metadata')->nullable();
+            $table->timestampTz('occurred_at');
+            $table->unique(['organisation_id', 'idempotency_key']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('supporter_journey_events');
+    }
+};

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -5,6 +5,7 @@ import {
     HandCoins,
     LayoutGrid,
     ListFilter,
+    MessagesSquare,
     Scale,
     Settings2,
     UsersRound,
@@ -29,6 +30,7 @@ import { index as donationsIndex } from '@/routes/donations';
 import { index as intakesIndex } from '@/routes/intakes';
 import { index as partiesIndex } from '@/routes/parties';
 import { index as programsIndex } from '@/routes/programs';
+import { index as supporterJourneysIndex } from '@/routes/supporter-journeys';
 import type { NavItem } from '@/types';
 
 export function AppSidebar() {
@@ -78,6 +80,18 @@ export function AppSidebar() {
                           page.props.currentOrganisation.slug,
                       ),
                       icon: ListFilter,
+                  },
+              ]
+            : []),
+        ...(page.props.canViewSupporterJourneys &&
+        page.props.currentOrganisation
+            ? [
+                  {
+                      title: 'Welcome journeys',
+                      href: supporterJourneysIndex(
+                          page.props.currentOrganisation.slug,
+                      ),
+                      icon: MessagesSquare,
                   },
               ]
             : []),

--- a/resources/js/pages/supporter-journeys/index.tsx
+++ b/resources/js/pages/supporter-journeys/index.tsx
@@ -1,0 +1,153 @@
+import { Form, Head, Link, usePage } from '@inertiajs/react';
+import Heading from '@/components/heading';
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { index, show, store } from '@/routes/supporter-journeys';
+
+type Props = {
+    journeys: Array<{
+        id: string;
+        name: string;
+        status: string;
+        recipientCount: number;
+    }>;
+    segments: Array<{ id: string; name: string }>;
+};
+
+export default function SupporterJourneysIndex({ journeys, segments }: Props) {
+    const organisation = usePage().props.currentOrganisation!;
+
+    return (
+        <>
+            <Head title="Welcome journeys" />
+            <div className="space-y-6 p-4">
+                <Heading
+                    title="Welcome journeys"
+                    description="Personalise and simulate supporter acknowledgements locally. No real message is sent."
+                />
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Create a local journey</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <Form
+                            {...store.form(organisation.slug)}
+                            className="grid gap-4"
+                        >
+                            {({ errors, processing }) => (
+                                <>
+                                    <Field
+                                        name="name"
+                                        label="Journey name"
+                                        error={errors.name}
+                                    />
+                                    <label className="grid gap-1">
+                                        <span>Saved audience</span>
+                                        <select
+                                            name="audience_segment_id"
+                                            required
+                                            className="h-9 rounded-md border bg-transparent px-3"
+                                        >
+                                            {segments.map((segment) => (
+                                                <option
+                                                    key={segment.id}
+                                                    value={segment.id}
+                                                >
+                                                    {segment.name}
+                                                </option>
+                                            ))}
+                                        </select>
+                                        <InputError
+                                            message={errors.audience_segment_id}
+                                        />
+                                    </label>
+                                    <Field
+                                        name="subject"
+                                        label="Subject"
+                                        error={errors.subject}
+                                    />
+                                    <label className="grid gap-1">
+                                        <span>Message</span>
+                                        <textarea
+                                            name="body"
+                                            required
+                                            rows={6}
+                                            defaultValue="Hi {{ supporter_name }}, thank you for supporting our work. Your {{ donation_count }} successful contribution(s) make a difference."
+                                            className="rounded-md border bg-transparent px-3 py-2"
+                                        />
+                                        <InputError message={errors.body} />
+                                    </label>
+                                    <p className="text-muted-foreground text-sm">
+                                        Safe placeholders:{' '}
+                                        {'{{ supporter_name }}'} and{' '}
+                                        {'{{ donation_count }}'}.
+                                    </p>
+                                    <Button
+                                        type="submit"
+                                        disabled={
+                                            processing || segments.length === 0
+                                        }
+                                    >
+                                        Create and preview
+                                    </Button>
+                                </>
+                            )}
+                        </Form>
+                    </CardContent>
+                </Card>
+                <section className="space-y-3" aria-labelledby="journey-list">
+                    <h2 id="journey-list" className="text-xl font-semibold">
+                        Journeys
+                    </h2>
+                    {journeys.map((journey) => (
+                        <Link
+                            key={journey.id}
+                            href={show([organisation.slug, journey.id])}
+                            className="hover:bg-muted/50 block rounded-lg border p-4"
+                        >
+                            <strong>{journey.name}</strong>
+                            <p className="text-muted-foreground text-sm">
+                                {journey.status} · {journey.recipientCount}{' '}
+                                recipients
+                            </p>
+                        </Link>
+                    ))}
+                </section>
+            </div>
+        </>
+    );
+}
+
+function Field({
+    name,
+    label,
+    error,
+}: {
+    name: string;
+    label: string;
+    error?: string;
+}) {
+    return (
+        <label className="grid gap-1">
+            <span>{label}</span>
+            <input
+                name={name}
+                required
+                className="h-9 rounded-md border bg-transparent px-3"
+            />
+            <InputError message={error} />
+        </label>
+    );
+}
+
+SupporterJourneysIndex.layout = (props: {
+    currentOrganisation: { slug: string };
+}) => ({
+    breadcrumbs: [
+        {
+            title: 'Welcome journeys',
+            href: index(props.currentOrganisation.slug),
+        },
+    ],
+});

--- a/resources/js/pages/supporter-journeys/show.tsx
+++ b/resources/js/pages/supporter-journeys/show.tsx
@@ -1,0 +1,201 @@
+import { Form, Head, usePage } from '@inertiajs/react';
+import Heading from '@/components/heading';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { approve, dispatch, index, show } from '@/routes/supporter-journeys';
+import { store as transition } from '@/routes/supporter-journeys/recipients/transitions';
+
+type Recipient = {
+    id: string;
+    displayName: string;
+    status: string;
+    attemptCount: number;
+    events: Array<{ id: string; type: string }>;
+    actionKeys: Record<string, string>;
+};
+type Journey = {
+    id: string;
+    name: string;
+    subject: string;
+    body: string;
+    status: string;
+    audienceName: string;
+    audienceSnapshot: Array<{
+        uuid: string;
+        displayName: string;
+        donationCount: number;
+    }>;
+    approvalHash: string | null;
+    recipients: Recipient[];
+};
+
+export default function SupporterJourneyShow({
+    journey,
+    simulationOnly,
+}: {
+    journey: Journey;
+    simulationOnly: boolean;
+}) {
+    const organisation = usePage().props.currentOrganisation!;
+    const routeArgs: [string, string] = [organisation.slug, journey.id];
+
+    return (
+        <>
+            <Head title={journey.name} />
+            <div className="space-y-6 p-4">
+                <Heading
+                    title={journey.name}
+                    description={`Audience: ${journey.audienceName}`}
+                />
+                <div className="rounded-lg border border-amber-300 bg-amber-50 p-4 text-amber-950 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-100">
+                    <strong>Local simulation only.</strong> No email, SMS, or
+                    external provider is contacted.
+                    {!simulationOnly ? ' Simulation is disabled.' : ''}
+                </div>
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Preview and approval</CardTitle>
+                    </CardHeader>
+                    <CardContent className="space-y-4">
+                        <Badge>{journey.status}</Badge>
+                        <div className="rounded-md border p-4">
+                            <strong>
+                                {render(
+                                    journey.subject,
+                                    journey.audienceSnapshot[0],
+                                )}
+                            </strong>
+                            <p className="mt-3 whitespace-pre-wrap">
+                                {render(
+                                    journey.body,
+                                    journey.audienceSnapshot[0],
+                                )}
+                            </p>
+                        </div>
+                        <p className="text-muted-foreground text-sm">
+                            {journey.status === 'draft'
+                                ? 'Approval freezes this content and the currently eligible audience.'
+                                : `${journey.audienceSnapshot.length} supporters frozen · ${journey.approvalHash}`}
+                        </p>
+                        {journey.status === 'draft' ? (
+                            <Form {...approve.form(routeArgs)}>
+                                {({ processing }) => (
+                                    <Button disabled={processing}>
+                                        Approve and freeze
+                                    </Button>
+                                )}
+                            </Form>
+                        ) : (
+                            <Form {...dispatch.form(routeArgs)}>
+                                {({ processing }) => (
+                                    <Button disabled={processing}>
+                                        Recheck eligibility and simulate
+                                        dispatch
+                                    </Button>
+                                )}
+                            </Form>
+                        )}
+                    </CardContent>
+                </Card>
+                <section
+                    className="space-y-3"
+                    aria-labelledby="recipient-results"
+                >
+                    <h2
+                        id="recipient-results"
+                        className="text-xl font-semibold"
+                    >
+                        Recipient outcomes
+                    </h2>
+                    {journey.recipients.map((recipient) => (
+                        <Card key={recipient.id}>
+                            <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-6">
+                                <div>
+                                    <strong>{recipient.displayName}</strong>
+                                    <p className="text-muted-foreground text-sm">
+                                        {recipient.status} ·{' '}
+                                        {recipient.attemptCount} retries
+                                    </p>
+                                </div>
+                                <div className="flex flex-wrap gap-2">
+                                    {actionsFor(recipient.status).map(
+                                        (type) => (
+                                            <Form
+                                                key={type}
+                                                {...transition.form([
+                                                    organisation.slug,
+                                                    journey.id,
+                                                    recipient.id,
+                                                ])}
+                                            >
+                                                <input
+                                                    type="hidden"
+                                                    name="type"
+                                                    value={type}
+                                                />
+                                                <input
+                                                    type="hidden"
+                                                    name="idempotency_key"
+                                                    value={
+                                                        recipient.actionKeys[
+                                                            type
+                                                        ]
+                                                    }
+                                                />
+                                                <Button
+                                                    variant="outline"
+                                                    size="sm"
+                                                >
+                                                    {type.replace('_', ' ')}
+                                                </Button>
+                                            </Form>
+                                        ),
+                                    )}
+                                </div>
+                            </CardContent>
+                        </Card>
+                    ))}
+                </section>
+            </div>
+        </>
+    );
+}
+
+function render(
+    template: string,
+    supporter?: { displayName: string; donationCount: number },
+) {
+    return template
+        .replaceAll(
+            '{{ supporter_name }}',
+            supporter?.displayName ?? 'Supporter',
+        )
+        .replaceAll(
+            '{{ donation_count }}',
+            String(supporter?.donationCount ?? 0),
+        );
+}
+
+function actionsFor(status: string): string[] {
+    if (status === 'queued') return ['delivered', 'bounced', 'cancelled'];
+    if (status === 'bounced') return ['retried'];
+    if (status === 'delivered') return ['meaningful_action', 'unsubscribed'];
+    return [];
+}
+
+SupporterJourneyShow.layout = (props: {
+    currentOrganisation: { slug: string };
+    journey: Journey;
+}) => ({
+    breadcrumbs: [
+        {
+            title: 'Welcome journeys',
+            href: index(props.currentOrganisation.slug),
+        },
+        {
+            title: props.journey.name,
+            href: show([props.currentOrganisation.slug, props.journey.id]),
+        },
+    ],
+});

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -19,6 +19,7 @@ declare module '@inertiajs/core' {
             canViewIntakes: boolean;
             canViewDonations: boolean;
             canViewAudienceSegments: boolean;
+            canViewSupporterJourneys: boolean;
             currentOrganisation: Organisation | null;
             organisations: Organisation[];
             [key: string]: unknown;

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,7 @@ use App\Http\Controllers\Organisations\PartySafeContactInstructionController;
 use App\Http\Controllers\Organisations\ProgramController;
 use App\Http\Controllers\Organisations\ServiceCaseController;
 use App\Http\Controllers\Organisations\ServiceOperationsExportController;
+use App\Http\Controllers\Organisations\SupporterJourneyController;
 use App\Http\Controllers\Public\DonationController as PublicDonationController;
 use App\Http\Controllers\Public\OrganisationController as PublicOrganisationController;
 use App\Http\Middleware\EnsureOrganisationAccess;
@@ -94,6 +95,10 @@ Route::prefix('{current_organisation}')
         Route::get('programs', [ProgramController::class, 'index'])->name('programs.index');
         Route::resource('donations', DonationController::class)->only(['index', 'show']);
         Route::resource('audience-segments', AudienceSegmentController::class)->only(['index', 'store', 'show']);
+        Route::resource('supporter-journeys', SupporterJourneyController::class)->only(['index', 'store', 'show']);
+        Route::post('supporter-journeys/{supporter_journey}/approve', [SupporterJourneyController::class, 'approve'])->name('supporter-journeys.approve');
+        Route::post('supporter-journeys/{supporter_journey}/dispatch', [SupporterJourneyController::class, 'dispatch'])->name('supporter-journeys.dispatch');
+        Route::post('supporter-journeys/{supporter_journey}/recipients/{recipient}/transitions', [SupporterJourneyController::class, 'transition'])->name('supporter-journeys.recipients.transitions.store');
         Route::resource('parties', PartyController::class)->only(['index', 'store', 'show', 'update']);
         Route::resource('intakes', IntakeRequestController::class)
             ->parameters(['intakes' => 'intake'])

--- a/tests/Feature/SupporterJourneyTest.php
+++ b/tests/Feature/SupporterJourneyTest.php
@@ -1,0 +1,207 @@
+<?php
+
+use App\Actions\Engagement\ApproveSupporterJourney;
+use App\Actions\Engagement\DispatchSupporterJourney;
+use App\Actions\Engagement\TransitionSupporterJourneyRecipient;
+use App\Actions\Parties\RecordPartyConsent;
+use App\Actions\Parties\StorePartyContact;
+use App\Enums\ConsentChannel;
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use App\Enums\OrganisationRole;
+use App\Enums\PartyBusinessRole;
+use App\Enums\PartyContactType;
+use App\Enums\SupporterJourneyEventType;
+use App\Enums\SupporterJourneyRecipientStatus;
+use App\Enums\SupporterJourneyStatus;
+use App\Models\AudienceSegment;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\SupporterJourney;
+use App\Models\SupporterJourneyEvent;
+use App\Models\SupporterJourneyRecipient;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Str;
+use Inertia\Testing\AssertableInertia as Assert;
+
+beforeEach(function () {
+    $key = 'base64:'.base64_encode(str_repeat('j', 32));
+    config([
+        'classified_data.encryption.current_version' => 'journey-data-v1',
+        'classified_data.encryption.keys' => ['journey-data-v1' => $key],
+        'classified_data.contact_index.current_version' => 'journey-index-v1',
+        'classified_data.contact_index.previous_version' => null,
+        'classified_data.contact_index.keys' => ['journey-index-v1' => $key],
+        'engagement.simulation_only' => true,
+    ]);
+});
+
+it('freezes approval and rechecks safety before a local simulated dispatch', function () {
+    [$organisation, $officer] = journeyOrganisation();
+
+    [$journey, $eligible, $withdrawn] = app(OrganisationContext::class)->run($organisation, function () use ($officer, $organisation): array {
+        $eligible = journeySupporter($organisation, $officer, 'Eligible Rowan');
+        $withdrawn = journeySupporter($organisation, $officer, 'Withdrawn Avery');
+        $segment = journeySegment('Consented donors');
+        $journey = SupporterJourney::factory()->create([
+            'audience_segment_id' => $segment->id,
+            'name' => 'Donation thank-you and welcome',
+        ]);
+        app(ApproveSupporterJourney::class)->handle($journey, $officer);
+        app(RecordPartyConsent::class)->handle($withdrawn, [
+            'purpose' => ConsentPurpose::SupporterUpdates,
+            'channel' => ConsentChannel::Email,
+            'decision' => ConsentDecision::Withdrawn,
+            'wording_version' => 'v1',
+            'wording' => 'Stop simulated supporter updates.',
+            'source' => 'preference-centre',
+            'occurred_at' => now()->addSecond()->toAtomString(),
+        ], $officer);
+        app(DispatchSupporterJourney::class)->handle($journey->fresh());
+
+        return [$journey->fresh(), $eligible, $withdrawn];
+    });
+
+    expect($journey->status)->toBe(SupporterJourneyStatus::Approved)
+        ->and($journey->audience_snapshot)->toHaveCount(2)
+        ->and($journey->approval_hash)->toHaveLength(64);
+    app(OrganisationContext::class)->run($organisation, function () use ($eligible, $journey, $withdrawn): void {
+        expect(SupporterJourneyRecipient::query()->whereBelongsTo($journey, 'journey')->whereBelongsTo($eligible)->sole()->status)->toBe(SupporterJourneyRecipientStatus::Queued)
+            ->and(SupporterJourneyRecipient::query()->whereBelongsTo($journey, 'journey')->whereBelongsTo($withdrawn)->sole()->status)->toBe(SupporterJourneyRecipientStatus::Cancelled);
+        expect(fn () => $journey->update(['body' => 'Changed after approval']))->toThrow(LogicException::class);
+    });
+});
+
+it('runs deterministic idempotent outcomes and suppresses future supporter email on unsubscribe', function () {
+    [$organisation, $officer] = journeyOrganisation();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($officer, $organisation): void {
+        $party = journeySupporter($organisation, $officer, 'Journey Morgan');
+        app(StorePartyContact::class)->handle($party, PartyContactType::Telephone, '+27820000000');
+        app(RecordPartyConsent::class)->handle($party, [
+            'purpose' => ConsentPurpose::SupporterUpdates,
+            'channel' => ConsentChannel::Sms,
+            'decision' => ConsentDecision::Granted,
+            'wording_version' => 'sms-v1',
+            'wording' => 'I agree to simulated supporter SMS updates.',
+            'source' => 'local-fixture',
+            'occurred_at' => now()->subMinute()->toAtomString(),
+        ], $officer);
+        $journey = SupporterJourney::factory()->create(['audience_segment_id' => journeySegment(channel: ConsentChannel::Sms)->id]);
+        app(ApproveSupporterJourney::class)->handle($journey, $officer);
+        $recipient = app(DispatchSupporterJourney::class)->handle($journey->fresh())->sole();
+        $transition = app(TransitionSupporterJourneyRecipient::class);
+        $deliveredKey = Str::uuid()->toString();
+        $transition->handle($recipient, SupporterJourneyEventType::Delivered, $deliveredKey, $officer);
+        $transition->handle($recipient->fresh(), SupporterJourneyEventType::Delivered, $deliveredKey, $officer);
+        $transition->handle($recipient->fresh(), SupporterJourneyEventType::MeaningfulAction, Str::uuid()->toString(), $officer);
+        $unsubscribeKey = Str::uuid()->toString();
+        $transition->handle($recipient->fresh(), SupporterJourneyEventType::Unsubscribed, $unsubscribeKey, $officer);
+        $transition->handle($recipient->fresh(), SupporterJourneyEventType::Unsubscribed, $unsubscribeKey, $officer);
+
+        expect($recipient->fresh()->status)->toBe(SupporterJourneyRecipientStatus::Unsubscribed)
+            ->and(SupporterJourneyEvent::query()->where('idempotency_key', $deliveredKey)->count())->toBe(1)
+            ->and(SupporterJourneyEvent::query()->where('idempotency_key', $unsubscribeKey)->count())->toBe(1)
+            ->and($party->consents()->where('channel', ConsentChannel::Sms)->latest('occurred_at')->firstOrFail()->decision)->toBe(ConsentDecision::Suppressed)
+            ->and($party->consents()->where('channel', ConsentChannel::Email)->latest('occurred_at')->firstOrFail()->decision)->toBe(ConsentDecision::Granted)
+            ->and($party->timelineEvents()->where('summary', 'like', 'Local supporter journey%')->count())->toBe(4);
+    });
+});
+
+it('supports bounce and retry while enforcing the frequency cap', function () {
+    [$organisation, $officer] = journeyOrganisation();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($officer, $organisation): void {
+        $party = journeySupporter($organisation, $officer, 'Retry Taylor');
+        $segment = journeySegment();
+        $first = SupporterJourney::factory()->create(['audience_segment_id' => $segment->id, 'name' => 'First welcome']);
+        app(ApproveSupporterJourney::class)->handle($first, $officer);
+        $recipient = app(DispatchSupporterJourney::class)->handle($first->fresh())->sole();
+        app(TransitionSupporterJourneyRecipient::class)->handle($recipient, SupporterJourneyEventType::Bounced, Str::uuid()->toString(), $officer);
+        app(TransitionSupporterJourneyRecipient::class)->handle($recipient->fresh(), SupporterJourneyEventType::Retried, Str::uuid()->toString(), $officer);
+        app(TransitionSupporterJourneyRecipient::class)->handle($recipient->fresh(), SupporterJourneyEventType::Delivered, Str::uuid()->toString(), $officer);
+
+        $second = SupporterJourney::factory()->create(['audience_segment_id' => $segment->id, 'name' => 'Second welcome']);
+        app(ApproveSupporterJourney::class)->handle($second, $officer);
+        $capped = app(DispatchSupporterJourney::class)->handle($second->fresh())->sole();
+
+        expect($recipient->fresh()->attempt_count)->toBe(1)
+            ->and($capped->status)->toBe(SupporterJourneyRecipientStatus::Cancelled)
+            ->and($party->timelineEvents()->get()->flatMap->metadata->join(' '))->not->toContain('email');
+    });
+});
+
+it('refuses dispatch outside local or testing and restricts the interface to engagement officers', function () {
+    [$organisation, $officer] = journeyOrganisation();
+    $caseWorker = User::factory()->create();
+    $organisation->memberships()->create(['user_id' => $caseWorker->id, 'role' => OrganisationRole::CaseWorker]);
+    $journey = app(OrganisationContext::class)->run($organisation, function () use ($officer, $organisation): SupporterJourney {
+        journeySupporter($organisation, $officer, 'Safe Casey');
+        $journey = SupporterJourney::factory()->create(['audience_segment_id' => journeySegment()->id]);
+        app(ApproveSupporterJourney::class)->handle($journey, $officer);
+
+        return $journey->fresh();
+    });
+
+    $this->actingAs($officer)->get(route('supporter-journeys.show', [$organisation, $journey]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('supporter-journeys/show')
+            ->where('simulationOnly', true)
+            ->missing('journey.audienceSnapshot.0.email')
+            ->missing('journey.audienceSnapshot.0.serviceCases'));
+    $this->actingAs($caseWorker)->get(route('supporter-journeys.index', $organisation))->assertForbidden();
+    $this->actingAs($officer)->post(route('supporter-journeys.store', $organisation), [
+        'audience_segment_id' => $journey->audience_segment_id,
+        'name' => 'Unsafe template',
+        'subject' => 'Supporter update',
+        'body' => 'Case details: {{ service_case }}',
+    ])->assertSessionHasErrors('body');
+
+    app()->detectEnvironment(fn (): string => 'production');
+    expect(fn () => app(OrganisationContext::class)->run($organisation, fn () => app(DispatchSupporterJourney::class)->handle($journey)))
+        ->toThrow(LogicException::class, 'restricted to local simulation');
+});
+
+/** @return array{Organisation, User} */
+function journeyOrganisation(): array
+{
+    $organisation = Organisation::factory()->active()->create();
+    $officer = User::factory()->create();
+    $organisation->memberships()->create(['user_id' => $officer->id, 'role' => OrganisationRole::EngagementOfficer]);
+
+    return [$organisation, $officer];
+}
+
+function journeySupporter(Organisation $organisation, User $officer, string $name): Party
+{
+    $party = Party::factory()->for($organisation)->create(['display_name' => $name]);
+    $party->businessRoles()->create(['organisation_id' => $organisation->id, 'role' => PartyBusinessRole::Donor]);
+    app(StorePartyContact::class)->handle($party, PartyContactType::Email, Str::slug($name).'@example.test');
+    app(RecordPartyConsent::class)->handle($party, [
+        'purpose' => ConsentPurpose::SupporterUpdates,
+        'channel' => ConsentChannel::Email,
+        'decision' => ConsentDecision::Granted,
+        'wording_version' => 'v1',
+        'wording' => 'I agree to simulated supporter updates.',
+        'source' => 'local-fixture',
+        'occurred_at' => now()->subMinute()->toAtomString(),
+    ], $officer);
+
+    return $party;
+}
+
+function journeySegment(?string $name = null, ConsentChannel $channel = ConsentChannel::Email): AudienceSegment
+{
+    $factory = AudienceSegment::factory();
+
+    return $factory->create([
+        ...($name === null ? [] : ['name' => $name]),
+        'criteria' => [
+            ...$factory->raw()['criteria'],
+            'channel' => $channel->value,
+            'donation_activity' => false,
+        ],
+    ]);
+}


### PR DESCRIPTION
## Summary

- add engagement-only journey creation, safe preview, immutable approval, and audience snapshots
- recheck consent, suppression, safe-contact rules, and frequency caps before local simulation
- record deterministic idempotent outcomes, channel-aware unsubscribe suppression, and safe timeline events
- hard-block every dispatch path outside local/testing simulation

## Verification

- `DB_CONNECTION=pgsql composer ci:check` (306 tests, 1690 assertions)
- `npm test -- --run`
- `npm run licenses:check`
- `npm run build`
- signed commit with DCO sign-off
- reviewed against `origin/main`; review findings fixed

Closes #18