### PR TITLE
Reconcile role-specific dashboards through a metric registry

### DIFF
--- a/app/Actions/CaseDelivery/RecordCaseMetric.php
+++ b/app/Actions/CaseDelivery/RecordCaseMetric.php
@@ -19,7 +19,7 @@ class RecordCaseMetric
                 'program_id' => $case->program_id,
                 'code' => $code,
                 'value' => $value,
-                'dimensions' => $dimensions,
+                'dimensions' => [...$dimensions, 'party_id' => $case->party_id],
                 'occurred_at' => $occurredAt,
                 'recorded_at' => now(),
             ],

--- a/app/Actions/Demo/BuildDonorToRetainedSupporterScenario.php
+++ b/app/Actions/Demo/BuildDonorToRetainedSupporterScenario.php
@@ -3,6 +3,9 @@
 namespace App\Actions\Demo;
 
 use App\Actions\Donations\CreateDonation;
+use App\Actions\Engagement\ApproveSupporterJourney;
+use App\Actions\Engagement\DispatchSupporterJourney;
+use App\Actions\Engagement\TransitionSupporterJourneyRecipient;
 use App\Actions\Parties\RecordPartyConsent;
 use App\Donations\DonationPaymentProvider;
 use App\Enums\ConsentChannel;
@@ -10,12 +13,15 @@ use App\Enums\ConsentDecision;
 use App\Enums\ConsentPurpose;
 use App\Enums\DonationFrequency;
 use App\Enums\DonationSimulationScenario;
+use App\Enums\SupporterJourneyEventType;
+use App\Enums\SupporterJourneyStatus;
 use App\Models\AudienceSegment;
 use App\Models\Donation;
 use App\Models\DonationFund;
 use App\Models\FundraisingCampaign;
 use App\Models\Party;
 use App\Models\PartyConsent;
+use App\Models\SupporterJourney;
 use App\Models\User;
 
 class BuildDonorToRetainedSupporterScenario
@@ -24,6 +30,9 @@ class BuildDonorToRetainedSupporterScenario
         private readonly CreateDonation $createDonation,
         private readonly DonationPaymentProvider $paymentProvider,
         private readonly RecordPartyConsent $recordPartyConsent,
+        private readonly ApproveSupporterJourney $approveJourney,
+        private readonly DispatchSupporterJourney $dispatchJourney,
+        private readonly TransitionSupporterJourneyRecipient $transitionRecipient,
     ) {}
 
     public function handle(Party $donor, User $actor): Donation
@@ -65,7 +74,7 @@ class BuildDonorToRetainedSupporterScenario
                 'occurred_at' => now()->toAtomString(),
             ], $actor);
         }
