### PR TITLE
Provision disposable demo sandboxes

### DIFF
--- a/app/Actions/Auditing/BuildTenantAuditView.php
+++ b/app/Actions/Auditing/BuildTenantAuditView.php
@@ -53,6 +53,8 @@ class BuildTenantAuditView
             OrganisationRole::OrganisationAdministrator => in_array($event->type, [
                 TenantAuditEventType::ProgramUpdated,
                 TenantAuditEventType::AuditViewAccessed,
+                TenantAuditEventType::DemoPersonaSelected,
+                TenantAuditEventType::DemoOrganisationReset,
             ], true),
             OrganisationRole::ProgramManager => in_array($this->domain($event->type), ['service', 'configuration'], true)
                 && ($this->programIsVisible($event, $user) || ($event->actor_user_id === $user->id && $event->type === TenantAuditEventType::ServiceOperationsExported)),
@@ -100,7 +102,10 @@ class BuildTenantAuditView
     private function domain(TenantAuditEventType $type): string
     {
         return match ($type) {
-            TenantAuditEventType::ProgramUpdated, TenantAuditEventType::AuditViewAccessed => 'configuration',
+            TenantAuditEventType::ProgramUpdated,
+            TenantAuditEventType::AuditViewAccessed,
+            TenantAuditEventType::DemoPersonaSelected,
+            TenantAuditEventType::DemoOrganisationReset => 'configuration',
             TenantAuditEventType::DonationCreated,
             TenantAuditEventType::DonationPaymentTransitioned,
             TenantAuditEventType::DonationRefunded,

--- a/app/Actions/CaseDocuments/QuarantineCaseDocument.php
+++ b/app/Actions/CaseDocuments/QuarantineCaseDocument.php
@@ -128,7 +128,12 @@ final class QuarantineCaseDocument
                     $actor,
                 );
 
-                ScanCaseDocument::dispatch($case->organisation->uuid, $document->id, $document->generation)->afterCommit();
+                ScanCaseDocument::dispatch(
+                    $case->organisation->uuid,
+                    $document->id,
+                    $document->generation,
+                    $case->organisation->demo_generation,
+                )->afterCommit();
 
                 return $document;
             });

--- a/app/Actions/Demo/BuildOrganisationScenario.php
+++ b/app/Actions/Demo/BuildOrganisationScenario.php
@@ -29,7 +29,7 @@ use Ramsey\Uuid\Uuid;
  * @phpstan-type ProgramDefinition array{name: string, slug: string, configuration: array<string, mixed>}
  * @phpstan-type MemberDefinition array{party_uuid: string, name: string, email: string, telephone: string, owner: bool, role: OrganisationRole|null, program_slugs: list<string>}
  * @phpstan-type PartyDefinition array{uuid: string, kind: PartyKind, name: string, email?: string, telephone?: string, program_slugs?: list<string>, roles?: list<PartyBusinessRole>, interests?: list<string>}
- * @phpstan-type ScenarioDefinition array{uuid: string, name: string, slug: string, timezone: string, currency: string, reporting_at: string, synthetic: true, party_population: array<string, int>, programs: list<ProgramDefinition>, members: list<MemberDefinition>, parties: list<PartyDefinition>}
+ * @phpstan-type ScenarioDefinition array{uuid: string, name: string, slug: string, timezone: string, currency: string, reporting_at: string, synthetic: true, template_slug?: string, sandbox_pair_id?: string, demo_generation?: int, party_population: array<string, int>, programs: list<ProgramDefinition>, members: list<MemberDefinition>, parties: list<PartyDefinition>}
  */
 final class BuildOrganisationScenario
 {
@@ -54,6 +54,10 @@ final class BuildOrganisationScenario
                 'uuid' => $scenario['uuid'],
                 'name' => $scenario['name'],
                 'slug' => $scenario['slug'],
+                'sandbox_pair_id' => $scenario['sandbox_pair_id'] ?? null,
+                'sandbox_template' => $scenario['template_slug'] ?? null,
+                'demo_generation' => $scenario['demo_generation'] ?? 0,
+                'is_synthetic' => $scenario['synthetic'],
             ];
 
             if (! $organisation->exists) {
@@ -80,17 +84,27 @@ final class BuildOrganisationScenario
 
                 $this->upsertPartyPopulation($organisation, $scenario);
 
-                if ($scenario['slug'] === 'harbourkind') {
+                if (($scenario['template_slug'] ?? $scenario['slug']) === 'harbourkind') {
+                    $client = collect($scenario['parties'])->first(fn (array $party): bool => in_array(PartyBusinessRole::Client, $party['roles'] ?? [], true));
+                    $donor = collect($scenario['parties'])->first(fn (array $party): bool => in_array(PartyBusinessRole::Donor, $party['roles'] ?? [], true));
+                    $manager = collect($scenario['members'])->first(fn (array $member): bool => $member['role'] === OrganisationRole::ProgramManager && in_array('housing-support', $member['program_slugs'], true));
+                    $caseworker = collect($scenario['members'])->first(fn (array $member): bool => $member['role'] === OrganisationRole::CaseWorker && in_array('housing-support', $member['program_slugs'], true));
+                    $engagement = collect($scenario['members'])->first(fn (array $member): bool => $member['role'] === OrganisationRole::EngagementOfficer);
+
+                    if ($client === null || $donor === null || $manager === null || $caseworker === null || $engagement === null) {
+                        throw new LogicException('The HarbourKind scenario is missing a required showcase persona.');
+                    }
+
                     $this->buildRequestToOutcomeScenario->handle(
                         $organisation,
                         Program::query()->where('slug', 'housing-support')->firstOrFail(),
-                        Party::query()->where('uuid', '12000000-0000-4000-8000-000000000001')->firstOrFail(),
-                        User::query()->where('email', 'manager@harbourkind.example.test')->firstOrFail(),
-                        Membership::query()->whereHas('user', fn ($query) => $query->where('email', 'caseworker@harbourkind.example.test'))->firstOrFail(),
+                        Party::query()->where('uuid', $client['uuid'])->firstOrFail(),
+                        User::query()->where('email', $manager['email'])->firstOrFail(),
+                        Membership::query()->whereHas('user', fn ($query) => $query->where('email', $caseworker['email']))->firstOrFail(),
                     );
                     $this->buildDonorToRetainedSupporterScenario->handle(
-                        Party::query()->where('uuid', '12000000-0000-4000-8000-000000000002')->firstOrFail(),
-                        User::query()->where('email', 'engagement@harbourkind.example.test')->firstOrFail(),
+                        Party::query()->where('uuid', $donor['uuid'])->firstOrFail(),
+                        User::query()->where('email', $engagement['email'])->firstOrFail(),
                     );
                 }
             });

--- a/app/Actions/Demo/BuildSandboxScenario.php
+++ b/app/Actions/Demo/BuildSandboxScenario.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Actions\Demo;
+
+use Ramsey\Uuid\Uuid;
+
+/** @phpstan-import-type ScenarioDefinition from BuildOrganisationScenario */
+final class BuildSandboxScenario
+{
+    /**
+     * @param  ScenarioDefinition  $template
+     * @return ScenarioDefinition
+     */
+    public function handle(array $template, string $pairId, int $generation): array
+    {
+        $shortPairId = substr(str_replace('-', '', $pairId), 0, 8);
+        $suffix = "{$shortPairId}-g{$generation}";
+        $scenario = $template;
+        $scenario['uuid'] = $this->uuid($pairId, $generation, $template['uuid']);
+        $scenario['slug'] = "{$template['slug']}-{$suffix}";
+        $scenario['name'] = "{$template['name']} Sandbox {$shortPairId}";
+        $scenario['template_slug'] = $template['slug'];
+        $scenario['sandbox_pair_id'] = $pairId;
+        $scenario['demo_generation'] = $generation;
+
+        $scenario['members'] = array_map(function (array $member) use ($pairId, $generation, $suffix): array {
+            $member['party_uuid'] = $this->uuid($pairId, $generation, $member['party_uuid']);
+            $member['email'] = $this->email($member['email'], $suffix);
+
+            return $member;
+        }, $template['members']);
+
+        $scenario['parties'] = array_map(function (array $party) use ($pairId, $generation, $suffix): array {
+            $party['uuid'] = $this->uuid($pairId, $generation, $party['uuid']);
+
+            if (isset($party['email'])) {
+                $party['email'] = $this->email($party['email'], $suffix);
+            }
+
+            return $party;
+        }, $template['parties']);
+
+        return $scenario;
+    }
+
+    private function uuid(string $pairId, int $generation, string $templateUuid): string
+    {
+        return Uuid::uuid5($pairId, "generation:{$generation}:{$templateUuid}")->toString();
+    }
+
+    private function email(string $email, string $suffix): string
+    {
+        [$local, $domain] = explode('@', $email, 2);
+
+        return "{$local}+{$suffix}@{$domain}";
+    }
+}

