### PR TITLE
Export accessible, privacy-safe impact reports and charts

### DIFF
--- a/app/Enums/TenantAuditEventType.php
+++ b/app/Enums/TenantAuditEventType.php
@@ -23,6 +23,7 @@ enum TenantAuditEventType: string
     case DonationRefunded = 'donation_refunded';
     case RecurringMandateTransitioned = 'recurring_mandate_transitioned';
     case AudienceSegmentCreated = 'audience_segment_created';
+    case ImpactReportExported = 'impact_report_exported';
 
     /** @return array<string, string> */
     public function payloadSchema(): array
@@ -110,6 +111,12 @@ enum TenantAuditEventType: string
             self::AudienceSegmentCreated => [
                 'segment_id' => 'string',
                 'name' => 'string',
+            ],
+            self::ImpactReportExported => [
+                'registry_version' => 'string',
+                'filters_hash' => 'string',
+                'metric_count' => 'integer',
+                'format' => 'string',
             ],
         };
     }

--- a/app/Http/Controllers/Organisations/ImpactChartExportController.php
+++ b/app/Http/Controllers/Organisations/ImpactChartExportController.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Actions\Reporting\BuildImpactDashboard;
+use App\Enums\TenantAuditEventType;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\DashboardMetricsRequest;
+use App\Models\Organisation;
+use Illuminate\Http\Response;
+use LogicException;
+
+class ImpactChartExportController extends Controller
+{
+    public function __invoke(
+        DashboardMetricsRequest $request,
+        Organisation $currentOrganisation,
+        BuildImpactDashboard $buildDashboard,
+        RecordTenantAuditEvent $recordAudit,
+    ): Response {
+        $dashboard = $buildDashboard->handle($request->user(), $currentOrganisation, $request->validated());
+        $metrics = $dashboard['metrics'];
+        abort_if($metrics === [], 403);
+        if (! is_array($metrics)) {
+            throw new LogicException('The impact dashboard metrics must be an array.');
+        }
+
+        $dashboardFilters = $dashboard['filters'];
+        if (! is_array($dashboardFilters)) {
+            throw new LogicException('The impact dashboard filters must be an array.');
+        }
+        $filters = array_filter($dashboardFilters, fn (mixed $value): bool => filled($value));
+        $recordAudit->handle($currentOrganisation, TenantAuditEventType::ImpactReportExported, 'organisation', (string) $currentOrganisation->id, [
+            'registry_version' => $dashboard['registryVersion'],
+            'filters_hash' => hash('sha256', json_encode($filters, JSON_THROW_ON_ERROR)),
+            'metric_count' => count($metrics),
+            'format' => 'svg',
+        ], $request->user());
+
+        return response($this->renderChart($dashboard, $metrics, $filters), headers: [
+            'Content-Type' => 'image/svg+xml; charset=UTF-8',
+            'Content-Disposition' => 'attachment; filename="fictional-impact-chart.svg"',
+            'Cache-Control' => 'private, no-store',
+            'X-Content-Type-Options' => 'nosniff',
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $dashboard
+     * @param  array<int, mixed>  $metrics
+     * @param  array<array-key, mixed>  $filters
+     */
+    private function renderChart(array $dashboard, array $metrics, array $filters): string
+    {
+        $rows = [];
+        $maximumByUnit = [];
+
+        foreach ($metrics as $metric) {
+            if (! is_array($metric) || ! is_array($metric['definition'] ?? null)) {
+                throw new LogicException('Every impact metric must contain a definition.');
+            }
+
+            $definition = $metric['definition'];
+            $availability = (string) ($metric['availability'] ?? 'unavailable');
+            $value = is_numeric($metric['value'] ?? null) ? (float) $metric['value'] : null;
+            $unit = (string) ($definition['unit'] ?? '');
+            if ($availability === 'available' && $value !== null) {
+                $maximumByUnit[$unit] = max($maximumByUnit[$unit] ?? 1.0, abs($value));
+            }
+            $rows[] = [
+                'label' => (string) ($definition['label'] ?? 'Metric'),
+                'definition' => sprintf(
+                    '%s v%s — %s',
+                    (string) ($definition['id'] ?? ''),
+                    (string) ($definition['version'] ?? ''),
+                    (string) ($definition['formula'] ?? ''),
+                ),
+                'availability' => $availability,
+                'value' => $value,
+                'unit' => $unit,
+                'display' => $this->metricValue($value, $availability, $unit, (string) $dashboard['currency']),
+            ];
+        }
+
+        $height = 230 + (count($rows) * 76);
+        $description = 'Fictional data. Data as of '.(string) $dashboard['freshAt'].'. '
+            .'Period '.(string) $dashboard['period']['start'].' to '.(string) $dashboard['period']['endExclusive'].' exclusive. '
+            .'Filters '.json_encode($filters, JSON_THROW_ON_ERROR).'. '
+            .implode(' ', array_map(fn (array $row): string => $row['label'].': '.$row['display'].'; '.$row['definition'].'.', $rows));
+        $svgRows = [];
+
+        foreach ($rows as $index => $row) {
+            $y = 190 + ($index * 76);
+            $barWidth = $row['availability'] === 'available' && $row['value'] !== null
+                ? max(2, (int) round(abs($row['value']) / $maximumByUnit[$row['unit']] * 520))
+                : 0;
+            $svgRows[] = sprintf(
+                '<g transform="translate(0 %d)"><text x="48" y="0" class="label">%s</text><text x="1152" y="0" text-anchor="end" class="value">%s</text><text x="48" y="22" class="definition">%s</text>%s</g>',
+                $y,
+                $this->escape($row['label']),
+                $this->escape($row['display']),
+                $this->escape($row['definition']),
+                $barWidth > 0 ? sprintf('<rect x="48" y="34" width="%d" height="18" rx="4" fill="#155e75"/>', $barWidth) : '',
+            );
+        }
+
+        return sprintf(
+            '<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="%d" viewBox="0 0 1200 %d" role="img" aria-labelledby="title description"><title id="title">CommunityKind impact chart</title><desc id="description">%s</desc><rect width="1200" height="100%%" fill="#ffffff"/><style>.title{font:700 30px system-ui,sans-serif;fill:#172554}.meta{font:16px system-ui,sans-serif;fill:#334155}.label,.value{font:600 18px system-ui,sans-serif;fill:#0f172a}.definition{font:14px system-ui,sans-serif;fill:#475569}</style><text x="48" y="54" class="title">CommunityKind impact chart</text><text x="48" y="86" class="meta">Fictional data · Data as of %s</text><text x="48" y="112" class="meta">Period %s to %s (exclusive)</text><text x="48" y="138" class="meta">Filters: %s</text>%s</svg>',
+            $height,
+            $height,
+            $this->escape($description),
+            $this->escape((string) $dashboard['freshAt']),
+            $this->escape((string) $dashboard['period']['start']),
+            $this->escape((string) $dashboard['period']['endExclusive']),
+            $this->escape(json_encode($filters, JSON_THROW_ON_ERROR)),
+            implode('', $svgRows),
+        );
+    }
+
+    private function metricValue(?float $value, string $availability, string $unit, string $currency): string
+    {
+        if ($availability === 'suppressed') {
+            return 'Suppressed';
+        }
+        if ($availability !== 'available' || $value === null) {
+            return 'Unavailable';
+        }
+
+        return match ($unit) {
+            'currency' => $currency.' '.$value,
+            'percent' => $value.'%',
+            default => (string) $value,
+        };
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_XML1, 'UTF-8');
+    }
+}

--- a/app/Http/Controllers/Organisations/ImpactReportExportController.php
+++ b/app/Http/Controllers/Organisations/ImpactReportExportController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Actions\Reporting\BuildImpactDashboard;
+use App\Enums\TenantAuditEventType;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\DashboardMetricsRequest;
+use App\Models\Organisation;
+use LogicException;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ImpactReportExportController extends Controller
+{
+    public function __invoke(
+        DashboardMetricsRequest $request,
+        Organisation $currentOrganisation,
+        BuildImpactDashboard $buildDashboard,
+        RecordTenantAuditEvent $recordAudit,
+    ): StreamedResponse {
+        $dashboard = $buildDashboard->handle($request->user(), $currentOrganisation, $request->validated());
+        abort_if($dashboard['metrics'] === [], 403);
+        $dashboardFilters = $dashboard['filters'];
+        if (! is_array($dashboardFilters)) {
+            throw new LogicException('The impact dashboard filters must be an array.');
+        }
+        $filters = array_filter($dashboardFilters, fn (mixed $value): bool => filled($value));
+        $recordAudit->handle($currentOrganisation, TenantAuditEventType::ImpactReportExported, 'organisation', (string) $currentOrganisation->id, [
+            'registry_version' => $dashboard['registryVersion'],
+            'filters_hash' => hash('sha256', json_encode($filters, JSON_THROW_ON_ERROR)),
+            'metric_count' => count($dashboard['metrics']),
+            'format' => 'csv',
+        ], $request->user());
+
+        return response()->streamDownload(function () use ($dashboard, $filters): void {
+            $stream = fopen('php://output', 'wb');
+            if ($stream === false) {
+                return;
+            }
+
+            fputcsv($stream, ['category', 'metric', 'value', 'availability', 'unit', 'definition_id', 'definition_version', 'formula', 'period_start', 'period_end_exclusive', 'timezone', 'currency', 'fictional_data', 'fresh_at', 'filters']);
+            foreach ($dashboard['metrics'] as $metric) {
+                fputcsv($stream, [
+                    $metric['definition']['category'],
+                    $this->spreadsheetSafe($metric['definition']['label']),
+                    $metric['value'],
+                    $metric['availability'],
+                    $metric['definition']['unit'],
+                    $metric['definition']['id'],
+                    $metric['definition']['version'],
+                    $this->spreadsheetSafe($metric['definition']['formula']),
+                    $dashboard['period']['start'],
+                    $dashboard['period']['endExclusive'],
+                    $dashboard['timezone'],
+                    $dashboard['currency'],
+                    'Fictional data',
+                    $dashboard['freshAt'],
+                    json_encode($filters, JSON_THROW_ON_ERROR),
+                ]);
+            }
+            fclose($stream);
+        }, 'fictional-impact-report.csv', [
+            'Content-Type' => 'text/csv; charset=UTF-8',
+            'Cache-Control' => 'private, no-store',
+            'X-Content-Type-Options' => 'nosniff',
+        ]);
+    }
+
+    private function spreadsheetSafe(string $value): string
+    {
+        return preg_match('/^\s*[=+\-@]/u', $value) === 1 ? "'{$value}" : $value;
+    }
+}

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -8,6 +8,8 @@ import { dashboard } from '@/routes';
 import { show as showCase } from '@/routes/cases';
 import { show as showIntake } from '@/routes/intakes';
 import { exportMethod as exportServiceOperations } from '@/routes/dashboard/service-operations';
+import { exportMethod as exportImpact } from '@/routes/dashboard/impact';
+import { exportMethod as exportImpactChart } from '@/routes/dashboard/impact/chart';
 import type { DashboardInvitation } from '@/types';
 
 type Props = {
@@ -297,6 +299,26 @@ function ImpactMetrics({ impact }: { impact: ImpactDashboard }) {
                         exclusive
                     </p>
                 </div>
+                <div className="flex flex-wrap gap-2">
+                    <Button asChild variant="outline">
+                        <a
+                            href={exportImpact.url(organisation.slug, {
+                                query: impact.filters,
+                            })}
+                        >
+                            Export accessible CSV
+                        </a>
+                    </Button>
+                    <Button asChild variant="outline">
+                        <a
+                            href={exportImpactChart.url(organisation.slug, {
+                                query: impact.filters,
+                            })}
+                        >
+                            Export accessible SVG
+                        </a>
+                    </Button>
+                </div>
             </div>
             <Form
                 action={dashboard.url(organisation.slug)}
@@ -409,11 +431,94 @@ function ImpactMetrics({ impact }: { impact: ImpactDashboard }) {
                     </div>
                 );
             })}
+            <MetricChart metrics={impact.metrics} currency={impact.currency} />
             <p className="text-muted-foreground text-xs">
                 Slices with 1–{impact.minimumCohort - 1} people are suppressed.
                 Aggregates do not provide person or case drill-down.
             </p>
         </section>
+    );
+}
+
+function MetricChart({
+    metrics,
+    currency,
+}: {
+    metrics: Metric[];
+    currency: string;
+}) {
+    const available = metrics.filter(
+        (metric) =>
+            metric.availability === 'available' && metric.value !== null,
+    );
+    const maximumByUnit = available.reduce<Record<string, number>>(
+        (maximums, metric) => ({
+            ...maximums,
+            [metric.definition.unit]: Math.max(
+                maximums[metric.definition.unit] ?? 1,
+                Math.abs(metric.value ?? 0),
+            ),
+        }),
+        {},
+    );
+
+    return (
+        <figure
+            className="space-y-3 rounded-lg border p-4"
+            aria-labelledby="impact-chart-title"
+            aria-describedby="impact-chart-description"
+        >
+            <figcaption>
+                <h2 id="impact-chart-title" className="font-semibold">
+                    Presentation chart
+                </h2>
+                <p
+                    id="impact-chart-description"
+                    className="text-muted-foreground text-sm"
+                >
+                    Relative bars for available aggregate values, scaled
+                    separately by unit. Units are retained in each label;
+                    suppressed and unavailable values have no bar.
+                </p>
+            </figcaption>
+            <div className="space-y-3" aria-hidden="true">
+                {available.map((metric) => (
+                    <div key={metric.definition.id} className="grid gap-1">
+                        <div className="flex justify-between gap-3 text-sm">
+                            <span>{metric.definition.label}</span>
+                            <strong>{metricValue(metric, currency)}</strong>
+                        </div>
+                        <div className="bg-muted h-4 rounded-sm">
+                            <div
+                                className="bg-primary h-4 min-w-1 rounded-sm"
+                                style={{
+                                    width: `${(Math.abs(metric.value ?? 0) / maximumByUnit[metric.definition.unit]) * 100}%`,
+                                }}
+                            />
+                        </div>
+                    </div>
+                ))}
+            </div>
+            <table className="sr-only">
+                <caption>Nonvisual equivalent of the impact chart</caption>
+                <thead>
+                    <tr>
+                        <th scope="col">Metric</th>
+                        <th scope="col">Value</th>
+                        <th scope="col">Status</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {metrics.map((metric) => (
+                        <tr key={metric.definition.id}>
+                            <th scope="row">{metric.definition.label}</th>
+                            <td>{metricValue(metric, currency)}</td>
+                            <td>{metric.availability}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </figure>
     );
 }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,8 @@ use App\Http\Controllers\Organisations\CaseExportController;
 use App\Http\Controllers\Organisations\CaseItemController;
 use App\Http\Controllers\Organisations\CaseWorkflowController;
 use App\Http\Controllers\Organisations\DonationController;
+use App\Http\Controllers\Organisations\ImpactChartExportController;
+use App\Http\Controllers\Organisations\ImpactReportExportController;
 use App\Http\Controllers\Organisations\IntakeRequestController;
 use App\Http\Controllers\Organisations\IntakeTransitionController;
 use App\Http\Controllers\Organisations\OrganisationInvitationController;
@@ -92,6 +94,8 @@ Route::prefix('{current_organisation}')
     ->group(function () {
         Route::get('dashboard', DashboardController::class)->name('dashboard');
         Route::get('dashboard/service-operations/export', ServiceOperationsExportController::class)->name('dashboard.service-operations.export');
+        Route::get('dashboard/impact/export', ImpactReportExportController::class)->name('dashboard.impact.export');
+        Route::get('dashboard/impact/chart.svg', ImpactChartExportController::class)->name('dashboard.impact.chart.export');
         Route::get('programs', [ProgramController::class, 'index'])->name('programs.index');
         Route::resource('donations', DonationController::class)->only(['index', 'show']);
         Route::resource('audience-segments', AudienceSegmentController::class)->only(['index', 'store', 'show']);

--- a/tests/Feature/ImpactReportExportTest.php
+++ b/tests/Feature/ImpactReportExportTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Enums\CaseMetricCode;
+use App\Enums\OrganisationRole;
+use App\Enums\TenantAuditEventType;
+use App\Models\MetricEvent;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\PartyAddress;
+use App\Models\Program;
+use App\Models\TenantAuditEvent;
+use App\Models\User;
+use App\OrganisationContext;
+
+beforeEach(function () {
+    $key = 'base64:'.base64_encode(str_repeat('e', 32));
+    config([
+        'classified_data.encryption.current_version' => 'export-data-v1',
+        'classified_data.encryption.keys' => ['export-data-v1' => $key],
+        'classified_data.contact_index.current_version' => 'export-index-v1',
+        'classified_data.contact_index.keys' => ['export-index-v1' => $key],
+        'reporting.minimum_cohort' => 5,
+    ]);
+});
+
+it('exports the exact privacy-safe dashboard context and audits it separately', function () {
+    [$organisation, $manager, $program, $party] = impactExportFixture();
+    app(OrganisationContext::class)->run($organisation, fn () => MetricEvent::factory()->create([
+        'program_id' => $program->id,
+        'code' => CaseMetricCode::ServiceDelivered,
+        'value' => 2,
+        'dimensions' => ['party_id' => $party->id],
+        'occurred_at' => '2026-06-10 12:00:00',
+    ]));
+
+    $query = ['period_start' => '2026-06-01', 'period_end' => '2026-07-01'];
+    $csv = $this->actingAs($manager)->get(route('dashboard.impact.export', [$organisation, ...$query]))
+        ->assertOk()->assertHeader('content-type', 'text/csv; charset=UTF-8')->streamedContent();
+    expect($csv)->toContain('service.services_delivered')
+        ->toContain(',2,available,count,')
+        ->toContain('2026.1')
+        ->toContain('Fictional')
+        ->not->toContain($party->uuid)
+        ->not->toContain('case note');
+
+    $suppressed = $this->actingAs($manager)->get(route('dashboard.impact.export', [$organisation, ...$query, 'area' => 'Small Ward']))
+        ->assertOk()->streamedContent();
+    expect($suppressed)->toContain(',suppressed,')
+        ->toContain('Small Ward')
+        ->not->toContain($party->uuid);
+
+    $chart = $this->actingAs($manager)->get(route('dashboard.impact.chart.export', [$organisation, ...$query, 'area' => 'Small Ward']))
+        ->assertOk()
+        ->assertHeader('content-type', 'image/svg+xml; charset=UTF-8')
+        ->assertHeader('content-disposition', 'attachment; filename="fictional-impact-chart.svg"')
+        ->getContent();
+    expect($chart)->toContain('role="img"')
+        ->toContain('<title id="title">CommunityKind impact chart</title>')
+        ->toContain('<desc id="description">')
+        ->toContain('Fictional data')
+        ->toContain('Small Ward')
+        ->toContain('service.services_delivered v2026.1')
+        ->toContain('Suppressed')
+        ->not->toContain($party->uuid)
+        ->not->toContain('case note');
+
+    app(OrganisationContext::class)->run($organisation, function (): void {
+        $audits = TenantAuditEvent::query()->where('type', TenantAuditEventType::ImpactReportExported)->get();
+        expect($audits)->toHaveCount(3)
+            ->and($audits->every(fn (TenantAuditEvent $audit): bool => $audit->payload['metric_count'] === 4 && $audit->payload['registry_version'] === '2026.1'))->toBeTrue()
+            ->and($audits->pluck('payload.format')->all())->toBe(['csv', 'csv', 'svg']);
+    });
+});
+
+it('forbids exports for roles without impact definitions and across organisations', function () {
+    [$organisation] = impactExportFixture();
+    $worker = User::factory()->create();
+    $organisation->memberships()->create(['user_id' => $worker->id, 'role' => OrganisationRole::CaseWorker]);
+    $other = Organisation::factory()->active()->create();
+
+    $this->actingAs($worker)->get(route('dashboard.impact.export', $organisation))->assertForbidden();
+    $this->actingAs($worker)->get(route('dashboard.impact.chart.export', $organisation))->assertForbidden();
+    $this->actingAs($worker)->get(route('dashboard.impact.export', $other))->assertForbidden();
+    $this->actingAs($worker)->get(route('dashboard.impact.chart.export', $other))->assertForbidden();
+});
+
+/** @return array{Organisation, User, Program, Party} */
+function impactExportFixture(): array
+{
+    $organisation = Organisation::factory()->active()->create(['slug' => 'harbourkind']);
+    $manager = User::factory()->create();
+    $membership = $organisation->memberships()->create(['user_id' => $manager->id, 'role' => OrganisationRole::ProgramManager]);
+    [$program, $party] = app(OrganisationContext::class)->run($organisation, function () use ($organisation): array {
+        $program = Program::factory()->for($organisation)->create();
+        $party = Party::factory()->for($organisation)->create();
+        PartyAddress::factory()->for($party)->create(['service_area' => 'Small Ward', 'country_code' => 'ZA']);
+
+        return [$program, $party];
+    });
+    app(OrganisationContext::class)->run($organisation, fn () => $membership->programs()->attach($program));
+
+    return [$organisation, $manager, $program, $party];
+}


### PR DESCRIPTION
Closes #20

## Summary
- export the authorised dashboard view as privacy-safe CSV with exact registry definitions, filters, period, fictional-data label, and freshness timestamp
- export a presentation-ready accessible SVG chart, with values scaled only against comparable units and a complete nonvisual description
- retain suppression and tenant/role scoping for both formats, and audit every CSV or SVG export separately
- add an accessible on-screen chart and export controls to the role-specific dashboard

## Verification
- `DB_CONNECTION=pgsql composer ci:check` (311 tests, 1777 assertions)
- `npm test`
- `npm run build`
- `npm run licenses:check`

## Review
Reviewed against `origin/main`; fixed static shape validation, the missing separately authorised chart export, and misleading cross-unit chart scaling before opening this PR.