-        AudienceSegment::query()->updateOrCreate(
+        $segment = AudienceSegment::query()->updateOrCreate(
             ['organisation_id' => $donor->organisation_id, 'name' => 'Winter Warmth retained supporters'],
             [
                 'criteria' => [
@@ -80,6 +89,30 @@ class BuildDonorToRetainedSupporterScenario
                 'created_by_user_id' => $actor->id,
             ],
         );
+
+        if (! app()->environment(['local', 'testing']) || ! config('engagement.simulation_only')) {
+            return $donation->refresh();
+        }
+
+        $journey = SupporterJourney::query()->firstOrCreate(
+            ['organisation_id' => $donor->organisation_id, 'name' => 'Winter Warmth donor welcome'],
+            [
+                'id' => '40000000-0000-4000-8000-000000000001',
+                'audience_segment_id' => $segment->id,
+                'subject' => 'Thank you, {{ supporter_name }}',
+                'body' => 'Your {{ donation_count }} simulated contribution makes a difference.',
+                'status' => SupporterJourneyStatus::Draft,
+                'created_by_user_id' => $actor->id,
+            ],
+        );
+        if ($journey->status === SupporterJourneyStatus::Draft) {
+            $journey = $this->approveJourney->handle($journey, $actor);
+        }
+        $recipient = $this->dispatchJourney->handle($journey)->firstWhere('party_id', $donor->id);
+        if ($recipient !== null) {
+            $this->transitionRecipient->handle($recipient, SupporterJourneyEventType::Delivered, '40000000-0000-4000-8000-000000000002', $actor);
+            $this->transitionRecipient->handle($recipient->fresh(), SupporterJourneyEventType::MeaningfulAction, '40000000-0000-4000-8000-000000000003', $actor);
+        }
 
         return $donation->refresh();
     }

--- a/app/Actions/Reporting/BuildImpactDashboard.php
+++ b/app/Actions/Reporting/BuildImpactDashboard.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace App\Actions\Reporting;
+
+use App\Data\Demo\ScenarioCatalog;
+use App\Enums\CaseMetricCode;
+use App\Enums\DonationPaymentStatus;
+use App\Enums\OrganisationRole;
+use App\Enums\PartyBusinessRole;
+use App\Enums\SupporterJourneyEventType;
+use App\Models\CaseInteraction;
+use App\Models\Donation;
+use App\Models\DonationPaymentEvent;
+use App\Models\DonationRefund;
+use App\Models\FundraisingCampaign;
+use App\Models\IntakeRequest;
+use App\Models\MetricEvent;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\PartyAddress;
+use App\Models\Program;
+use App\Models\SupporterJourneyEvent;
+use App\Models\User;
+use App\Reporting\MetricRegistry;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+class BuildImpactDashboard
+{
+    public function __construct(private readonly MetricRegistry $registry) {}
+
+    /** @param array<string, mixed> $filters
+     * @return array<string, mixed>
+     */
+    public function handle(User $user, Organisation $organisation, array $filters): array
+    {
+        $role = $user->organisationRole($organisation);
+        if ($role === OrganisationRole::ProgramManager) {
+            $allowedProgramIds = Program::query()->get()->filter(fn (Program $program): bool => $user->hasProgramAccess($program))->pluck('id');
+            $filters['_program_ids'] = filled($filters['program_id'] ?? null)
+                ? $allowedProgramIds->intersect([(int) $filters['program_id']])->values()->all()
+                : $allowedProgramIds->values()->all();
+        }
+        $context = $this->reportingContext($organisation);
+        [$start, $end] = $this->period($filters, $context['timezone']);
+        $duration = $start->diffInSeconds($end);
+        $priorEnd = $start;
+        $priorStart = $start->subSeconds($duration);
+        $definitions = $this->registry->forRole($role);
+        $sensitiveSlice = filled($filters['area'] ?? null) || filled($filters['location'] ?? null) || filled($filters['cohort'] ?? null);
+
+        $metrics = collect($definitions)->map(function (array $definition) use ($end, $filters, $priorEnd, $priorStart, $sensitiveSlice, $start): array {
+            $unsupported = array_diff($this->activeDimensions($filters), $definition['dimensions']);
+            $current = $unsupported === [] ? $this->calculate($definition['id'], $start, $end, $filters) : ['value' => null, 'sampleSize' => 0];
+            $prior = $unsupported === [] ? $this->calculate($definition['id'], $priorStart, $priorEnd, $filters) : ['value' => null, 'sampleSize' => 0];
+            $suppressed = $sensitiveSlice && $current['sampleSize'] > 0 && $current['sampleSize'] < config('reporting.minimum_cohort');
+            $availability = $suppressed ? 'suppressed' : ($current['value'] === null ? 'unavailable' : 'available');
+
+            return [
+                'definition' => $definition,
+                'value' => $availability === 'available' ? $current['value'] : null,
+                'availability' => $availability,
+                'sampleSize' => $availability === 'suppressed' ? null : $current['sampleSize'],
+                'comparison' => $availability === 'available' && $prior['value'] !== null ? [
+                    'priorValue' => $prior['value'],
+                    'change' => round($current['value'] - $prior['value'], 2),
+                ] : null,
+            ];
+        })->values()->all();
+
+        return [
+            'registryVersion' => MetricRegistry::VERSION,
+            'fictional' => true,
+            'freshAt' => now()->toAtomString(),
+            'timezone' => $context['timezone'],
+            'currency' => $context['currency'],
+            'period' => [
+                'start' => $start->setTimezone($context['timezone'])->toAtomString(),
+                'endExclusive' => $end->setTimezone($context['timezone'])->toAtomString(),
+            ],
+            'filters' => collect($filters)->except('_program_ids')->all(),
+            'minimumCohort' => config('reporting.minimum_cohort'),
+            'metrics' => $metrics,
+            'options' => $this->options($user, $organisation, $role),
+        ];
+    }
+
+    /** @param array<string, mixed> $filters
+     * @return array{0: CarbonImmutable, 1: CarbonImmutable}
+     */
+    private function period(array $filters, string $timezone): array
+    {
+        if (filled($filters['period_start'] ?? null) && filled($filters['period_end'] ?? null)) {
+            return [
+                CarbonImmutable::parse($filters['period_start'], $timezone)->startOfDay()->utc(),
+                CarbonImmutable::parse($filters['period_end'], $timezone)->startOfDay()->utc(),
+            ];
+        }
+
+        $now = CarbonImmutable::instance(now())->setTimezone($timezone);
+
+        return [$now->startOfMonth()->utc(), $now->addDay()->startOfDay()->utc()];
+    }
+
+    /** @param array<string, mixed> $filters
+     * @return array{value: float|null, sampleSize: int}
+     */
+    private function calculate(string $metric, CarbonImmutable $start, CarbonImmutable $end, array $filters): array
+    {
+        return match ($metric) {
+            'service.requests_received' => $this->requestsReceived($start, $end, $filters),
+            'service.case_interactions' => $this->caseInteractions($start, $end, $filters),
+            'service.services_delivered' => $this->caseMetric(CaseMetricCode::ServiceDelivered, $start, $end, $filters),
+            'service.goal_achievement_rate' => $this->goalRate($start, $end, $filters),
+            'fundraising.successful_donations' => $this->successfulDonations($start, $end, $filters, false),
+            'fundraising.net_raised' => $this->successfulDonations($start, $end, $filters, true),
+            'engagement.welcome_deliveries' => $this->journeyMetric(SupporterJourneyEventType::Delivered, $start, $end, $filters, false),
+            'engagement.meaningful_action_rate' => $this->journeyMetric(SupporterJourneyEventType::MeaningfulAction, $start, $end, $filters, true),
+            default => ['value' => null, 'sampleSize' => 0],
+        };
+    }
+
+    /** @param array<string, mixed> $filters
+     * @return array{value: float, sampleSize: int}
+     */
+    private function requestsReceived(CarbonImmutable $start, CarbonImmutable $end, array $filters): array
+    {
+        $records = IntakeRequest::query()->with(['party.addresses', 'party.businessRoles'])
+            ->where('created_at', '>=', $start)->where('created_at', '<', $end)
+            ->when(array_key_exists('_program_ids', $filters), fn (Builder $query) => $query->whereIn('program_id', $filters['_program_ids']))
+            ->when(filled($filters['program_id'] ?? null), fn (Builder $query) => $query->where('program_id', $filters['program_id']))
+            ->get()->filter(fn (IntakeRequest $intake): bool => $this->matchesParty($intake->party, $filters));
+
+        return ['value' => (float) $records->count(), 'sampleSize' => $records->pluck('party_id')->unique()->count()];
+    }
+
+    /** @param array<string, mixed> $filters
+     * @return array{value: float, sampleSize: int}
+     */
+    private function caseInteractions(CarbonImmutable $start, CarbonImmutable $end, array $filters): array
+    {
+        $records = CaseInteraction::query()->with(['serviceCase.party.addresses', 'serviceCase.party.businessRoles'])
+            ->where('occurred_at', '>=', $start)->where('occurred_at', '<', $end)
+            ->when(array_key_exists('_program_ids', $filters), fn (Builder $query) => $query->whereHas('serviceCase', fn (Builder $case) => $case->whereIn('program_id', $filters['_program_ids'])))
+            ->when(filled($filters['program_id'] ?? null), fn (Builder $query) => $query->whereHas('serviceCase', fn (Builder $case) => $case->where('program_id', $filters['program_id'])))
+            ->get()->filter(fn (CaseInteraction $interaction): bool => $this->matchesParty($interaction->serviceCase->party, $filters));
+
+        return ['value' => (float) $records->count(), 'sampleSize' => $records->pluck('serviceCase.party_id')->unique()->count()];
+    }
+
+    /** @param array<string, mixed> $filters
+     * @return array{value: float, sampleSize: int}
+     */
+    private function caseMetric(CaseMetricCode $code, CarbonImmutable $start, CarbonImmutable $end, array $filters): array
+    {
+        $events = MetricEvent::query()->where('code', $code)->where('occurred_at', '>=', $start)->where('occurred_at', '<', $end)
+            ->when(array_key_exists('_program_ids', $filters), fn (Builder $query) => $query->whereIn('program_id', $filters['_program_ids']))
+            ->when(filled($filters['program_id'] ?? null), fn (Builder $query) => $query->where('program_id', $filters['program_id']))->get();
+        $events = $this->filterMetricEventsByParty($events, $filters);
+
+        return ['value' => (float) $events->sum(fn (MetricEvent $event): float => (float) $event->value), 'sampleSize' => $events->pluck('dimensions.party_id')->filter()->unique()->count()];
+    }
+
+    /** @param array<string, mixed> $filters
+     * @return array{value: float|null, sampleSize: int}
+     */
+    private function goalRate(CarbonImmutable $start, CarbonImmutable $end, array $filters): array
+    {
+        $events = MetricEvent::query()->whereIn('code', [CaseMetricCode::GoalAchieved, CaseMetricCode::GoalNotAchieved])
+            ->where('occurred_at', '>=', $start)->where('occurred_at', '<', $end)
+            ->when(array_key_exists('_program_ids', $filters), fn (Builder $query) => $query->whereIn('program_id', $filters['_program_ids']))
+            ->when(filled($filters['program_id'] ?? null), fn (Builder $query) => $query->where('program_id', $filters['program_id']))->get();
+        $events = $this->filterMetricEventsByParty($events, $filters);
+        $achieved = (float) $events->where('code', CaseMetricCode::GoalAchieved)->sum(fn (MetricEvent $event): float => (float) $event->value);
+        $denominator = (float) $events->sum(fn (MetricEvent $event): float => (float) $event->value);
+
+        return ['value' => $denominator > 0 ? round($achieved / $denominator * 100, 2) : null, 'sampleSize' => $events->pluck('dimensions.party_id')->filter()->unique()->count()];
+    }
+
+    /** @param array<string, mixed> $filters
+     * @return array{value: float, sampleSize: int}
+     */
+    private function successfulDonations(CarbonImmutable $start, CarbonImmutable $end, array $filters, bool $money): array
+    {
+        $events = DonationPaymentEvent::query()->with(['payment.donation.party.addresses', 'payment.donation.party.businessRoles'])
+            ->where('to_status', DonationPaymentStatus::Succeeded)->where('occurred_at', '>=', $start)->where('occurred_at', '<', $end)->get()
+            ->filter(fn (DonationPaymentEvent $event): bool => $this->matchesDonation($event->payment->donation, $filters))->unique('donation_payment_id');
+        $partyIds = $events->pluck('payment.donation.party_id')->unique();
+
+        if (! $money) {
+            return ['value' => (float) $events->count(), 'sampleSize' => $partyIds->count()];
+        }
+
+        $gross = $events->sum(fn (DonationPaymentEvent $event): int => $event->payment->amount_minor);
+        $refunds = DonationRefund::query()->with(['payment.donation.party.addresses', 'payment.donation.party.businessRoles'])
+            ->where('occurred_at', '>=', $start)->where('occurred_at', '<', $end)->get()
+            ->filter(fn (DonationRefund $refund): bool => $this->matchesDonation($refund->payment->donation, $filters))
+            ->sum('amount_minor');
+
+        return ['value' => round(($gross - $refunds) / 100, 2), 'sampleSize' => $partyIds->count()];
+    }
+
+    /** @param array<string, mixed> $filters
+     * @return array{value: float|null, sampleSize: int}
+     */
+    private function journeyMetric(SupporterJourneyEventType $type, CarbonImmutable $start, CarbonImmutable $end, array $filters, bool $rate): array
+    {
+        $events = $this->journeyEvents($start, $end, $filters);
+        $matching = $events->where('type', $type)->unique('supporter_journey_recipient_id');
+
+        if (! $rate) {
+            return ['value' => (float) $matching->count(), 'sampleSize' => $matching->pluck('recipient.party_id')->unique()->count()];
+        }
+
+        $delivered = $events->where('type', SupporterJourneyEventType::Delivered)->unique('supporter_journey_recipient_id');
+
+        return [
+            'value' => $delivered->isNotEmpty() ? round($matching->count() / $delivered->count() * 100, 2) : null,
+            'sampleSize' => $delivered->pluck('recipient.party_id')->unique()->count(),
+        ];
+    }
+
+    /** @param array<string, mixed> $filters
+     * @return Collection<int, SupporterJourneyEvent>
+     */
+    private function journeyEvents(CarbonImmutable $start, CarbonImmutable $end, array $filters): Collection
+    {
+        return SupporterJourneyEvent::query()->with(['recipient.party.addresses', 'recipient.party.businessRoles', 'recipient.party.donations'])
+            ->where('occurred_at', '>=', $start)->where('occurred_at', '<', $end)->get()
+            ->filter(fn (SupporterJourneyEvent $event): bool => $this->matchesParty($event->recipient->party, $filters)
+                && (! filled($filters['campaign_id'] ?? null) || $event->recipient->party->donations->contains('fundraising_campaign_id', $filters['campaign_id'])))->values();
+    }
+
+    /** @param array<string, mixed> $filters */
+    private function matchesDonation(Donation $donation, array $filters): bool
+    {
+        return (! filled($filters['campaign_id'] ?? null) || $donation->fundraising_campaign_id === (int) $filters['campaign_id'])
+            && $this->matchesParty($donation->party, $filters);
+    }
+
+    /** @param array<string, mixed> $filters */
+    private function matchesParty(Party $party, array $filters): bool
+    {
+        return (! filled($filters['area'] ?? null) || $party->addresses->contains('service_area', $filters['area']))
+            && (! filled($filters['location'] ?? null) || $party->addresses->contains('country_code', $filters['location']))
+            && (! filled($filters['cohort'] ?? null) || $party->businessRoles->contains('role', PartyBusinessRole::from($filters['cohort'])));
+    }
+
+    /** @param Collection<int, MetricEvent> $events
+     * @param  array<string, mixed>  $filters
+     * @return Collection<int, MetricEvent>
+     */
+    private function filterMetricEventsByParty(Collection $events, array $filters): Collection
+    {
+        if (! filled($filters['area'] ?? null) && ! filled($filters['location'] ?? null) && ! filled($filters['cohort'] ?? null)) {
+            return $events;
+        }
+
+        $partyIds = Party::query()->with(['addresses', 'businessRoles'])->get()
+            ->filter(fn (Party $party): bool => $this->matchesParty($party, $filters))->pluck('id');
+
+        return $events->filter(fn (MetricEvent $event): bool => in_array($event->dimensions['party_id'] ?? null, $partyIds->all(), true))->values();
+    }
+
+    /** @return array{timezone: string, currency: string} */
+    private function reportingContext(Organisation $organisation): array
+    {
+        $scenario = collect(ScenarioCatalog::organisations())->firstWhere('slug', $organisation->slug);
+
+        return [
+            'timezone' => $scenario['timezone'] ?? config('app.timezone'),
+            'currency' => Donation::query()->value('currency') ?? ($scenario['currency'] ?? config('reporting.default_currency')),
+        ];
+    }
+
+    /** @param array<string, mixed> $filters
+     * @return list<string>
+     */
+    private function activeDimensions(array $filters): array
+    {
+        return array_values(array_filter([
+            'program_id' => 'program',
+            'area' => 'area',
+            'location' => 'location',
+            'cohort' => 'cohort',
+            'campaign_id' => 'campaign',
+        ], fn (string $dimension, string $key): bool => filled($filters[$key] ?? null), ARRAY_FILTER_USE_BOTH));
+    }
+
+    /** @return array<string, mixed> */
+    private function options(User $user, Organisation $organisation, ?OrganisationRole $role): array
+    {
+        $programs = Program::query()->orderBy('name')->get()->filter(fn (Program $program): bool => $role === OrganisationRole::ExecutiveViewer || $user->hasProgramAccess($program));
+
+        return [
+            'programs' => $programs->map(fn (Program $program): array => ['id' => $program->id, 'name' => $program->name])->values(),
+            'areas' => PartyAddress::query()->whereNotNull('service_area')->distinct()->orderBy('service_area')->pluck('service_area'),
+            'locations' => PartyAddress::query()->distinct()->orderBy('country_code')->pluck('country_code'),
+            'cohorts' => collect(PartyBusinessRole::cases())->map(fn (PartyBusinessRole $cohort): array => ['value' => $cohort->value, 'label' => $cohort->label()]),
+            'campaigns' => FundraisingCampaign::query()->orderBy('name')->get()->map(fn (FundraisingCampaign $campaign): array => ['id' => $campaign->id, 'name' => $campaign->name]),
+        ];
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -2,17 +2,18 @@
 
 namespace App\Http\Controllers;
 
+use App\Actions\Reporting\BuildImpactDashboard;
 use App\Actions\ServiceMonitoring\BuildServiceOperationsDashboard;
+use App\Http\Requests\DashboardMetricsRequest;
 use App\Models\Organisation;
 use App\Models\OrganisationInvitation;
 use App\OrganisationContext;
-use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
 
 class DashboardController extends Controller
 {
-    public function __invoke(Request $request, Organisation $currentOrganisation, BuildServiceOperationsDashboard $buildDashboard): Response
+    public function __invoke(DashboardMetricsRequest $request, Organisation $currentOrganisation, BuildServiceOperationsDashboard $buildDashboard, BuildImpactDashboard $buildImpact): Response
     {
         $email = strtolower($request->user()->email);
 
@@ -59,6 +60,7 @@ class DashboardController extends Controller
                 $currentOrganisation,
                 $request->filled('program_id') ? $request->integer('program_id') : null,
             ),
+            'impact' => $buildImpact->handle($request->user(), $currentOrganisation, $request->validated()),
         ]);
     }
 }