--- a/app/Actions/Demo/CreateSandboxBootstrapToken.php
+++ b/app/Actions/Demo/CreateSandboxBootstrapToken.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Actions\Demo;
+
+use App\Models\SandboxBootstrapToken;
+use App\Models\SandboxPair;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+final class CreateSandboxBootstrapToken
+{
+    public function handle(SandboxPair $pair): string
+    {
+        return DB::transaction(function () use ($pair): string {
+            $pair = SandboxPair::query()->lockForUpdate()->findOrFail($pair->id);
+
+            if (! $pair->status->isAccessible() || $pair->expires_at->isPast()) {
+                throw new \LogicException('Bootstrap tokens require an accessible, unexpired sandbox pair.');
+            }
+
+            $pair->bootstrapTokens()
+                ->whereNull('used_at')
+                ->whereNull('revoked_at')
+                ->update(['revoked_at' => now()]);
+
+            $plainTextToken = Str::random(64);
+
+            SandboxBootstrapToken::query()->create([
+                'sandbox_pair_id' => $pair->id,
+                'token_hash' => hash('sha256', $plainTextToken),
+                'generation' => $pair->generation,
+                'expires_at' => $pair->expires_at,
+            ]);
+
+            return $plainTextToken;
+        });
+    }
+}

--- a/app/Actions/Demo/ExpireSandboxPair.php
+++ b/app/Actions/Demo/ExpireSandboxPair.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Actions\Demo;
+
+use App\Enums\OrganisationStatus;
+use App\Enums\SandboxPairStatus;
+use App\Models\SandboxPair;
+use Illuminate\Support\Facades\DB;
+
+final class ExpireSandboxPair
+{
+    public function handle(SandboxPair $pair): void
+    {
+        DB::transaction(function () use ($pair): void {
+            $pair = SandboxPair::query()->lockForUpdate()->findOrFail($pair->id);
+
+            if (in_array($pair->status, [SandboxPairStatus::Expired, SandboxPairStatus::Purging, SandboxPairStatus::Purged], true)) {
+                return;
+            }
+
+            if (! in_array($pair->status, [SandboxPairStatus::Ready, SandboxPairStatus::Active], true)) {
+                throw new \LogicException('Only ready or active sandboxes can expire.');
+            }
+
+            $userIds = DB::table('organisation_members')
+                ->whereIn('organisation_id', $pair->organisations()->select('id'))
+                ->pluck('user_id');
+
+            DB::table('sessions')->whereIn('user_id', $userIds)->delete();
+            $pair->bootstrapTokens()->whereNull('revoked_at')->update(['revoked_at' => now()]);
+            $pair->organisations()->update([
+                'status' => OrganisationStatus::Archived,
+                'status_changed_at' => now(),
+                'access_version' => DB::raw('access_version + 1'),
+                'signed_links_invalidated_at' => now(),
+            ]);
+            $pair->update([
+                'status' => SandboxPairStatus::Expired,
+                'generation' => $pair->generation + 1,
+            ]);
+        });
+    }
+}

--- a/app/Actions/Demo/ProvisionSandboxPair.php
+++ b/app/Actions/Demo/ProvisionSandboxPair.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Actions\Demo;
+
+use App\Data\Demo\ScenarioCatalog;
+use App\Enums\SandboxPairStatus;
+use App\Models\Organisation;
+use App\Models\SandboxPair;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+/** @phpstan-import-type ScenarioDefinition from BuildOrganisationScenario */
+final class ProvisionSandboxPair
+{
+    public function __construct(
+        private readonly BuildSandboxScenario $buildSandboxScenario,
+        private readonly BuildOrganisationScenario $buildOrganisationScenario,
+        private readonly CreateSandboxBootstrapToken $createBootstrapToken,
+    ) {}
+
+    /** @return array{pair: SandboxPair, token: string} */
+    public function handle(int $lifetimeHours = 24): array
+    {
+        abort_unless(config('demo_sandbox.enabled'), 404);
+        $lifetimeHours = max(1, min($lifetimeHours, (int) config('demo_sandbox.maximum_lifetime_hours')));
+        $pair = SandboxPair::query()->create([
+            'status' => SandboxPairStatus::Provisioning,
+            'generation' => 1,
+            'expires_at' => now()->addHours($lifetimeHours),
+        ]);
+
+        try {
+            foreach (ScenarioCatalog::organisations() as $template) {
+                $this->buildOrganisationScenario->handle(
+                    $this->buildSandboxScenario->handle($template, $pair->id, $pair->generation),
+                );
+            }
+
+            $this->reconcile($pair);
+            $pair->update(['status' => SandboxPairStatus::Ready]);
+
+            return ['pair' => $pair, 'token' => $this->createBootstrapToken->handle($pair)];
+        } catch (Throwable $exception) {
+            $pair->update(['status' => SandboxPairStatus::Failed, 'failed_at' => now()]);
+
+            throw $exception;
+        }
+    }
+
+    public function reconcile(SandboxPair $pair): void
+    {
+        $organisations = $pair->organisations()->get();
+
+        if ($organisations->count() !== 2
+            || $organisations->pluck('sandbox_template')->sort()->values()->all() !== ['harbourkind', 'neighbourlink']) {
+            throw new \LogicException('The sandbox pair did not reconcile to its pinned scenario.');
+        }
+
+        foreach (ScenarioCatalog::organisations() as $template) {
+            $organisation = $organisations->firstWhere('sandbox_template', $template['slug']);
+
+            if ($organisation === null) {
+                throw new \LogicException('The sandbox pair is missing a pinned Organisation.');
+            }
+
+            $this->reconcileOrganisation($organisation, $template);
+        }
+
+        if (! DB::table('sandbox_pairs')->where('id', $pair->id)->where('generation', $pair->generation)->exists()) {
+            throw new \LogicException('The sandbox generation changed while it was being reconciled.');
+        }
+    }
+
+    /** @param ScenarioDefinition $template */
+    public function reconcileOrganisation(Organisation $organisation, array $template): void
+    {
+        $expectedCounts = [
+            'programs' => count($template['programs']),
+            'organisation_members' => count($template['members']),
+            'parties' => array_sum($template['party_population']),
+            'role_assignments' => collect($template['members'])->whereNotNull('role')->count(),
+        ];
+        $showcaseCounts = $template['slug'] === 'harbourkind'
+            ? [
+                'service_cases' => 1,
+                'metric_events' => 5,
+                'fundraising_campaigns' => 1,
+                'donation_funds' => 1,
+                'donations' => 1,
+                'donation_payments' => 1,
+                'donation_receipts' => 1,
+                'audience_segments' => 1,
+                'supporter_journeys' => 1,
+                'supporter_journey_recipients' => 1,
+                'supporter_journey_events' => 3,
+                'party_consents' => 2,
+            ]
+            : [
+                'service_cases' => 0,
+                'metric_events' => 0,
+                'fundraising_campaigns' => 0,
+                'donation_funds' => 0,
+                'donations' => 0,
+                'donation_payments' => 0,
+                'donation_receipts' => 0,
+                'audience_segments' => 0,
+                'supporter_journeys' => 0,
+                'supporter_journey_recipients' => 0,
+                'supporter_journey_events' => 0,
+                'party_consents' => 0,
+            ];
+
+        foreach ($expectedCounts + $showcaseCounts as $table => $expectedCount) {
+            $query = DB::table($table)->where('organisation_id', $organisation->id);
+
+            if (in_array($table, ['programs', 'parties'], true)) {
+                $query->whereNull('deleted_at');
+            }
+
+            if ($table === 'organisation_members' || $table === 'role_assignments') {
+                $query->whereNull('ended_at');
+            }
+
+            if ($query->count() !== $expectedCount) {
+                throw new \LogicException("The {$organisation->sandbox_template} sandbox did not reconcile {$table} exactly.");
+            }
+        }
+    }
+}

--- a/app/Actions/Demo/PurgeSandboxPair.php
+++ b/app/Actions/Demo/PurgeSandboxPair.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Actions\Demo;
+
+use App\Enums\OrganisationStatus;
+use App\Enums\SandboxPairStatus;
+use App\Models\SandboxPair;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Throwable;
+
+final class PurgeSandboxPair
+{
+    public function handle(SandboxPair $pair): void
+    {
+        try {
+            DB::transaction(function () use ($pair): void {
+                $pair = SandboxPair::query()->lockForUpdate()->findOrFail($pair->id);
+
+                if ($pair->status === SandboxPairStatus::Purged) {
+                    return;
+                }
+
+                if (! in_array($pair->status, [SandboxPairStatus::Expired, SandboxPairStatus::Failed, SandboxPairStatus::Purging], true)) {
+                    throw new \LogicException('Only expired or failed sandboxes can be purged.');
+                }
+
+                $pair->update(['status' => SandboxPairStatus::Purging]);
+                $organisations = $pair->organisations()->withTrashed()->get();
+                $organisationIds = $organisations->pluck('id');
+                $userIds = DB::table('organisation_members')->whereIn('organisation_id', $organisationIds)->pluck('user_id');
+
+                DB::table('sessions')->whereIn('user_id', $userIds)->delete();
+                $pair->bootstrapTokens()->delete();
+
+                foreach ($organisations as $organisation) {
+                    $organisation->forceFill([
+                        'sandbox_pair_id' => null,
+                        'status' => OrganisationStatus::Deleted,
+                        'status_changed_at' => now(),
+                        'slug' => 'purged-sandbox-'.$organisation->id.'-'.Str::lower((string) Str::ulid()),
+                        'name' => 'Purged synthetic sandbox',
+                    ])->save();
+                    $organisation->delete();
+                }
+
+                User::query()->whereIn('id', $userIds)->each(function (User $user) use ($organisationIds): void {
+                    $hasExternalMembership = DB::table('organisation_members')
+                        ->where('user_id', $user->id)
+                        ->whereNotIn('organisation_id', $organisationIds)
+                        ->whereNull('ended_at')
+                        ->exists();
+
+                    if (! $hasExternalMembership) {
+                        $user->forceFill([
+                            'name' => 'Purged synthetic sandbox user',
+                            'email' => 'purged-sandbox-'.$user->id.'-'.Str::lower((string) Str::ulid()).'@example.test',
+                            'email_verified_at' => null,
+                            'password' => Str::random(64),
+                            'current_organisation_id' => null,
+                            'two_factor_secret' => null,
+                            'two_factor_recovery_codes' => null,
+                            'two_factor_confirmed_at' => null,
+                            'recovery_codes_acknowledged_at' => null,
+                            'remember_token' => null,
+                        ])->save();
+                    }
+                });
+
+                $pair->update(['status' => SandboxPairStatus::Purged, 'purged_at' => now()]);
+            });
+        } catch (Throwable $exception) {
+            SandboxPair::query()
+                ->whereKey($pair->id)
+                ->whereIn('status', [SandboxPairStatus::Expired, SandboxPairStatus::Failed, SandboxPairStatus::Purging])
+                ->update(['status' => SandboxPairStatus::Failed, 'failed_at' => now()]);
+
+            throw $exception;
+        }
+    }
+}