--- a/app/Http/Requests/DashboardMetricsRequest.php
+++ b/app/Http/Requests/DashboardMetricsRequest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\PartyBusinessRole;
+use App\Models\Organisation;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+
+class DashboardMetricsRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $organisation = $this->route('current_organisation');
+        $organisationId = $organisation instanceof Organisation ? $organisation->id : 0;
+
+        return [
+            'period_start' => ['nullable', 'date_format:Y-m-d'],
+            'period_end' => ['nullable', 'date_format:Y-m-d'],
+            'program_id' => ['nullable', 'integer', Rule::exists('programs', 'id')->where('organisation_id', $organisationId)],
+            'area' => ['nullable', 'string', 'max:100', Rule::exists('party_addresses', 'service_area')->where('organisation_id', $organisationId)],
+            'location' => ['nullable', 'string', 'size:2', Rule::exists('party_addresses', 'country_code')->where('organisation_id', $organisationId)],
+            'cohort' => ['nullable', Rule::enum(PartyBusinessRole::class)],
+            'campaign_id' => ['nullable', 'integer', Rule::exists('fundraising_campaigns', 'id')->where('organisation_id', $organisationId)],
+        ];
+    }
+
+    /** @return array<int, callable(Validator): void> */
+    public function after(): array
+    {
+        return [function (Validator $validator): void {
+            if ($this->filled('period_start') xor $this->filled('period_end')) {
+                $validator->errors()->add('period_end', 'Both period boundaries are required.');
+            }
+
+            if ($this->filled('period_start') && $this->filled('period_end') && $this->date('period_start')->gte($this->date('period_end'))) {
+                $validator->errors()->add('period_end', 'The exclusive period end must be after the period start.');
+            }
+
+            if ($this->filled('period_start') && $this->filled('period_end') && $this->date('period_start')->diffInDays($this->date('period_end')) > 366) {
+                $validator->errors()->add('period_end', 'Reporting periods cannot exceed 366 days.');
+            }
+
+        }];
+    }
+}