--- a/app/Actions/Demo/ResetSandboxOrganisation.php
+++ b/app/Actions/Demo/ResetSandboxOrganisation.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace App\Actions\Demo;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Data\Demo\ScenarioCatalog;
+use App\Enums\OrganisationRole;
+use App\Enums\OrganisationStatus;
+use App\Enums\TenantAuditEventType;
+use App\Models\Organisation;
+use App\Models\SandboxPair;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use LogicException;
+
+/** @phpstan-import-type ScenarioDefinition from BuildOrganisationScenario */
+final class ResetSandboxOrganisation
+{
+    public function __construct(
+        private readonly BuildSandboxScenario $buildSandboxScenario,
+        private readonly BuildOrganisationScenario $buildOrganisationScenario,
+        private readonly ProvisionSandboxPair $provisionSandboxPair,
+        private readonly CreateSandboxBootstrapToken $createBootstrapToken,
+        private readonly RecordTenantAuditEvent $recordAudit,
+        private readonly OrganisationContext $organisationContext,
+    ) {}
+
+    /** @return array{organisation: Organisation, token: string} */
+    public function handle(Organisation $organisation, User $actor): array
+    {
+        abort_unless(config('demo_sandbox.enabled'), 404);
+        $pairId = $organisation->sandbox_pair_id;
+
+        return DB::transaction(function () use ($organisation, $actor, $pairId): array {
+            $pair = SandboxPair::query()->lockForUpdate()->findOrFail($pairId);
+            $organisation = Organisation::query()->lockForUpdate()->findOrFail($organisation->id);
+            $isAdministrator = DB::table('organisation_members')
+                ->where('organisation_id', $organisation->id)
+                ->where('user_id', $actor->id)
+                ->whereNull('ended_at')
+                ->where(function ($query) use ($organisation): void {
+                    $query->where('is_owner', true)
+                        ->orWhereExists(fn ($roles) => $roles
+                            ->selectRaw('1')
+                            ->from('role_assignments')
+                            ->whereColumn('role_assignments.membership_id', 'organisation_members.id')
+                            ->where('role_assignments.organisation_id', $organisation->id)
+                            ->where('role_assignments.role', OrganisationRole::OrganisationAdministrator)
+                            ->whereNull('role_assignments.program_id')
+                            ->whereNull('role_assignments.ended_at'));
+                })
+                ->exists();
+
+            abort_unless($isAdministrator, 403);
+
+            if ($organisation->sandbox_pair_id !== $pair->id || ! $organisation->is_synthetic || $organisation->sandbox_template === null || ! $pair->status->isAccessible()) {
+                throw new LogicException('Only an accessible synthetic sandbox Organisation can be reset.');
+            }
+
+            $template = $this->template($organisation->sandbox_template);
+
+            $oldOrganisationId = $organisation->id;
+            $oldSlug = $organisation->slug;
+            $nextGeneration = $organisation->demo_generation + 1;
+            $userIds = DB::table('organisation_members')->where('organisation_id', $oldOrganisationId)->pluck('user_id');
+
+            DB::table('sessions')->whereIn('user_id', $userIds)->delete();
+            $organisation->forceFill([
+                'status' => OrganisationStatus::Deleted,
+                'status_changed_at' => now(),
+                'access_version' => $organisation->access_version + 1,
+                'signed_links_invalidated_at' => now(),
+                'slug' => "retired-sandbox-{$organisation->id}-".Str::lower((string) Str::ulid()),
+            ])->save();
+            $organisation->delete();
+
+            $scenario = $this->buildSandboxScenario->handle($template, $pair->id, $nextGeneration);
+            $scenario['slug'] = $oldSlug;
+            $replacement = $this->buildOrganisationScenario->handle($scenario);
+            $this->provisionSandboxPair->reconcileOrganisation($replacement, $template);
+
+            $this->organisationContext->run($replacement, fn () => $this->recordAudit->handle(
+                $replacement,
+                TenantAuditEventType::DemoOrganisationReset,
+                'organisation',
+                (string) $replacement->id,
+                ['generation' => $nextGeneration, 'template' => $replacement->sandbox_template],
+                $actor,
+            ));
+
+            return [
+                'organisation' => $replacement,
+                'token' => $this->createBootstrapToken->handle($pair),
+            ];
+        });
+    }
+
+    /** @return ScenarioDefinition */
+    private function template(string $slug): array
+    {
+        foreach (ScenarioCatalog::organisations() as $scenario) {
+            if ($scenario['slug'] === $slug) {
+                return $scenario;
+            }
+        }
+
+        throw new LogicException('The sandbox template is no longer available.');
+    }
+}