--- a/app/Models/DonationRefund.php
+++ b/app/Models/DonationRefund.php
@@ -20,6 +20,7 @@ use LogicException;
  * @property string $idempotency_key
  * @property string $provider_refund_id
  * @property Carbon $occurred_at
+ * @property-read DonationPayment $payment
  */
 class DonationRefund extends Model
 {

--- a/app/Models/SupporterJourneyEvent.php
+++ b/app/Models/SupporterJourneyEvent.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
 use LogicException;
 
 /**
@@ -18,6 +19,8 @@ use LogicException;
  * @property string $supporter_journey_recipient_id
  * @property string $idempotency_key
  * @property SupporterJourneyEventType $type
+ * @property Carbon $occurred_at
+ * @property-read SupporterJourneyRecipient $recipient
  */
 #[Fillable(['organisation_id', 'supporter_journey_recipient_id', 'idempotency_key', 'type', 'from_status', 'to_status', 'metadata', 'occurred_at'])]
 class SupporterJourneyEvent extends Model

--- a/app/Models/SupporterJourneyRecipient.php
+++ b/app/Models/SupporterJourneyRecipient.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property SupporterJourneyRecipientStatus $status
  * @property int $attempt_count
  * @property-read Party $party
+ * @property-read SupporterJourney $journey
  */
 #[Fillable(['organisation_id', 'supporter_journey_id', 'party_id', 'status', 'attempt_count', 'last_attempted_at'])]
 class SupporterJourneyRecipient extends Model

--- a/app/Reporting/MetricRegistry.php
+++ b/app/Reporting/MetricRegistry.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Reporting;
+
+use App\Enums\OrganisationRole;
+
+class MetricRegistry
+{
+    public const VERSION = '2026.1';
+
+    /** @return list<array{id: string, version: string, category: string, domain: string, label: string, description: string, formula: string, unit: string, dimensions: list<string>}> */
+    public function forRole(?OrganisationRole $role): array
+    {
+        $definitions = [
+            $this->definition('service.requests_received', 'input', 'service', 'Requests received', 'Submitted requests created in the reporting period.', 'count(requests)', 'count', ['date', 'program', 'area', 'location', 'cohort']),
+            $this->definition('service.case_interactions', 'activity', 'service', 'Case interactions', 'Recorded service interactions in the reporting period.', 'count(interactions)', 'count', ['date', 'program', 'area', 'location', 'cohort']),
+            $this->definition('service.services_delivered', 'output', 'service', 'Services delivered', 'Net immutable service-delivered metric events in the reporting period.', 'sum(service_delivered events)', 'count', ['date', 'program', 'area', 'location', 'cohort']),
+            $this->definition('service.goal_achievement_rate', 'outcome', 'service', 'Goal achievement rate', 'Achieved goals divided by all achieved or not-achieved goal events.', 'achieved / (achieved + not achieved)', 'percent', ['date', 'program', 'area', 'location', 'cohort']),
+            $this->definition('fundraising.successful_donations', 'input', 'fundraising', 'Successful donations', 'Payments that entered succeeded state in the reporting period.', 'count(distinct succeeded payments)', 'count', ['date', 'area', 'location', 'cohort', 'campaign']),
+            $this->definition('engagement.welcome_deliveries', 'activity', 'engagement', 'Welcome deliveries', 'Recipients with a simulated delivered event in the reporting period.', 'count(distinct delivered recipients)', 'count', ['date', 'area', 'location', 'cohort', 'campaign']),
+            $this->definition('fundraising.net_raised', 'output', 'fundraising', 'Net raised', 'Succeeded payment value less refunds recorded in the reporting period.', 'sum(succeeded payment minor units) - sum(refund minor units)', 'currency', ['date', 'area', 'location', 'cohort', 'campaign']),
+            $this->definition('engagement.meaningful_action_rate', 'outcome', 'engagement', 'Meaningful action rate', 'Recipients with a meaningful action divided by delivered recipients.', 'meaningful recipients / delivered recipients', 'percent', ['date', 'area', 'location', 'cohort', 'campaign']),
+        ];
+
+        $domains = match ($role) {
+            OrganisationRole::ProgramManager => ['service'],
+            OrganisationRole::EngagementOfficer => ['fundraising', 'engagement'],
+            OrganisationRole::ExecutiveViewer => ['service', 'fundraising', 'engagement'],
+            default => [],
+        };
+
+        return array_values(array_filter($definitions, fn (array $definition): bool => in_array($definition['domain'], $domains, true)));
+    }
+
+    /** @param list<string> $dimensions
+     * @return array{id: string, version: string, category: string, domain: string, label: string, description: string, formula: string, unit: string, dimensions: list<string>}
+     */
+    private function definition(string $id, string $category, string $domain, string $label, string $description, string $formula, string $unit, array $dimensions): array
+    {
+        return compact('id', 'category', 'domain', 'label', 'description', 'formula', 'unit', 'dimensions') + ['version' => self::VERSION];
+    }
+}

--- a/config/reporting.php
+++ b/config/reporting.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'minimum_cohort' => (int) env('REPORTING_MINIMUM_COHORT', 5),
+    'default_currency' => env('REPORTING_DEFAULT_CURRENCY', 'ZAR'),
+];

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -13,6 +13,42 @@ import type { DashboardInvitation } from '@/types';
 type Props = {
     pendingInvitations?: DashboardInvitation[];
     serviceOperations: ServiceOperations;
+    impact?: ImpactDashboard;
+};
+
+type Metric = {
+    definition: {
+        id: string;
+        version: string;
+        category: string;
+        label: string;
+        description: string;
+        formula: string;
+        unit: string;
+    };
+    value: number | null;
+    availability: 'available' | 'unavailable' | 'suppressed';
+    sampleSize: number | null;
+    comparison: { priorValue: number; change: number } | null;
+};
+
+type ImpactDashboard = {
+    registryVersion: string;
+    fictional: boolean;
+    freshAt: string;
+    timezone: string;
+    currency: string;
+    period: { start: string; endExclusive: string };
+    filters: Record<string, string | number | null>;
+    minimumCohort: number;
+    metrics: Metric[];
+    options: {
+        programs: Array<{ id: number; name: string }>;
+        areas: string[];
+        locations: string[];
+        cohorts: Array<{ value: string; label: string }>;
+        campaigns: Array<{ id: number; name: string }>;
+    };
 };
 
 type ServiceOperationsRow = {
@@ -48,6 +84,7 @@ type QueueKey = (typeof queueDefinitions)[number]['key'];
 export default function Dashboard({
     pendingInvitations = [],
     serviceOperations,
+    impact,
 }: Props) {
     const [showInvitations, setShowInvitations] = useState(
         pendingInvitations.length > 0,
@@ -63,6 +100,7 @@ export default function Dashboard({
                 onOpenChange={setShowInvitations}
             />
             <main className="flex h-full flex-1 flex-col gap-6 overflow-x-auto rounded-xl p-4">
+                {impact ? <ImpactMetrics impact={impact} /> : null}
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
                     <div>
                         <h1 className="text-2xl font-semibold">
@@ -229,6 +267,221 @@ export default function Dashboard({
                 </div>
             </main>
         </>
+    );
+}
+
+const categories = ['input', 'activity', 'output', 'outcome'] as const;
+
+function ImpactMetrics({ impact }: { impact: ImpactDashboard }) {
+    const organisation = usePage().props.currentOrganisation!;
+
+    if (impact.metrics.length === 0) return null;
+
+    return (
+        <section className="space-y-5" aria-labelledby="impact-heading">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                    <div className="flex items-center gap-2">
+                        <h1
+                            id="impact-heading"
+                            className="text-2xl font-semibold"
+                        >
+                            Reconciled impact
+                        </h1>
+                        <Badge variant="outline">Fictional data</Badge>
+                    </div>
+                    <p className="text-muted-foreground mt-1 text-sm">
+                        Registry {impact.registryVersion} · refreshed{' '}
+                        {new Date(impact.freshAt).toLocaleString()} ·{' '}
+                        {impact.timezone} · {impact.currency} · period end is
+                        exclusive
+                    </p>
+                </div>
+            </div>
+            <Form
+                action={dashboard.url(organisation.slug)}
+                method="get"
+                className="grid gap-3 rounded-lg border p-4 md:grid-cols-4"
+            >
+                <Filter
+                    label="Period start"
+                    name="period_start"
+                    type="date"
+                    value={impact.period.start.slice(0, 10)}
+                />
+                <Filter
+                    label="Exclusive period end"
+                    name="period_end"
+                    type="date"
+                    value={impact.period.endExclusive.slice(0, 10)}
+                />
+                <SelectFilter
+                    label="Program"
+                    name="program_id"
+                    value={impact.filters.program_id}
+                    options={impact.options.programs.map((item) => ({
+                        value: item.id,
+                        label: item.name,
+                    }))}
+                />
+                <SelectFilter
+                    label="Service area"
+                    name="area"
+                    value={impact.filters.area}
+                    options={impact.options.areas.map((item) => ({
+                        value: item,
+                        label: item,
+                    }))}
+                />
+                <SelectFilter
+                    label="Location"
+                    name="location"
+                    value={impact.filters.location}
+                    options={impact.options.locations.map((item) => ({
+                        value: item,
+                        label: item,
+                    }))}
+                />
+                <SelectFilter
+                    label="Cohort"
+                    name="cohort"
+                    value={impact.filters.cohort}
+                    options={impact.options.cohorts}
+                />
+                <SelectFilter
+                    label="Campaign"
+                    name="campaign_id"
+                    value={impact.filters.campaign_id}
+                    options={impact.options.campaigns.map((item) => ({
+                        value: item.id,
+                        label: item.name,
+                    }))}
+                />
+                <Button className="self-end">Apply reporting filters</Button>
+            </Form>
+            {categories.map((category) => {
+                const metrics = impact.metrics.filter(
+                    (metric) => metric.definition.category === category,
+                );
+                if (metrics.length === 0) return null;
+
+                return (
+                    <div key={category} className="space-y-2">
+                        <h2 className="text-sm font-semibold tracking-wide uppercase">
+                            {category}s
+                        </h2>
+                        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                            {metrics.map((metric) => (
+                                <Card key={metric.definition.id}>
+                                    <CardHeader className="pb-2">
+                                        <CardTitle className="text-sm">
+                                            {metric.definition.label}
+                                        </CardTitle>
+                                    </CardHeader>
+                                    <CardContent className="space-y-2">
+                                        <p className="text-3xl font-semibold">
+                                            {metricValue(
+                                                metric,
+                                                impact.currency,
+                                            )}
+                                        </p>
+                                        <p className="text-muted-foreground text-xs">
+                                            {metric.definition.description}
+                                        </p>
+                                        <p className="text-muted-foreground text-xs">
+                                            Definition {metric.definition.id}@
+                                            {metric.definition.version} ·{' '}
+                                            {metric.definition.formula}
+                                        </p>
+                                        {metric.comparison ? (
+                                            <p className="text-xs">
+                                                Prior-period change:{' '}
+                                                {metric.comparison.change > 0
+                                                    ? '+'
+                                                    : ''}
+                                                {metric.comparison.change}
+                                            </p>
+                                        ) : null}
+                                    </CardContent>
+                                </Card>
+                            ))}
+                        </div>
+                    </div>
+                );
+            })}
+            <p className="text-muted-foreground text-xs">
+                Slices with 1–{impact.minimumCohort - 1} people are suppressed.
+                Aggregates do not provide person or case drill-down.
+            </p>
+        </section>
+    );
+}
+
+function metricValue(metric: Metric, currency: string) {
+    if (metric.availability === 'suppressed') return 'Suppressed';
+    if (metric.availability === 'unavailable' || metric.value === null)
+        return 'Unavailable';
+    if (metric.definition.unit === 'percent')
+        return `${metric.value.toFixed(1)}%`;
+    if (metric.definition.unit === 'currency')
+        return new Intl.NumberFormat(undefined, {
+            style: 'currency',
+            currency,
+        }).format(metric.value);
+    return metric.value.toLocaleString();
+}
+
+function Filter({
+    label,
+    name,
+    type,
+    value,
+}: {
+    label: string;
+    name: string;
+    type: string;
+    value: string;
+}) {
+    return (
+        <label className="grid gap-1 text-sm">
+            <span>{label}</span>
+            <input
+                className="h-9 rounded-md border bg-transparent px-3"
+                name={name}
+                type={type}
+                defaultValue={value}
+            />
+        </label>
+    );
+}
+
+function SelectFilter({
+    label,
+    name,
+    value,
+    options,
+}: {
+    label: string;
+    name: string;
+    value: string | number | null | undefined;
+    options: Array<{ value: string | number; label: string }>;
+}) {
+    return (
+        <label className="grid gap-1 text-sm">
+            <span>{label}</span>
+            <select
+                className="h-9 rounded-md border bg-transparent px-3"
+                name={name}
+                defaultValue={value ?? ''}
+            >
+                <option value="">All</option>
+                {options.map((option) => (
+                    <option key={option.value} value={option.value}>
+                        {option.label}
+                    </option>
+                ))}
+            </select>
+        </label>
     );
 }
 

--- a/tests/Feature/CommunityKindScenarioSeederTest.php
+++ b/tests/Feature/CommunityKindScenarioSeederTest.php
@@ -23,6 +23,9 @@ use App\Models\PartyContactPoint;
 use App\Models\Program;
 use App\Models\RoleAssignment;
 use App\Models\ServiceCase;
+use App\Models\SupporterJourney;
+use App\Models\SupporterJourneyEvent;
+use App\Models\SupporterJourneyRecipient;
 use App\Models\User;
 use App\OrganisationCache;
 use App\OrganisationContext;
@@ -90,6 +93,9 @@ it('seeds the versioned synthetic scenarios deterministically', function () {
         ->and(DonationPayment::withoutGlobalScopes()->sole()->status)->toBe(DonationPaymentStatus::Succeeded)
         ->and(DonationReceipt::withoutGlobalScopes()->sole()->marker)->toBe('Demo—Not a tax receipt')
         ->and(AudienceSegment::withoutGlobalScopes()->count())->toBe(1)
+        ->and(SupporterJourney::withoutGlobalScopes()->count())->toBe(1)
+        ->and(SupporterJourneyRecipient::withoutGlobalScopes()->count())->toBe(1)
+        ->and(SupporterJourneyEvent::withoutGlobalScopes()->count())->toBe(3)
         ->and(PartyConsent::withoutGlobalScopes()->where('purpose', ConsentPurpose::SupporterUpdates)->count())->toBe(1)
         ->and($showcaseCase->opened_at->toDateTimeString())->toBe('2026-06-02 06:00:00')
         ->and($showcaseCase->closed_at?->toDateTimeString())->toBe('2026-06-28 13:00:00')
@@ -118,6 +124,9 @@ it('seeds the versioned synthetic scenarios deterministically', function () {
         ->and(DonationPayment::withoutGlobalScopes()->count())->toBe(1)
         ->and(DonationReceipt::withoutGlobalScopes()->count())->toBe(1)
         ->and(AudienceSegment::withoutGlobalScopes()->count())->toBe(1)
+        ->and(SupporterJourney::withoutGlobalScopes()->count())->toBe(1)
+        ->and(SupporterJourneyRecipient::withoutGlobalScopes()->count())->toBe(1)
+        ->and(SupporterJourneyEvent::withoutGlobalScopes()->count())->toBe(3)
         ->and(PartyConsent::withoutGlobalScopes()->where('purpose', ConsentPurpose::SupporterUpdates)->count())->toBe(1);
 
     $harbourKind = Organisation::query()->findOrFail($harbourKindId);

--- a/tests/Feature/ImpactDashboardTest.php
+++ b/tests/Feature/ImpactDashboardTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use App\Actions\Reporting\BuildImpactDashboard;
+use App\Enums\CaseMetricCode;
+use App\Enums\DonationPaymentStatus;
+use App\Enums\OrganisationRole;
+use App\Enums\PartyBusinessRole;
+use App\Enums\SupporterJourneyEventType;
+use App\Models\Donation;
+use App\Models\DonationPayment;
+use App\Models\DonationPaymentEvent;
+use App\Models\DonationRefund;
+use App\Models\IntakeRequest;
+use App\Models\MetricEvent;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\PartyAddress;
+use App\Models\Program;
+use App\Models\SupporterJourneyEvent;
+use App\Models\SupporterJourneyRecipient;
+use App\Models\User;
+use App\OrganisationContext;
+use Database\Seeders\CommunityKindScenarioSeeder;
+use Illuminate\Support\Facades\Date;
+use Inertia\Testing\AssertableInertia as Assert;
+
+beforeEach(function () {
+    $key = 'base64:'.base64_encode(str_repeat('m', 32));
+    config([
+        'classified_data.encryption.current_version' => 'metrics-data-v1',
+        'classified_data.encryption.keys' => ['metrics-data-v1' => $key],
+        'classified_data.contact_index.current_version' => 'metrics-index-v1',
+        'classified_data.contact_index.previous_version' => null,
+        'classified_data.contact_index.keys' => ['metrics-index-v1' => $key],
+        'reporting.minimum_cohort' => 5,
+    ]);
+    Date::setTestNow('2026-07-01 12:00:00 UTC');
+});
+
+afterEach(fn () => Date::setTestNow());
+
+it('reconciles fixed definitions, half-open periods, comparisons, rates, money, and unavailable values', function () {
+    [$organisation, $program, $manager, $engagement, $executive] = reportingFixture();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($organisation, $program): void {
+        $party = Party::factory()->for($organisation)->create();
+        $party->businessRoles()->create(['organisation_id' => $organisation->id, 'role' => PartyBusinessRole::Donor]);
+        PartyAddress::factory()->for($party)->create(['service_area' => 'Harbour Ward', 'country_code' => 'ZA']);
+        IntakeRequest::factory()->create(['party_id' => $party->id, 'program_id' => $program->id, 'created_at' => '2026-05-15 10:00:00']);
+        IntakeRequest::factory()->create(['party_id' => $party->id, 'program_id' => $program->id, 'created_at' => '2026-06-01 00:00:00']);
+        IntakeRequest::factory()->create(['party_id' => $party->id, 'program_id' => $program->id, 'created_at' => '2026-07-01 00:00:00']);
+        MetricEvent::factory()->create(['program_id' => $program->id, 'code' => CaseMetricCode::ServiceDelivered, 'value' => 2, 'occurred_at' => '2026-06-10 12:00:00']);
+        MetricEvent::factory()->create(['program_id' => $program->id, 'code' => CaseMetricCode::GoalAchieved, 'occurred_at' => '2026-06-20 12:00:00']);
+        MetricEvent::factory()->create(['program_id' => $program->id, 'code' => CaseMetricCode::GoalNotAchieved, 'occurred_at' => '2026-06-21 12:00:00']);
+
+        $donation = Donation::factory()->for($party)->create(['amount_minor' => 5000]);
+        $payment = DonationPayment::factory()->for($donation)->create(['amount_minor' => 5000]);
+        DonationPaymentEvent::factory()->for($payment, 'payment')->create(['to_status' => DonationPaymentStatus::Succeeded, 'occurred_at' => '2026-06-12 12:00:00']);
+        DonationRefund::factory()->for($payment, 'payment')->create(['amount_minor' => 1000, 'occurred_at' => '2026-06-15 12:00:00']);
+        DonationRefund::factory()->for($payment, 'payment')->create(['amount_minor' => 1000, 'occurred_at' => '2026-07-05 12:00:00']);
+        $recipient = SupporterJourneyRecipient::factory()->for($party)->create();
+        SupporterJourneyEvent::factory()->for($recipient, 'recipient')->create(['type' => SupporterJourneyEventType::Delivered, 'to_status' => 'delivered', 'occurred_at' => '2026-06-16 12:00:00']);
+        SupporterJourneyEvent::factory()->for($recipient, 'recipient')->create(['type' => SupporterJourneyEventType::MeaningfulAction, 'from_status' => 'delivered', 'to_status' => 'delivered', 'occurred_at' => '2026-06-17 12:00:00']);
+    });
+
+    $filters = ['period_start' => '2026-06-01', 'period_end' => '2026-07-01', 'program_id' => $program->id];
+    $managerDashboard = app(OrganisationContext::class)->run($organisation, fn () => app(BuildImpactDashboard::class)->handle($manager, $organisation, $filters));
+    $managerMetrics = collect($managerDashboard['metrics'])->keyBy('definition.id');
+    expect($managerMetrics)->toHaveCount(4)
+        ->and($managerMetrics['service.requests_received']['value'])->toBe(1.0)
+        ->and($managerMetrics['service.requests_received']['comparison']['priorValue'])->toBe(1.0)
+        ->and($managerMetrics['service.services_delivered']['value'])->toBe(2.0)
+        ->and($managerMetrics['service.goal_achievement_rate']['value'])->toBe(50.0)
+        ->and($managerDashboard['period']['endExclusive'])->toStartWith('2026-07-01T00:00:00');
+
+    $engagementFilters = ['period_start' => '2026-06-01', 'period_end' => '2026-07-01'];
+    $engagementDashboard = app(OrganisationContext::class)->run($organisation, fn () => app(BuildImpactDashboard::class)->handle($engagement, $organisation, $engagementFilters));
+    $engagementMetrics = collect($engagementDashboard['metrics'])->keyBy('definition.id');
+    expect($engagementMetrics)->toHaveCount(4)
+        ->and($engagementMetrics['fundraising.successful_donations']['value'])->toBe(1.0)
+        ->and($engagementMetrics['fundraising.net_raised']['value'])->toBe(40.0)
+        ->and($engagementMetrics['engagement.welcome_deliveries']['value'])->toBe(1.0)
+        ->and($engagementMetrics['engagement.meaningful_action_rate']['value'])->toBe(100.0);
+
+    $refundPeriod = app(OrganisationContext::class)->run($organisation, fn () => app(BuildImpactDashboard::class)->handle($engagement, $organisation, ['period_start' => '2026-07-01', 'period_end' => '2026-08-01']));
+    $refundMetrics = collect($refundPeriod['metrics'])->keyBy('definition.id');
+    expect($refundMetrics['fundraising.successful_donations']['value'])->toBe(0.0)
+        ->and($refundMetrics['fundraising.net_raised']['value'])->toBe(-10.0);
+
+    $empty = app(OrganisationContext::class)->run($organisation, fn () => app(BuildImpactDashboard::class)->handle($executive, $organisation, ['period_start' => '2025-01-01', 'period_end' => '2025-02-01']));
+    $emptyMetrics = collect($empty['metrics'])->keyBy('definition.id');
+    expect($emptyMetrics)->toHaveCount(8)
+        ->and($emptyMetrics['service.requests_received']['value'])->toBe(0.0)
+        ->and($emptyMetrics['service.goal_achievement_rate']['availability'])->toBe('unavailable')
+        ->and($emptyMetrics['engagement.meaningful_action_rate']['availability'])->toBe('unavailable');
+});
+
+it('suppresses small sensitive slices and does not expose forbidden program drill-downs', function () {
+    [$organisation, $program, $manager] = reportingFixture();
+    $hiddenProgram = app(OrganisationContext::class)->run($organisation, fn () => Program::factory()->for($organisation)->create());
+
+    app(OrganisationContext::class)->run($organisation, function () use ($hiddenProgram, $organisation, $program): void {
+        $party = Party::factory()->for($organisation)->create();
+        PartyAddress::factory()->for($party)->create(['service_area' => 'Small Ward', 'country_code' => 'ZA']);
+        IntakeRequest::factory()->create(['party_id' => $party->id, 'program_id' => $program->id, 'created_at' => '2026-06-10']);
+        MetricEvent::factory()->create(['program_id' => $program->id, 'code' => CaseMetricCode::ServiceDelivered, 'value' => 2, 'dimensions' => ['party_id' => $party->id], 'occurred_at' => '2026-06-10']);
+        $otherParty = Party::factory()->for($organisation)->create();
+        PartyAddress::factory()->for($otherParty)->create(['service_area' => 'Other Ward', 'country_code' => 'ZA']);
+        MetricEvent::factory()->create(['program_id' => $program->id, 'code' => CaseMetricCode::ServiceDelivered, 'value' => 50, 'dimensions' => ['party_id' => $otherParty->id], 'occurred_at' => '2026-06-10']);
+        MetricEvent::factory()->create(['program_id' => $hiddenProgram->id, 'code' => CaseMetricCode::ServiceDelivered, 'value' => 99, 'occurred_at' => '2026-06-10']);
+    });
+
+    $slice = app(OrganisationContext::class)->run($organisation, fn () => app(BuildImpactDashboard::class)->handle($manager, $organisation, ['period_start' => '2026-06-01', 'period_end' => '2026-07-01', 'area' => 'Small Ward']));
+    $sliceMetrics = collect($slice['metrics'])->keyBy('definition.id');
+    expect($sliceMetrics['service.requests_received']['availability'])->toBe('suppressed')
+        ->and($sliceMetrics['service.requests_received']['value'])->toBeNull()
+        ->and($sliceMetrics['service.requests_received']['sampleSize'])->toBeNull();
+    config(['reporting.minimum_cohort' => 1]);
+    $visibleSlice = app(OrganisationContext::class)->run($organisation, fn () => app(BuildImpactDashboard::class)->handle($manager, $organisation, ['period_start' => '2026-06-01', 'period_end' => '2026-07-01', 'area' => 'Small Ward']));
+    expect(collect($visibleSlice['metrics'])->keyBy('definition.id')['service.services_delivered']['value'])->toBe(2.0);
+
+    $this->actingAs($manager)->get(route('dashboard', [$organisation, 'program_id' => $hiddenProgram->id]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('impact.metrics.2.value', 0)
+            ->missing('impact.metrics.0.records')
+            ->missing('impact.metrics.0.partyIds'));
+    $this->actingAs($manager)->get(route('dashboard', [$organisation, 'period_start' => '2026-06-01', 'period_end' => '2026-07-01']))
+        ->assertInertia(fn (Assert $page) => $page->where('impact.metrics.2.value', 52));
+});
+
+it('exactly reconciles the versioned seeded service, donation, and communication journeys', function () {
+    $this->seed(CommunityKindScenarioSeeder::class);
+    $organisation = Organisation::query()->where('slug', 'harbourkind')->firstOrFail();
+    $manager = User::query()->where('email', 'manager@harbourkind.example.test')->firstOrFail();
+    $engagement = User::query()->where('email', 'engagement@harbourkind.example.test')->firstOrFail();
+    $period = ['period_start' => '2026-06-01', 'period_end' => '2026-07-01'];
+
+    $managerMetrics = app(OrganisationContext::class)->run($organisation, fn () => collect(app(BuildImpactDashboard::class)->handle($manager, $organisation, $period)['metrics'])->keyBy('definition.id'));
+    $engagementMetrics = app(OrganisationContext::class)->run($organisation, fn () => collect(app(BuildImpactDashboard::class)->handle($engagement, $organisation, $period)['metrics'])->keyBy('definition.id'));
+
+    expect($managerMetrics['service.requests_received']['value'])->toBe(1.0)
+        ->and($managerMetrics['service.services_delivered']['value'])->toBe(1.0)
+        ->and($managerMetrics['service.goal_achievement_rate']['value'])->toBe(100.0)
+        ->and($engagementMetrics['fundraising.successful_donations']['value'])->toBe(1.0)
+        ->and($engagementMetrics['fundraising.net_raised']['value'])->toBe(50.0)
+        ->and($engagementMetrics['engagement.welcome_deliveries']['value'])->toBe(1.0)
+        ->and($engagementMetrics['engagement.meaningful_action_rate']['value'])->toBe(100.0);
+});
+
+/** @return array{Organisation, Program, User, User, User} */
+function reportingFixture(): array
+{
+    $organisation = Organisation::factory()->active()->create(['slug' => 'harbourkind']);
+    $manager = User::factory()->create();
+    $engagement = User::factory()->create();
+    $executive = User::factory()->create();
+    $managerMembership = $organisation->memberships()->create(['user_id' => $manager->id, 'role' => OrganisationRole::ProgramManager]);
+    $organisation->memberships()->create(['user_id' => $engagement->id, 'role' => OrganisationRole::EngagementOfficer]);
+    $organisation->memberships()->create(['user_id' => $executive->id, 'role' => OrganisationRole::ExecutiveViewer]);
+    $program = app(OrganisationContext::class)->run($organisation, fn () => Program::factory()->for($organisation)->create());
+    app(OrganisationContext::class)->run($organisation, fn () => $managerMembership->programs()->attach($program));
+
+    return [$organisation, $program, $manager, $engagement, $executive];
+}


### PR DESCRIPTION
## Summary

- add a fixed versioned metric registry for program manager, engagement, and executive dashboards
- reconcile service, donation, refund, delivery, and meaningful-action values directly from immutable source histories
- enforce half-open periods, prior-period comparisons, program authorization, supported dimensions, and small-cohort suppression
- label fictional data, freshness, timezone, currency, reporting period, formulas, and definition versions
- extend the deterministic donor scenario through local welcome delivery and meaningful action

## Verification

- `DB_CONNECTION=pgsql composer ci:check` (309 tests, 1743 assertions)
- `npm test -- --run`
- `npm run licenses:check`
- `npm run build`
- signed commit with DCO sign-off
- reviewed against `codex/issue-18-local-supporter-welcome`; review findings fixed

Stacked on #59.

Closes #19