--- a/app/Console/Commands/ExpireDemoSandboxes.php
+++ b/app/Console/Commands/ExpireDemoSandboxes.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Demo\ExpireSandboxPair;
+use App\Enums\SandboxPairStatus;
+use App\Models\SandboxPair;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+#[Signature('demo:sandbox:expire')]
+#[Description('Expire due demo sandboxes and terminate their sessions')]
+class ExpireDemoSandboxes extends Command
+{
+    /**
+     * Execute the console command.
+     */
+    public function handle(ExpireSandboxPair $expire): int
+    {
+        SandboxPair::query()
+            ->whereIn('status', [SandboxPairStatus::Ready, SandboxPairStatus::Active])
+            ->where('expires_at', '<=', now())
+            ->eachById(fn (SandboxPair $pair) => $expire->handle($pair));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/IssueDemoSandboxToken.php
+++ b/app/Console/Commands/IssueDemoSandboxToken.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Demo\CreateSandboxBootstrapToken;
+use App\Models\SandboxPair;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+#[Signature('demo:sandbox:token {pair : Sandbox pair UUID}')]
+#[Description('Issue a replacement token for an unexpired demo sandbox')]
+class IssueDemoSandboxToken extends Command
+{
+    /**
+     * Execute the console command.
+     */
+    public function handle(CreateSandboxBootstrapToken $createToken): int
+    {
+        if (! config('demo_sandbox.enabled')) {
+            $this->error('Demo sandboxes are disabled in this environment.');
+
+            return self::FAILURE;
+        }
+
+        $pair = SandboxPair::query()->findOrFail($this->argument('pair'));
+
+        if (! $pair->status->isAccessible() || $pair->expires_at->isPast()) {
+            $this->error('The sandbox pair is not accessible.');
+
+            return self::FAILURE;
+        }
+
+        $this->line(route('demo.bootstrap', ['token' => $createToken->handle($pair)]));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/ProvisionDemoSandbox.php
+++ b/app/Console/Commands/ProvisionDemoSandbox.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Demo\ProvisionSandboxPair;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+#[Signature('demo:sandbox:provision {--hours=24 : Lifetime from one to 24 hours}')]
+#[Description('Provision an isolated synthetic demo sandbox pair')]
+class ProvisionDemoSandbox extends Command
+{
+    /**
+     * Execute the console command.
+     */
+    public function handle(ProvisionSandboxPair $provision): int
+    {
+        if (! config('demo_sandbox.enabled')) {
+            $this->error('Demo sandboxes are disabled in this environment.');
+
+            return self::FAILURE;
+        }
+
+        $result = $provision->handle((int) $this->option('hours'));
+        $this->info('Sandbox pair: '.$result['pair']->id);
+        $this->line(route('demo.bootstrap', ['token' => $result['token']]));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/PurgeDemoSandboxes.php
+++ b/app/Console/Commands/PurgeDemoSandboxes.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Actions\Demo\PurgeSandboxPair;
+use App\Enums\SandboxPairStatus;
+use App\Models\SandboxPair;
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+
+#[Signature('demo:sandbox:purge {pair? : Limit the purge to one sandbox pair UUID}')]
+#[Description('Idempotently purge expired or failed demo sandboxes')]
+class PurgeDemoSandboxes extends Command
+{
+    /**
+     * Execute the console command.
+     */
+    public function handle(PurgeSandboxPair $purge): int
+    {
+        SandboxPair::query()
+            ->when($this->argument('pair'), fn ($query, string $pair) => $query->whereKey($pair))
+            ->whereIn('status', [SandboxPairStatus::Expired, SandboxPairStatus::Failed, SandboxPairStatus::Purging])
+            ->eachById(fn (SandboxPair $pair) => $purge->handle($pair));
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Enums/SandboxPairStatus.php
+++ b/app/Enums/SandboxPairStatus.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Enums;
+
+enum SandboxPairStatus: string
+{
+    case Provisioning = 'provisioning';
+    case Ready = 'ready';
+    case Active = 'active';
+    case Expired = 'expired';
+    case Purging = 'purging';
+    case Purged = 'purged';
+    case Failed = 'failed';
+
+    public function isAccessible(): bool
+    {
+        return in_array($this, [self::Ready, self::Active], true);
+    }
+}

--- a/app/Enums/TenantAuditEventType.php
+++ b/app/Enums/TenantAuditEventType.php
@@ -25,6 +25,8 @@ enum TenantAuditEventType: string
     case AudienceSegmentCreated = 'audience_segment_created';
     case ImpactReportExported = 'impact_report_exported';
     case AuditViewAccessed = 'audit_view_accessed';
+    case DemoPersonaSelected = 'demo_persona_selected';
+    case DemoOrganisationReset = 'demo_organisation_reset';
 
     /** @return array<string, string> */
     public function payloadSchema(): array
@@ -123,6 +125,15 @@ enum TenantAuditEventType: string
                 'record_count' => 'integer',
                 'scope' => 'string',
                 'role' => 'string',
+            ],
+            self::DemoPersonaSelected => [
+                'membership_id' => 'integer',
+                'role' => 'string',
+                'generation' => 'integer',
+            ],
+            self::DemoOrganisationReset => [
+                'generation' => 'integer',
+                'template' => 'string',
             ],
         };
     }

--- a/app/Http/Controllers/Demo/SandboxBootstrapController.php
+++ b/app/Http/Controllers/Demo/SandboxBootstrapController.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Http\Controllers\Demo;
+
+use App\Enums\SandboxPairStatus;
+use App\Http\Controllers\Controller;
+use App\Models\SandboxBootstrapToken;
+use App\Models\SandboxPair;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class SandboxBootstrapController extends Controller
+{
+    public function __invoke(Request $request, string $token): RedirectResponse
+    {
+        abort_unless(config('demo_sandbox.enabled'), 404);
+        $tokenHash = hash('sha256', $token);
+        $pairId = SandboxBootstrapToken::query()->where('token_hash', $tokenHash)->value('sandbox_pair_id');
+        abort_unless(is_string($pairId), 404);
+
+        $bootstrap = DB::transaction(function () use ($pairId, $tokenHash): SandboxBootstrapToken {
+            $pair = SandboxPair::query()->lockForUpdate()->findOrFail($pairId);
+            $bootstrap = SandboxBootstrapToken::query()
+                ->where('sandbox_pair_id', $pair->id)
+                ->where('token_hash', $tokenHash)
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            abort_if($bootstrap->used_at !== null || $bootstrap->revoked_at !== null, 410);
+            abort_if($bootstrap->expires_at->isPast() || $pair->expires_at->isPast(), 410);
+            abort_unless($bootstrap->generation === $pair->generation && $pair->status->isAccessible(), 410);
+
+            $bootstrap->update(['used_at' => now()]);
+
+            if ($pair->status === SandboxPairStatus::Ready) {
+                $pair->update(['status' => SandboxPairStatus::Active, 'activated_at' => now()]);
+            }
+
+            return $bootstrap;
+        });
+
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+        $request->session()->put([
+            'demo_sandbox_pair_id' => $bootstrap->sandbox_pair_id,
+            'demo_sandbox_generation' => $bootstrap->generation,
+        ]);
+
+        return to_route('demo.personas.index')->withHeaders([
+            'Referrer-Policy' => 'no-referrer',
+            'Cache-Control' => 'no-store',
+        ]);
+    }
+}

--- a/app/Http/Controllers/Demo/SandboxOrganisationController.php
+++ b/app/Http/Controllers/Demo/SandboxOrganisationController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Demo;
+
+use App\Actions\Demo\ResetSandboxOrganisation;
+use App\Http\Controllers\Controller;
+use App\Models\Organisation;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class SandboxOrganisationController extends Controller
+{
+    public function reset(Request $request, Organisation $organisation, ResetSandboxOrganisation $reset): RedirectResponse
+    {
+        $request->validate(['slug' => ['required', 'string', 'in:'.$organisation->slug]]);
+        $user = $request->user();
+        abort_if($user === null, 403);
+        $result = $reset->handle($organisation, $user);
+
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect()->route('demo.bootstrap', ['token' => $result['token']]);
+    }
+}

--- a/app/Http/Controllers/Demo/SandboxPersonaController.php
+++ b/app/Http/Controllers/Demo/SandboxPersonaController.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Http\Controllers\Demo;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Enums\OrganisationRole;
+use App\Enums\TenantAuditEventType;
+use App\Http\Controllers\Controller;
+use App\Models\Membership;
+use App\Models\SandboxPair;
+use App\OrganisationContext;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class SandboxPersonaController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        $pair = $this->pair($request);
+        $organisationIds = $pair->organisations()->pluck('id');
+        $roles = DB::table('role_assignments')
+            ->whereIn('organisation_id', $organisationIds)
+            ->whereNull('program_id')
+            ->whereNull('ended_at')
+            ->pluck('role', 'membership_id');
+        $personas = Membership::query()
+            ->with(['user', 'organisation'])
+            ->whereIn('organisation_id', $organisationIds)
+            ->whereNull('ended_at')
+            ->orderBy('id')
+            ->get()
+            ->map(function (Membership $membership) use ($roles): ?array {
+                $role = OrganisationRole::tryFrom((string) $roles->get($membership->id));
+
+                if (! $role instanceof OrganisationRole) {
+                    return null;
+                }
+
+                return [
+                    'membershipId' => $membership->id,
+                    'name' => $membership->user->name,
+                    'organisation' => $membership->organisation->name,
+                    'role' => $role->label(),
+                ];
+            })
+            ->filter()
+            ->unique('role')
+            ->values();
+
+        return Inertia::render('demo/personas', ['personas' => $personas]);
+    }
+
+    public function store(Request $request, RecordTenantAuditEvent $recordAudit, OrganisationContext $context): RedirectResponse
+    {
+        $pair = $this->pair($request);
+        $validated = $request->validate(['membership_id' => ['required', 'integer']]);
+        $membership = Membership::query()
+            ->with(['user', 'organisation'])
+            ->whereKey($validated['membership_id'])
+            ->whereIn('organisation_id', $pair->organisations()->select('id'))
+            ->whereNull('ended_at')
+            ->firstOrFail();
+        $role = OrganisationRole::tryFrom((string) DB::table('role_assignments')
+            ->where('organisation_id', $membership->organisation_id)
+            ->where('membership_id', $membership->id)
+            ->whereNull('program_id')
+            ->whereNull('ended_at')
+            ->value('role'));
+        abort_unless($role instanceof OrganisationRole, 404);
+
+        Auth::login($membership->user);
+        $request->session()->regenerate();
+        $membership->user->switchOrganisation($membership->organisation);
+        $request->session()->put([
+            'demo_organisation_generation' => $membership->organisation->demo_generation,
+            'auth.password_confirmed_at' => now()->getTimestamp(),
+            'auth.mfa_confirmed_at' => now()->getTimestamp(),
+        ]);
+
+        $context->run($membership->organisation, fn () => $recordAudit->handle(
+            $membership->organisation,
+            TenantAuditEventType::DemoPersonaSelected,
+            'membership',
+            (string) $membership->id,
+            [
+                'membership_id' => $membership->id,
+                'role' => $role->value,
+                'generation' => $membership->organisation->demo_generation,
+            ],
+            $membership->user,
+        ));
+
+        return to_route('dashboard', ['current_organisation' => $membership->organisation]);
+    }
+
+    private function pair(Request $request): SandboxPair
+    {
+        abort_unless(config('demo_sandbox.enabled'), 404);
+        $pairId = $request->session()->get('demo_sandbox_pair_id');
+        abort_unless(is_string($pairId), 404);
+        $pair = SandboxPair::query()->findOrFail($pairId);
+        abort_unless($pair->status->isAccessible() && $pair->generation === $request->session()->get('demo_sandbox_generation'), 410);
+
+        return $pair;
+    }
+}

--- a/app/Http/Controllers/Organisations/OrganisationController.php
+++ b/app/Http/Controllers/Organisations/OrganisationController.php
@@ -79,6 +79,8 @@ class OrganisationController extends Controller
                 'name' => $organisation->name,
                 'slug' => $organisation->slug,
                 'status' => $organisation->status->value,
+                'isSynthetic' => $organisation->is_synthetic,
+                'demoGeneration' => $organisation->demo_generation,
             ],
             'members' => $memberships
                 ->map(function (Membership $membership) use ($organisation, $permissions, $user) {

--- a/app/Http/Middleware/EnforceDemoSandbox.php
+++ b/app/Http/Middleware/EnforceDemoSandbox.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\Organisation;
+use App\Models\SandboxPair;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnforceDemoSandbox
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $pairId = $request->session()->get('demo_sandbox_pair_id');
+
+        if (! is_string($pairId)) {
+            return $next($request);
+        }
+
+        $pair = SandboxPair::query()->find($pairId);
+
+        if ($pair === null || ! $pair->status->isAccessible() || $pair->expires_at->isPast()
+            || $pair->generation !== $request->session()->get('demo_sandbox_generation')) {
+            Auth::logout();
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+
+            abort(410, 'This demo sandbox has expired.');
+        }
+
+        if ($request->routeIs('demo.*')) {
+            return $next($request);
+        }
+
+        $organisation = $request->route('current_organisation')
+            ?? $request->route('organisation')
+            ?? $request->route('public_organisation');
+
+        if (is_string($organisation)) {
+            $organisation = Organisation::query()->where('slug', $organisation)->first();
+        }
+
+        if ($organisation instanceof Organisation) {
+            abort_unless($organisation->sandbox_pair_id === $pair->id && $organisation->is_synthetic, 404);
+            $sessionGeneration = $request->session()->get('demo_organisation_generation');
+
+            if (is_int($sessionGeneration)) {
+                abort_unless($organisation->demo_generation === $sessionGeneration, 410);
+            }
+        }
+
+        $blockedRoutes = [
+            'cases.documents.*',
+            'supporter-journeys.dispatch',
+            'invitations.*',
+            'organisations.invitations.*',
+            'organisations.members.*',
+            'organisations.lifecycle.*',
+            'organisations.slug.*',
+            'organisations.ownership-transfers.*',
+            'organisations.destroy',
+            'organisations.store',
+            'organisations.leave',
+            'profile.update',
+            'profile.destroy',
+            'user-password.update',
+            'two-factor.*',
+            'security.recovery-codes.*',
+            'security.other-browser-sessions.*',
+        ];
+
+        foreach ($blockedRoutes as $route) {
+            abort_if($request->routeIs($route), 403, 'This capability is disabled in demo sandboxes.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/EnsureStaffSecurityRequirements.php
+++ b/app/Http/Middleware/EnsureStaffSecurityRequirements.php
@@ -15,6 +15,10 @@ class EnsureStaffSecurityRequirements
      */
     public function handle(Request $request, Closure $next): Response
     {
+        if (config('demo_sandbox.enabled') && $request->session()->has('demo_sandbox_pair_id')) {
+            return $next($request);
+        }
+
         if (! config('auth.mfa_required')) {
             return $next($request);
         }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -8,6 +8,7 @@ use App\Models\IntakeRequest;
 use App\Models\Organisation;
 use App\Models\Party;
 use App\Models\Program;
+use App\Models\SandboxPair;
 use App\Models\SupporterJourney;
 use App\Models\TenantAuditEvent;
 use Illuminate\Http\Request;
@@ -62,6 +63,28 @@ class HandleInertiaRequests extends Middleware
             'canCreateOrganisation' => $user?->can('create', Organisation::class) ?? false,
             'currentOrganisation' => fn () => $organisations()->first(fn ($organisation) => $organisation->isCurrent),
             'organisations' => $organisations,
+            'demoSandbox' => function () use ($request, $user): ?array {
+                $pairId = $request->session()->get('demo_sandbox_pair_id');
+
+                if (is_string($pairId)) {
+                    $pair = SandboxPair::query()->find($pairId);
+
+                    if ($pair?->status->isAccessible()) {
+                        return [
+                            'pairId' => $pair->id,
+                            'expiresAt' => $pair->expires_at->toISOString(),
+                        ];
+                    }
+                }
+
+                $visibleOrganisation = $request->route('current_organisation')
+                    ?? $request->route('organisation')
+                    ?? $user?->currentOrganisation;
+
+                return $visibleOrganisation instanceof Organisation && $visibleOrganisation->is_synthetic
+                    ? ['pairId' => null, 'expiresAt' => null]
+                    : null;
+            },
             'canViewParties' => fn (): bool => $routeOrganisation instanceof Organisation
                 && Gate::allows('viewAny', [Party::class, $routeOrganisation]),
             'canViewPrograms' => fn (): bool => $routeOrganisation instanceof Organisation

--- a/app/Jobs/ScanCaseDocument.php
+++ b/app/Jobs/ScanCaseDocument.php
@@ -31,6 +31,7 @@ class ScanCaseDocument implements ShouldBeUnique, ShouldQueue
         public string $organisationUuid,
         public string $documentId,
         public int $expectedGeneration,
+        public int $expectedOrganisationGeneration = 0,
     ) {
         $this->onQueue('security');
     }
@@ -42,7 +43,7 @@ class ScanCaseDocument implements ShouldBeUnique, ShouldQueue
     {
         $organisation = Organisation::query()->where('uuid', $this->organisationUuid)->first();
 
-        if ($organisation === null) {
+        if ($organisation === null || $organisation->demo_generation !== $this->expectedOrganisationGeneration) {
             return;
         }
 
@@ -74,6 +75,6 @@ class ScanCaseDocument implements ShouldBeUnique, ShouldQueue
 
     public function uniqueId(): string
     {
-        return $this->organisationUuid.':'.$this->documentId.':'.$this->expectedGeneration;
+        return $this->organisationUuid.':'.$this->expectedOrganisationGeneration.':'.$this->documentId.':'.$this->expectedGeneration;
     }
 }

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -11,6 +11,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -30,11 +31,16 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property Carbon|null $deleted_at
+ * @property string|null $sandbox_pair_id
+ * @property string|null $sandbox_template
+ * @property int $demo_generation
+ * @property bool $is_synthetic
+ * @property-read SandboxPair|null $sandboxPair
  * @property-read Collection<int, OrganisationInvitation> $invitations
  * @property-read Collection<int, Membership> $memberships
  * @property-read Collection<int, User> $members
  */
-#[Fillable(['name', 'slug', 'status', 'status_changed_at', 'deletion_scheduled_for', 'signed_links_invalidated_at', 'access_version'])]
+#[Fillable(['name', 'slug', 'status', 'status_changed_at', 'deletion_scheduled_for', 'signed_links_invalidated_at', 'access_version', 'sandbox_pair_id', 'sandbox_template', 'demo_generation', 'is_synthetic'])]
 class Organisation extends Model
 {
     /** @use HasFactory<OrganisationFactory> */
@@ -136,6 +142,12 @@ class Organisation extends Model
         return $this->hasMany(OrganisationInvitation::class);
     }
 
+    /** @return BelongsTo<SandboxPair, $this> */
+    public function sandboxPair(): BelongsTo
+    {
+        return $this->belongsTo(SandboxPair::class);
+    }
+
     /**
      * Get the programs configured for this Organisation.
      *
@@ -201,6 +213,8 @@ class Organisation extends Model
             'deletion_scheduled_for' => 'datetime',
             'signed_links_invalidated_at' => 'datetime',
             'access_version' => 'integer',
+            'demo_generation' => 'integer',
+            'is_synthetic' => 'boolean',
         ];
     }
 

--- a/app/Models/SandboxBootstrapToken.php
+++ b/app/Models/SandboxBootstrapToken.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property string $sandbox_pair_id
+ * @property string $token_hash
+ * @property int $generation
+ * @property Carbon $expires_at
+ * @property Carbon|null $used_at
+ * @property Carbon|null $revoked_at
+ * @property-read SandboxPair $sandboxPair
+ */
+#[Fillable(['sandbox_pair_id', 'token_hash', 'generation', 'expires_at', 'used_at', 'revoked_at'])]
+class SandboxBootstrapToken extends Model
+{
+    use HasUlids;
+
+    /** @return BelongsTo<SandboxPair, $this> */
+    public function sandboxPair(): BelongsTo
+    {
+        return $this->belongsTo(SandboxPair::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'generation' => 'integer',
+            'expires_at' => 'datetime',
+            'used_at' => 'datetime',
+            'revoked_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/SandboxPair.php
+++ b/app/Models/SandboxPair.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\SandboxPairStatus;
+use Database\Factories\SandboxPairFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property string $id
+ * @property SandboxPairStatus $status
+ * @property int $generation
+ * @property Carbon|null $activated_at
+ * @property Carbon $expires_at
+ * @property Carbon|null $failed_at
+ * @property Carbon|null $purged_at
+ * @property-read Collection<int, Organisation> $organisations
+ */
+#[Fillable(['status', 'generation', 'activated_at', 'expires_at', 'failed_at', 'purged_at'])]
+class SandboxPair extends Model
+{
+    /** @use HasFactory<SandboxPairFactory> */
+    use HasFactory, HasUuids;
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    /** @return HasMany<Organisation, $this> */
+    public function organisations(): HasMany
+    {
+        return $this->hasMany(Organisation::class);
+    }
+
+    /** @return HasMany<SandboxBootstrapToken, $this> */
+    public function bootstrapTokens(): HasMany
+    {
+        return $this->hasMany(SandboxBootstrapToken::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'status' => SandboxPairStatus::class,
+            'generation' => 'integer',
+            'activated_at' => 'datetime',
+            'expires_at' => 'datetime',
+            'failed_at' => 'datetime',
+            'purged_at' => 'datetime',
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\EnforceAbsoluteSessionLifetime;
+use App\Http\Middleware\EnforceDemoSandbox;
 use App\Http\Middleware\EnsureInstallationAccess;
 use App\Http\Middleware\EnsureTrustedApplicationHost;
 use App\Http\Middleware\HandleAppearance;
@@ -27,6 +28,7 @@ return Application::configure(basePath: dirname(__DIR__))
         ], append: [
             EnsureInstallationAccess::class,
             EnforceAbsoluteSessionLifetime::class,
+            EnforceDemoSandbox::class,
             ProtectSensitiveFortifyRoutes::class,
             HandleAppearance::class,
             HandleInertiaRequests::class,

--- a/config/demo_sandbox.php
+++ b/config/demo_sandbox.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'enabled' => in_array(env('APP_ENV'), ['local', 'demo'], true)
+        && env('DEMO_SANDBOX_ENABLED', true),
+    'maximum_lifetime_hours' => 24,
+];

--- a/database/factories/SandboxPairFactory.php
+++ b/database/factories/SandboxPairFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\SandboxPairStatus;
+use App\Models\SandboxPair;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SandboxPair>
+ */
+class SandboxPairFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'status' => SandboxPairStatus::Ready,
+            'generation' => 1,
+            'expires_at' => now()->addHours(12),
+        ];
+    }
+}

--- a/database/migrations/2026_08_31_160156_create_sandbox_pairs_and_bootstrap_tokens.php
+++ b/database/migrations/2026_08_31_160156_create_sandbox_pairs_and_bootstrap_tokens.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('sandbox_pairs', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('status')->index();
+            $table->unsignedInteger('generation')->default(1);
+            $table->timestamp('activated_at')->nullable();
+            $table->timestamp('expires_at')->index();
+            $table->timestamp('failed_at')->nullable();
+            $table->timestamp('purged_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::create('sandbox_bootstrap_tokens', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignUuid('sandbox_pair_id')->constrained()->cascadeOnDelete();
+            $table->char('token_hash', 64)->unique();
+            $table->unsignedInteger('generation');
+            $table->timestamp('expires_at')->index();
+            $table->timestamp('used_at')->nullable();
+            $table->timestamp('revoked_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('sandbox_bootstrap_tokens');
+        Schema::dropIfExists('sandbox_pairs');
+    }
+};

--- a/database/migrations/2026_08_31_160157_add_sandbox_metadata_to_organisations.php
+++ b/database/migrations/2026_08_31_160157_add_sandbox_metadata_to_organisations.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('organisations', function (Blueprint $table) {
+            $table->foreignUuid('sandbox_pair_id')->nullable()->after('id')->constrained()->nullOnDelete();
+            $table->string('sandbox_template')->nullable()->after('sandbox_pair_id');
+            $table->unsignedInteger('demo_generation')->default(0)->after('sandbox_template');
+            $table->boolean('is_synthetic')->default(false)->after('demo_generation');
+            $table->index(['sandbox_pair_id', 'demo_generation']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('organisations', function (Blueprint $table) {
+            $table->dropIndex(['sandbox_pair_id', 'demo_generation']);
+            $table->dropConstrainedForeignId('sandbox_pair_id');
+            $table->dropColumn(['sandbox_template', 'demo_generation', 'is_synthetic']);
+        });
+    }
+};

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -2,27 +2,13 @@ import { createInertiaApp } from '@inertiajs/react';
 import { Toaster } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { initializeTheme } from '@/hooks/use-appearance';
-import AppLayout from '@/layouts/app-layout';
-import AuthLayout from '@/layouts/auth-layout';
-import SettingsLayout from '@/layouts/settings/layout';
+import { resolvePageLayout } from '@/page-layout';
 
 const appName = import.meta.env.VITE_APP_NAME || 'Laravel';
 
 void createInertiaApp({
     title: (title) => (title ? `${title} - ${appName}` : appName),
-    layout: (name) => {
-        switch (true) {
-            case name === 'welcome':
-                return null;
-            case name.startsWith('auth/'):
-                return AuthLayout;
-            case name.startsWith('settings/'):
-            case name.startsWith('organisations/'):
-                return [AppLayout, SettingsLayout];
-            default:
-                return AppLayout;
-        }
-    },
+    layout: resolvePageLayout,
     strictMode: true,
     withApp(app) {
         return (

--- a/resources/js/components/demo-sandbox-banner.test.tsx
+++ b/resources/js/components/demo-sandbox-banner.test.tsx
@@ -1,0 +1,41 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DemoSandboxBanner } from './demo-sandbox-banner';
+
+let demoSandbox: {
+    pairId: string | null;
+    expiresAt: string | null;
+} | null;
+
+vi.mock('@inertiajs/react', () => ({
+    usePage: () => ({ props: { demoSandbox } }),
+}));
+
+describe('DemoSandboxBanner', () => {
+    beforeEach(() => {
+        demoSandbox = null;
+    });
+
+    it('identifies a synthetic session and its disabled capabilities', () => {
+        demoSandbox = {
+            pairId: 'sandbox-pair',
+            expiresAt: '2026-08-31T20:00:00Z',
+        };
+
+        render(<DemoSandboxBanner />);
+
+        expect(screen.getByRole('status')).toHaveTextContent(
+            'Synthetic demo data',
+        );
+        expect(screen.getByRole('status')).toHaveTextContent(
+            'uploads, invitations, external messages, payments, and domains are disabled',
+        );
+    });
+
+    it('does not label ordinary sessions as demos', () => {
+        const { container } = render(<DemoSandboxBanner />);
+
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/resources/js/components/demo-sandbox-banner.tsx
+++ b/resources/js/components/demo-sandbox-banner.tsx
@@ -1,0 +1,27 @@
+import { usePage } from '@inertiajs/react';
+import { FlaskConical } from 'lucide-react';
+
+export function DemoSandboxBanner() {
+    const sandbox = usePage().props.demoSandbox;
+
+    if (!sandbox) {
+        return null;
+    }
+
+    return (
+        <div
+            className="border-amber-300 bg-amber-50 px-4 py-2 text-amber-950 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100"
+            role="status"
+            data-test="demo-sandbox-banner"
+        >
+            <div className="mx-auto flex max-w-7xl items-center justify-center gap-2 text-sm font-medium">
+                <FlaskConical className="size-4" aria-hidden="true" />
+                Synthetic demo data · uploads, invitations, external messages,
+                payments, and domains are disabled
+                {sandbox.expiresAt
+                    ? ` · expires ${new Date(sandbox.expiresAt).toLocaleString()}`
+                    : null}
+            </div>
+        </div>
+    );
+}

--- a/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -2,6 +2,7 @@ import { AppContent } from '@/components/app-content';
 import { AppShell } from '@/components/app-shell';
 import { AppSidebar } from '@/components/app-sidebar';
 import { AppSidebarHeader } from '@/components/app-sidebar-header';
+import { DemoSandboxBanner } from '@/components/demo-sandbox-banner';
 import type { AppLayoutProps } from '@/types';
 
 export default function AppSidebarLayout({
@@ -13,6 +14,7 @@ export default function AppSidebarLayout({
             <AppSidebar />
             <AppContent variant="sidebar" className="min-w-0 overflow-x-clip">
                 <AppSidebarHeader breadcrumbs={breadcrumbs} />
+                <DemoSandboxBanner />
                 {children}
             </AppContent>
         </AppShell>

--- a/resources/js/page-layout.test.ts
+++ b/resources/js/page-layout.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/layouts/app-layout', () => ({ default: () => null }));
+vi.mock('@/layouts/auth-layout', () => ({ default: () => null }));
+vi.mock('@/layouts/settings/layout', () => ({ default: () => null }));
+
+import { resolvePageLayout } from './page-layout';
+
+describe('resolvePageLayout', () => {
+    it('keeps the unauthenticated demo persona chooser out of the staff shell', () => {
+        expect(resolvePageLayout('demo/personas')).toBeNull();
+    });
+});

--- a/resources/js/page-layout.ts
+++ b/resources/js/page-layout.ts
@@ -1,0 +1,18 @@
+import AppLayout from '@/layouts/app-layout';
+import AuthLayout from '@/layouts/auth-layout';
+import SettingsLayout from '@/layouts/settings/layout';
+
+export function resolvePageLayout(name: string) {
+    switch (true) {
+        case name === 'welcome':
+        case name.startsWith('demo/'):
+            return null;
+        case name.startsWith('auth/'):
+            return AuthLayout;
+        case name.startsWith('settings/'):
+        case name.startsWith('organisations/'):
+            return [AppLayout, SettingsLayout];
+        default:
+            return AppLayout;
+    }
+}

--- a/resources/js/pages/demo/personas.tsx
+++ b/resources/js/pages/demo/personas.tsx
@@ -1,0 +1,77 @@
+import { Form, Head } from '@inertiajs/react';
+import { FlaskConical } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import { store } from '@/routes/demo/personas';
+
+type Persona = {
+    membershipId: number;
+    name: string;
+    organisation: string;
+    role: string;
+};
+
+export default function DemoPersonas({ personas }: { personas: Persona[] }) {
+    return (
+        <main className="bg-muted/30 min-h-screen px-4 py-12">
+            <Head title="Choose a demo persona" />
+            <div className="mx-auto max-w-5xl space-y-8">
+                <div className="space-y-3 text-center">
+                    <FlaskConical
+                        className="mx-auto size-10 text-amber-600"
+                        aria-hidden="true"
+                    />
+                    <h1 className="text-3xl font-semibold">
+                        Choose a synthetic demo persona
+                    </h1>
+                    <p className="text-muted-foreground">
+                        No personal details are collected. Demo access cannot
+                        reach real Organisations or enable uploads, invitations,
+                        external messaging, payments, or domains.
+                    </p>
+                </div>
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                    {personas.map((persona) => (
+                        <Card key={persona.membershipId}>
+                            <CardHeader>
+                                <CardTitle className="text-lg">
+                                    {persona.role}
+                                </CardTitle>
+                                <CardDescription>
+                                    {persona.organisation}
+                                </CardDescription>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                                <p className="text-sm">{persona.name}</p>
+                                <Form {...store.form()}>
+                                    {({ processing }) => (
+                                        <>
+                                            <input
+                                                type="hidden"
+                                                name="membership_id"
+                                                value={persona.membershipId}
+                                            />
+                                            <Button
+                                                className="w-full"
+                                                type="submit"
+                                                disabled={processing}
+                                            >
+                                                Continue as this persona
+                                            </Button>
+                                        </>
+                                    )}
+                                </Form>
+                            </CardContent>
+                        </Card>
+                    ))}
+                </div>
+            </div>
+        </main>
+    );
+}

--- a/resources/js/pages/organisations/edit.tsx
+++ b/resources/js/pages/organisations/edit.tsx
@@ -1,4 +1,4 @@
-import { Form, Head, router } from '@inertiajs/react';
+import { Form, Head, router, usePage } from '@inertiajs/react';
 import { Mail, Plus, ShieldAlert, UserPlus, X } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import CancelInvitationModal from '@/components/cancel-invitation-modal';
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/tooltip';
 import { useInitials } from '@/hooks/use-initials';
 import { edit, index, update } from '@/routes/organisations';
+import { reset as resetDemoOrganisation } from '@/routes/demo/organisations';
 import { update as updateLifecycle } from '@/routes/organisations/lifecycle';
 import { update as updateMember } from '@/routes/organisations/members';
 import {
@@ -73,6 +74,7 @@ export default function OrganisationEdit({
     accessHolds,
 }: Props) {
     const getInitials = useInitials();
+    const demoSandbox = usePage().props.demoSandbox;
 
     const [inviteDialogOpen, setInviteDialogOpen] = useState(false);
     const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -259,6 +261,38 @@ export default function OrganisationEdit({
                                 </Form>
                             ))}
                         </div>
+                    </div>
+                ) : null}
+
+                {demoSandbox &&
+                organisation.isSynthetic &&
+                permissions.canUpdateOrganisation ? (
+                    <div className="space-y-6 rounded-lg border border-amber-300 bg-amber-50 p-5 dark:border-amber-800 dark:bg-amber-950">
+                        <Heading
+                            variant="small"
+                            title="Reset this demo Organisation"
+                            description="Replaces only this Organisation with its pinned synthetic scenario and invalidates its current sessions and queued work."
+                        />
+                        <Form
+                            {...resetDemoOrganisation.form(organisation.slug)}
+                        >
+                            {({ processing }) => (
+                                <>
+                                    <input
+                                        type="hidden"
+                                        name="slug"
+                                        value={organisation.slug}
+                                    />
+                                    <Button
+                                        type="submit"
+                                        variant="outline"
+                                        disabled={processing}
+                                    >
+                                        Reset {organisation.name}
+                                    </Button>
+                                </>
+                            )}
+                        </Form>
                     </div>
                 ) : null}
 

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -23,6 +23,10 @@ declare module '@inertiajs/core' {
             canViewAudit: boolean;
             currentOrganisation: Organisation | null;
             organisations: Organisation[];
+            demoSandbox: {
+                pairId: string | null;
+                expiresAt: string | null;
+            } | null;
             [key: string]: unknown;
         };
     }

--- a/resources/js/types/organisations.ts
+++ b/resources/js/types/organisations.ts
@@ -15,6 +15,8 @@ export type Organisation = {
     status?: string;
     programIds?: number[];
     isCurrent?: boolean;
+    isSynthetic?: boolean;
+    demoGeneration?: number;
 };
 
 export type OrganisationMember = {

--- a/routes/console.php
+++ b/routes/console.php
@@ -29,3 +29,13 @@ Schedule::command('audit:digest:verify')
     ->dailyAt('01:00')
     ->onOneServer()
     ->withoutOverlapping(60);
+
+Schedule::command('demo:sandbox:expire')
+    ->hourly()
+    ->onOneServer()
+    ->withoutOverlapping(10);
+
+Schedule::command('demo:sandbox:purge')
+    ->daily()
+    ->onOneServer()
+    ->withoutOverlapping(60);

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,9 @@
 <?php
 
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\Demo\SandboxBootstrapController;
+use App\Http\Controllers\Demo\SandboxOrganisationController;
+use App\Http\Controllers\Demo\SandboxPersonaController;
 use App\Http\Controllers\Organisations\AudienceSegmentController;
 use App\Http\Controllers\Organisations\CaseAssignmentController;
 use App\Http\Controllers\Organisations\CaseConfidentialityController;
@@ -29,6 +32,7 @@ use App\Http\Controllers\Public\DonationController as PublicDonationController;
 use App\Http\Controllers\Public\OrganisationController as PublicOrganisationController;
 use App\Http\Middleware\EnsureOrganisationAccess;
 use App\Http\Middleware\EnsureOrganisationMembership;
+use App\Http\Middleware\EnsureRecentPassword;
 use App\Http\Middleware\EnsureStaffSecurityRequirements;
 use App\Http\Middleware\ResolvePublicOrganisation;
 use App\Http\Middleware\UseOrganisationContext;
@@ -75,6 +79,10 @@ Route::domain('{public_organisation}.'.config('organisations.public_domain'))
 
 Route::inertia('/', 'welcome')->name('home');
 Route::model('current_organisation', Organisation::class);
+
+Route::get('/demo/bootstrap/{token}', SandboxBootstrapController::class)->middleware('throttle:30,1')->name('demo.bootstrap');
+Route::get('/demo/personas', [SandboxPersonaController::class, 'index'])->name('demo.personas.index');
+Route::post('/demo/personas', [SandboxPersonaController::class, 'store'])->middleware('throttle:30,1')->name('demo.personas.store');
 
 Route::get('/.well-known/security.txt', $securityText)->name('security.txt');
 
@@ -132,6 +140,9 @@ Route::prefix('{current_organisation}')
     });
 
 Route::middleware(['auth', 'verified'])->group(function () {
+    Route::post('settings/organisations/{organisation}/demo-reset', [SandboxOrganisationController::class, 'reset'])
+        ->middleware([EnsureStaffSecurityRequirements::class, EnsureRecentPassword::class, EnsureOrganisationMembership::class, UseOrganisationContext::class, EnsureOrganisationAccess::class.':administration'])
+        ->name('demo.organisations.reset');
     Route::post('invitations/{invitation}/accept', [OrganisationInvitationController::class, 'accept'])->name('invitations.accept');
     Route::delete('invitations/{invitation}', [OrganisationInvitationController::class, 'decline'])->name('invitations.decline');
 });

--- a/tests/Feature/DemoSandboxTest.php
+++ b/tests/Feature/DemoSandboxTest.php
@@ -1,0 +1,207 @@
+<?php
+
+use App\Actions\Demo\ExpireSandboxPair;
+use App\Actions\Demo\ProvisionSandboxPair;
+use App\Actions\Demo\PurgeSandboxPair;
+use App\Enums\OrganisationRole;
+use App\Enums\OrganisationStatus;
+use App\Enums\SandboxPairStatus;
+use App\Enums\TenantAuditEventType;
+use App\Exceptions\ClassifiedDataUnavailable;
+use App\Models\Membership;
+use App\Models\Organisation;
+use App\Models\Program;
+use App\Models\SandboxBootstrapToken;
+use App\Models\SandboxPair;
+use App\Models\TenantAuditEvent;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+beforeEach(function () {
+    config(['demo_sandbox.enabled' => true]);
+});
+
+it('provisions a confined pair through a single-use hashed bootstrap and audited persona', function () {
+    $result = app(ProvisionSandboxPair::class)->handle(12);
+    $pair = $result['pair']->refresh();
+    $plainTextToken = $result['token'];
+    $bootstrap = SandboxBootstrapToken::query()->sole();
+
+    expect($pair->status)->toBe(SandboxPairStatus::Ready)
+        ->and($pair->expires_at->diffInHours(now()))->toBeLessThanOrEqual(12)
+        ->and($pair->organisations)->toHaveCount(2)
+        ->and($pair->organisations->every(fn (Organisation $organisation): bool => $organisation->is_synthetic))->toBeTrue()
+        ->and($bootstrap->token_hash)->toBe(hash('sha256', $plainTextToken))
+        ->and($bootstrap->getAttributes())->not->toContain($plainTextToken);
+
+    $this->get(route('demo.bootstrap', ['token' => $plainTextToken]))
+        ->assertRedirect(route('demo.personas.index'))
+        ->assertHeader('Referrer-Policy', 'no-referrer')
+        ->assertHeader('Cache-Control', 'no-store, private');
+
+    expect($bootstrap->refresh()->used_at)->not->toBeNull()
+        ->and($pair->refresh()->status)->toBe(SandboxPairStatus::Active);
+
+    $this->artisan('demo:sandbox:token', ['pair' => $pair->id])
+        ->expectsOutputToContain('/demo/bootstrap/')
+        ->assertSuccessful();
+    $this->artisan('demo:sandbox:token', ['pair' => $pair->id])->assertSuccessful();
+    expect($pair->bootstrapTokens()->count())->toBe(3)
+        ->and($pair->bootstrapTokens()->whereNull('used_at')->whereNull('revoked_at')->count())->toBe(1);
+
+    $this->get(route('demo.bootstrap', ['token' => $plainTextToken]))->assertGone();
+    $this->get(route('demo.personas.index'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('demo/personas')
+            ->has('personas', 5));
+
+    $harbourKind = $pair->organisations()->where('sandbox_template', 'harbourkind')->firstOrFail();
+    $administrator = Membership::query()->findOrFail((int) DB::table('role_assignments')
+        ->where('organisation_id', $harbourKind->id)
+        ->whereNull('program_id')
+        ->where('role', OrganisationRole::OrganisationAdministrator)
+        ->value('membership_id'));
+
+    $this->post(route('demo.personas.store'), ['membership_id' => $administrator->id])
+        ->assertRedirect(route('dashboard', ['current_organisation' => $harbourKind]))
+        ->assertSessionHas('auth.password_confirmed_at');
+    $this->assertAuthenticatedAs($administrator->user);
+
+    expect(TenantAuditEvent::withoutGlobalScopes()->where('type', TenantAuditEventType::DemoPersonaSelected)->sole()->payload)
+        ->toMatchArray(['membership_id' => $administrator->id, 'generation' => 1]);
+
+    $unrelated = Organisation::factory()->active()->create();
+    $unrelated->members()->attach($administrator->user, ['role' => OrganisationRole::OrganisationAdministrator]);
+    $this->get(route('dashboard', ['current_organisation' => $unrelated]))->assertNotFound();
+    $this->post(route('organisations.invitations.store', ['organisation' => $harbourKind]))->assertForbidden();
+    $this->patch(route('profile.update'), ['name' => 'Evaluator', 'email' => 'evaluator@example.com'])->assertForbidden();
+    $this->get("https://{$harbourKind->slug}.community-kind.test/")->assertOk();
+    $this->get("https://{$unrelated->slug}.community-kind.test/")->assertNotFound();
+});
+
+it('resets only the selected Organisation and invalidates its generation', function () {
+    $result = app(ProvisionSandboxPair::class)->handle();
+    $pair = $result['pair'];
+    $this->get(route('demo.bootstrap', ['token' => $result['token']]))->assertRedirect();
+    $harbourKind = $pair->organisations()->where('sandbox_template', 'harbourkind')->firstOrFail();
+    $neighbourLink = $pair->organisations()->where('sandbox_template', 'neighbourlink')->firstOrFail();
+    $administrator = Membership::query()->findOrFail((int) DB::table('role_assignments')
+        ->where('organisation_id', $harbourKind->id)
+        ->whereNull('program_id')
+        ->where('role', OrganisationRole::OrganisationAdministrator)
+        ->value('membership_id'));
+    $caseWorker = Membership::query()->findOrFail((int) DB::table('role_assignments')
+        ->where('organisation_id', $harbourKind->id)
+        ->where('role', OrganisationRole::CaseWorker)
+        ->orderBy('id')
+        ->value('membership_id'));
+    $this->post(route('demo.personas.store'), ['membership_id' => $caseWorker->id])->assertRedirect();
+    $this->post(route('demo.organisations.reset', ['organisation' => $harbourKind]), [
+        'slug' => $harbourKind->slug,
+    ])->assertForbidden();
+    $this->post(route('demo.personas.store'), ['membership_id' => $administrator->id])->assertRedirect();
+    $unrelated = Organisation::factory()->active()->create();
+    app(OrganisationContext::class)->run(
+        $neighbourLink,
+        fn () => Program::factory()->create(['organisation_id' => $neighbourLink->id]),
+    );
+
+    $response = $this->post(route('demo.organisations.reset', ['organisation' => $harbourKind]), [
+        'slug' => $harbourKind->slug,
+    ]);
+
+    $replacement = $pair->organisations()->where('sandbox_template', 'harbourkind')->firstOrFail();
+    $response->assertRedirectContains('/demo/bootstrap/');
+    expect($replacement->id)->not->toBe($harbourKind->id)
+        ->and($replacement->slug)->toBe($harbourKind->slug)
+        ->and($replacement->demo_generation)->toBe(2)
+        ->and($harbourKind->refresh()->sandbox_pair_id)->toBe($pair->id)
+        ->and($harbourKind->status)->toBe(OrganisationStatus::Deleted)
+        ->and($harbourKind->trashed())->toBeTrue()
+        ->and($pair->organisations()->count())->toBe(2)
+        ->and($pair->organisations()->withTrashed()->count())->toBe(3)
+        ->and($pair->organisations()->whereKey($neighbourLink->id)->exists())->toBeTrue()
+        ->and(DB::table('programs')->where('organisation_id', $neighbourLink->id)->whereNull('deleted_at')->count())->toBe(2)
+        ->and(Organisation::query()->whereKey($unrelated->id)->exists())->toBeTrue()
+        ->and(TenantAuditEvent::withoutGlobalScopes()->where('type', TenantAuditEventType::DemoOrganisationReset)->count())->toBe(1);
+
+    app(ExpireSandboxPair::class)->handle($pair->refresh());
+    app(PurgeSandboxPair::class)->handle($pair->refresh());
+
+    expect(User::query()->findOrFail($administrator->user_id)->email)->toStartWith('purged-sandbox-')
+        ->and($pair->refresh()->status)->toBe(SandboxPairStatus::Purged);
+});
+
+it('expires sessions and idempotently purges only synthetic sandbox identities', function () {
+    $pair = SandboxPair::factory()->create([
+        'status' => SandboxPairStatus::Active,
+        'expires_at' => now()->subMinute(),
+    ]);
+    $organisation = Organisation::factory()->active()->create([
+        'sandbox_pair_id' => $pair->id,
+        'sandbox_template' => 'harbourkind',
+        'demo_generation' => 1,
+        'is_synthetic' => true,
+    ]);
+    $user = User::query()->create([
+        'name' => 'Synthetic Sandbox Administrator',
+        'email' => 'administrator+sandbox@example.test',
+        'password' => 'password',
+        'current_organisation_id' => $organisation->id,
+        'email_verified_at' => now(),
+    ]);
+    $organisation->members()->attach($user, ['role' => OrganisationRole::OrganisationAdministrator]);
+    $token = SandboxBootstrapToken::query()->create([
+        'sandbox_pair_id' => $pair->id,
+        'token_hash' => hash('sha256', 'token'),
+        'generation' => 1,
+        'expires_at' => now()->subMinute(),
+    ]);
+    DB::table('sessions')->insert([
+        'id' => 'sandbox-session',
+        'user_id' => $user->id,
+        'payload' => '',
+        'last_activity' => now()->timestamp,
+    ]);
+
+    app(ExpireSandboxPair::class)->handle($pair);
+
+    expect($pair->refresh()->status)->toBe(SandboxPairStatus::Expired)
+        ->and($pair->generation)->toBe(2)
+        ->and($organisation->refresh()->status)->toBe(OrganisationStatus::Archived)
+        ->and($token->refresh()->revoked_at)->not->toBeNull()
+        ->and(DB::table('sessions')->where('id', 'sandbox-session')->exists())->toBeFalse();
+
+    app(PurgeSandboxPair::class)->handle($pair);
+    app(PurgeSandboxPair::class)->handle($pair->refresh());
+
+    expect($pair->refresh()->status)->toBe(SandboxPairStatus::Purged)
+        ->and($pair->purged_at)->not->toBeNull()
+        ->and(Organisation::withTrashed()->findOrFail($organisation->id)->trashed())->toBeTrue()
+        ->and(SandboxBootstrapToken::query()->whereKey($token->id)->exists())->toBeFalse()
+        ->and(User::query()->findOrFail($user->id)->email)->toStartWith('purged-sandbox-')
+        ->and($user->refresh()->current_organisation_id)->toBeNull();
+});
+
+it('does not expose sandbox provisioning outside explicitly enabled environments', function () {
+    config(['demo_sandbox.enabled' => false]);
+
+    expect(fn () => app(ProvisionSandboxPair::class)->handle())
+        ->toThrow(NotFoundHttpException::class);
+});
+
+it('fails closed without exposing a partially provisioned sandbox', function () {
+    config(['classified_data.encryption.keys' => []]);
+
+    expect(fn () => app(ProvisionSandboxPair::class)->handle())
+        ->toThrow(ClassifiedDataUnavailable::class, 'Classified data is unavailable.');
+
+    $pair = SandboxPair::query()->sole();
+    expect($pair->status)->toBe(SandboxPairStatus::Failed)
+        ->and($pair->status->isAccessible())->toBeFalse()
+        ->and($pair->bootstrapTokens()->count())->toBe(0);
+});


### PR DESCRIPTION
Closes #22

## Summary
- provision isolated HarbourKind and NeighbourLink sandbox pairs with hashed, single-use, expiring bootstrap links and audited persona selection
- confine demo sessions, disable dangerous capabilities, expose synthetic-data banners, and bypass MFA only for validated demo sessions
- reset one Organisation with generation invalidation and exact reconciliation, then expire and dependency-safely purge all sandbox generations
- keep the unauthenticated persona chooser outside the authenticated layout so Inertia SSR renders safely

## Verification
- composer ci:check (PostgreSQL 18: 327 tests, 1,995 assertions; PHPStan and Pint pass)
- npm test (4 files, 5 tests)
- npm run build:ssr
- npm run licenses:check
- local Valet bootstrap and persona chooser smoke test