### PR TITLE
Let verified supporters manage their profile and preferences

### DIFF
--- a/app/Actions/Auditing/BuildTenantAuditView.php
+++ b/app/Actions/Auditing/BuildTenantAuditView.php
@@ -111,7 +111,13 @@ class BuildTenantAuditView
             TenantAuditEventType::DonationRefunded,
             TenantAuditEventType::RecurringMandateTransitioned => 'fundraising',
             TenantAuditEventType::AudienceSegmentCreated,
-            TenantAuditEventType::ImpactReportExported => 'engagement',
+            TenantAuditEventType::ImpactReportExported,
+            TenantAuditEventType::PortalAccessIssued,
+            TenantAuditEventType::PortalAccessVerified,
+            TenantAuditEventType::PortalAccessRevoked,
+            TenantAuditEventType::SupporterProfileUpdated,
+            TenantAuditEventType::SupporterConsentPreferencesUpdated,
+            TenantAuditEventType::SupporterRegistrationCancelled => 'engagement',
             default => 'service',
         };
     }

--- a/app/Actions/Portal/CancelSupporterRegistration.php
+++ b/app/Actions/Portal/CancelSupporterRegistration.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Actions\Portal;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Actions\Parties\RecordPartyTimelineEvent;
+use App\Enums\PartyTimelineEventType;
+use App\Enums\SupporterRegistrationStatus;
+use App\Enums\TenantAuditEventType;
+use App\Models\PortalAccessGrant;
+use App\Models\SupporterRegistration;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+
+final class CancelSupporterRegistration
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly RecordPartyTimelineEvent $recordTimeline,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    public function handle(PortalAccessGrant $grant, SupporterRegistration $registration): SupporterRegistration
+    {
+        $this->context->ensureOwns($grant->organisation_id);
+        abort_unless($grant->hasActiveAccess(), 410);
+
+        return DB::transaction(function () use ($grant, $registration): SupporterRegistration {
+            $locked = SupporterRegistration::query()
+                ->whereKey($registration->id)
+                ->where('organisation_id', $grant->organisation_id)
+                ->where('party_id', $grant->person_party_id)
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            abort_unless($locked->status->canCancel(), 422, 'This registration can no longer be cancelled.');
+
+            $locked->update([
+                'status' => SupporterRegistrationStatus::Cancelled,
+                'version' => $locked->version + 1,
+                'cancelled_at' => now(),
+            ]);
+            $this->recordTimeline->handle(
+                $grant->personParty,
+                PartyTimelineEventType::SupporterRegistrationTransitioned,
+                "Supporter cancelled {$locked->title}.",
+                $grant->user,
+                'supporter_registration',
+                $locked->id,
+                ['status' => SupporterRegistrationStatus::Cancelled->value],
+            );
+            $this->recordAudit->handle(
+                $grant->organisation,
+                TenantAuditEventType::SupporterRegistrationCancelled,
+                'supporter_registration',
+                $locked->id,
+                [
+                    'registration_id' => $locked->id,
+                    'party_uuid' => $grant->personParty->uuid,
+                    'kind' => $locked->kind->value,
+                ],
+                $grant->user,
+            );
+
+            return $locked->refresh();
+        });
+    }
+}

--- a/app/Actions/Portal/IssuePortalAccessGrant.php
+++ b/app/Actions/Portal/IssuePortalAccessGrant.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Actions\Portal;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Enums\PartyKind;
+use App\Enums\TenantAuditEventType;
+use App\Models\Party;
+use App\Models\PortalAccessGrant;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use LogicException;
+
+final class IssuePortalAccessGrant
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    /** @return array{grant: PortalAccessGrant, token: string} */
+    public function handle(Party $party, User $user, User $actor): array
+    {
+        $this->context->ensureOwns($party->organisation_id);
+
+        if ($party->kind !== PartyKind::Person || $party->trashed()) {
+            throw new LogicException('Portal access requires an active Person Party.');
+        }
+
+        if (! $user->hasVerifiedEmail()) {
+            throw new LogicException('Portal access requires a verified User.');
+        }
+
+        return DB::transaction(function () use ($actor, $party, $user): array {
+            $party = Party::query()->lockForUpdate()->findOrFail($party->id);
+            $user = User::query()->lockForUpdate()->findOrFail($user->id);
+            if (! $user->hasVerifiedEmail()) {
+                throw new LogicException('Portal access requires a verified User.');
+            }
+
+            $replacedGrants = PortalAccessGrant::query()
+                ->where(fn ($query) => $query
+                    ->where('person_party_id', $party->id)
+                    ->orWhere('user_id', $user->id))
+                ->whereNull('revoked_at')
+                ->lockForUpdate()
+                ->get();
+            $replacedGrants->each(function (PortalAccessGrant $grant) use ($actor, $party): void {
+                $grant->update([
+                    'revoked_at' => now(),
+                    'revoked_by_user_id' => $actor->id,
+                    'access_version' => $grant->access_version + 1,
+                ]);
+                $this->recordAudit->handle(
+                    $party->organisation,
+                    TenantAuditEventType::PortalAccessRevoked,
+                    'portal_access_grant',
+                    $grant->id,
+                    [
+                        'grant_id' => $grant->id,
+                        'party_uuid' => $grant->personParty->uuid,
+                        'user_id' => $grant->user_id,
+                    ],
+                    $actor,
+                );
+            });
+
+            $plainTextToken = Str::random(64);
+            $grant = PortalAccessGrant::query()->create([
+                'organisation_id' => $party->organisation_id,
+                'user_id' => $user->id,
+                'person_party_id' => $party->id,
+                'token_hash' => hash('sha256', $plainTextToken),
+                'access_version' => 1,
+                'token_expires_at' => now()->addMinutes((int) config('portal.link_lifetime_minutes')),
+                'created_by_user_id' => $actor->id,
+            ]);
+
+            $this->recordAudit->handle(
+                $party->organisation,
+                TenantAuditEventType::PortalAccessIssued,
+                'portal_access_grant',
+                $grant->id,
+                [
+                    'grant_id' => $grant->id,
+                    'party_uuid' => $party->uuid,
+                    'user_id' => $user->id,
+                    'expires_at' => $grant->token_expires_at->toAtomString(),
+                ],
+                $actor,
+            );
+
+            return ['grant' => $grant, 'token' => $plainTextToken];
+        });
+    }
+}

--- a/app/Actions/Portal/ResolvePortalAccess.php
+++ b/app/Actions/Portal/ResolvePortalAccess.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Actions\Portal;
+
+use App\Models\Organisation;
+use App\Models\PortalAccessGrant;
+use App\Models\User;
+
+final class ResolvePortalAccess
+{
+    public function handle(string $grantId, int $accessVersion, Organisation $organisation, User $user): PortalAccessGrant
+    {
+        $grant = PortalAccessGrant::query()
+            ->with(['personParty', 'user'])
+            ->whereKey($grantId)
+            ->where('organisation_id', $organisation->id)
+            ->where('user_id', $user->id)
+            ->where('access_version', $accessVersion)
+            ->firstOrFail();
+
+        abort_unless($grant->hasActiveAccess(), 410, 'This portal access is no longer available.');
+
+        return $grant;
+    }
+}

--- a/app/Actions/Portal/RevokePortalAccessGrant.php
+++ b/app/Actions/Portal/RevokePortalAccessGrant.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Actions\Portal;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Actions\Parties\RecordPartyTimelineEvent;
+use App\Enums\PartyTimelineEventType;
+use App\Enums\TenantAuditEventType;
+use App\Models\PortalAccessGrant;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+
+final class RevokePortalAccessGrant
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly RecordPartyTimelineEvent $recordTimeline,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    public function handle(PortalAccessGrant $grant): void
+    {
+        $this->context->ensureOwns($grant->organisation_id);
+
+        DB::transaction(function () use ($grant): void {
+            $locked = PortalAccessGrant::query()->with(['organisation', 'personParty', 'user'])
+                ->whereKey($grant->id)
+                ->where('user_id', $grant->user_id)
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            if ($locked->revoked_at !== null) {
+                return;
+            }
+
+            $locked->update([
+                'revoked_at' => now(),
+                'revoked_by_user_id' => $locked->user_id,
+                'access_version' => $locked->access_version + 1,
+            ]);
+            $this->recordTimeline->handle(
+                $locked->personParty,
+                PartyTimelineEventType::PortalAccessChanged,
+                'Supporter revoked their portal access.',
+                $locked->user,
+                'portal_access_grant',
+                $locked->id,
+                ['status' => 'revoked'],
+            );
+            $this->recordAudit->handle(
+                $locked->organisation,
+                TenantAuditEventType::PortalAccessRevoked,
+                'portal_access_grant',
+                $locked->id,
+                [
+                    'grant_id' => $locked->id,
+                    'party_uuid' => $locked->personParty->uuid,
+                    'user_id' => $locked->user_id,
+                ],
+                $locked->user,
+            );
+        });
+    }
+}

--- a/app/Actions/Portal/UpdatePortalConsentPreferences.php
+++ b/app/Actions/Portal/UpdatePortalConsentPreferences.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Actions\Portal;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Actions\Parties\RecordPartyConsent;
+use App\Enums\ConsentChannel;
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use App\Enums\TenantAuditEventType;
+use App\Models\PartyConsent;
+use App\Models\PortalAccessGrant;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+
+final class UpdatePortalConsentPreferences
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly RecordPartyConsent $recordConsent,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    /** @param list<ConsentChannel> $enabledChannels */
+    public function handle(PortalAccessGrant $grant, array $enabledChannels): void
+    {
+        $this->context->ensureOwns($grant->organisation_id);
+        abort_unless($grant->hasActiveAccess(), 410);
+
+        DB::transaction(function () use ($enabledChannels, $grant): void {
+            $party = $grant->personParty()->lockForUpdate()->firstOrFail();
+            $changedChannels = [];
+
+            foreach ([ConsentChannel::Email, ConsentChannel::Sms, ConsentChannel::Telephone] as $channel) {
+                $latest = PartyConsent::query()
+                    ->where('party_id', $party->id)
+                    ->where('purpose', ConsentPurpose::SupporterUpdates)
+                    ->where('channel', $channel)
+                    ->latest('occurred_at')
+                    ->latest('id')
+                    ->first();
+                $enabled = in_array($channel, $enabledChannels, true);
+
+                if (($latest?->decision === ConsentDecision::Granted) === $enabled) {
+                    continue;
+                }
+
+                $decision = $enabled
+                    ? ConsentDecision::Granted
+                    : ($latest?->decision === ConsentDecision::Granted
+                        ? ConsentDecision::Withdrawn
+                        : ConsentDecision::Suppressed);
+
+                $this->recordConsent->handle($party, [
+                    'purpose' => ConsentPurpose::SupporterUpdates,
+                    'channel' => $channel,
+                    'decision' => $decision,
+                    'wording_version' => 'supporter-portal-v1',
+                    'wording' => 'I choose whether to receive supporter updates through this channel.',
+                    'source' => 'supporter_portal',
+                    'occurred_at' => now()->toAtomString(),
+                ], $grant->user);
+                $changedChannels[] = $channel->value;
+            }
+
+            if ($changedChannels !== []) {
+                $this->recordAudit->handle(
+                    $party->organisation,
+                    TenantAuditEventType::SupporterConsentPreferencesUpdated,
+                    'party',
+                    $party->uuid,
+                    ['party_uuid' => $party->uuid, 'channels' => $changedChannels],
+                    $grant->user,
+                );
+            }
+        });
+    }
+}

--- a/app/Actions/Portal/UpdatePortalProfile.php
+++ b/app/Actions/Portal/UpdatePortalProfile.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Actions\Portal;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Actions\Parties\RecordPartyTimelineEvent;
+use App\Actions\Parties\SyncPartyContacts;
+use App\Enums\PartyContactType;
+use App\Enums\PartyTimelineEventType;
+use App\Enums\TenantAuditEventType;
+use App\Models\Party;
+use App\Models\PartyContactPoint;
+use App\Models\PortalAccessGrant;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+
+final class UpdatePortalProfile
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly SyncPartyContacts $syncContacts,
+        private readonly RecordPartyTimelineEvent $recordTimeline,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    /** @param array{display_name: string, email: string|null, telephone: string|null} $attributes */
+    public function handle(PortalAccessGrant $grant, array $attributes): Party
+    {
+        $this->context->ensureOwns($grant->organisation_id);
+        abort_unless($grant->hasActiveAccess(), 410);
+
+        return DB::transaction(function () use ($attributes, $grant): Party {
+            $party = Party::query()->lockForUpdate()->findOrFail($grant->person_party_id);
+            $changedFields = [];
+
+            if ($party->display_name !== $attributes['display_name']) {
+                $party->update(['display_name' => $attributes['display_name']]);
+                $changedFields[] = 'display_name';
+            }
+
+            foreach ([PartyContactType::Email, PartyContactType::Telephone] as $type) {
+                $current = PartyContactPoint::query()
+                    ->where('party_id', $party->id)
+                    ->where('type', $type)
+                    ->first()?->encrypted_value->reveal();
+                $next = $attributes[$type === PartyContactType::Email ? 'email' : 'telephone'];
+
+                if ($current !== $next) {
+                    $changedFields[] = $type->value;
+                }
+            }
+
+            $this->syncContacts->handle($party, [
+                'email' => $attributes['email'],
+                'telephone' => $attributes['telephone'],
+            ]);
+
+            if ($changedFields !== []) {
+                $this->recordTimeline->handle(
+                    $party,
+                    PartyTimelineEventType::ProfileUpdated,
+                    'Supporter updated their portal profile.',
+                    $grant->user,
+                    'portal_access_grant',
+                    $grant->id,
+                    ['changed_fields' => implode(',', $changedFields)],
+                );
+                $this->recordAudit->handle(
+                    $party->organisation,
+                    TenantAuditEventType::SupporterProfileUpdated,
+                    'party',
+                    $party->uuid,
+                    ['party_uuid' => $party->uuid, 'changed_fields' => $changedFields],
+                    $grant->user,
+                );
+            }
+
+            return $party->refresh();
+        });
+    }
+}

--- a/app/Enums/PartyTimelineEventType.php
+++ b/app/Enums/PartyTimelineEventType.php
@@ -17,4 +17,6 @@ enum PartyTimelineEventType: string
     case DonationRefunded = 'donation_refunded';
     case RecurringMandateTransitioned = 'recurring_mandate_transitioned';
     case SupporterJourneyTransitioned = 'supporter_journey_transitioned';
+    case SupporterRegistrationTransitioned = 'supporter_registration_transitioned';
+    case PortalAccessChanged = 'portal_access_changed';
 }

--- a/app/Enums/SupporterRegistrationKind.php
+++ b/app/Enums/SupporterRegistrationKind.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums;
+
+enum SupporterRegistrationKind: string
+{
+    case Volunteer = 'volunteer';
+    case Event = 'event';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Volunteer => 'Volunteer opportunity',
+            self::Event => 'Event',
+        };
+    }
+}

--- a/app/Enums/SupporterRegistrationStatus.php
+++ b/app/Enums/SupporterRegistrationStatus.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Enums;
+
+enum SupporterRegistrationStatus: string
+{
+    case Pending = 'pending';
+    case Confirmed = 'confirmed';
+    case Waitlisted = 'waitlisted';
+    case Cancelled = 'cancelled';
+    case Completed = 'completed';
+
+    public function canCancel(): bool
+    {
+        return in_array($this, [self::Pending, self::Confirmed, self::Waitlisted], true);
+    }
+
+    public function label(): string
+    {
+        return str($this->value)->headline()->toString();
+    }
+}

--- a/app/Enums/TenantAuditEventType.php
+++ b/app/Enums/TenantAuditEventType.php
@@ -27,6 +27,12 @@ enum TenantAuditEventType: string
     case AuditViewAccessed = 'audit_view_accessed';
     case DemoPersonaSelected = 'demo_persona_selected';
     case DemoOrganisationReset = 'demo_organisation_reset';
+    case PortalAccessIssued = 'portal_access_issued';
+    case PortalAccessVerified = 'portal_access_verified';
+    case PortalAccessRevoked = 'portal_access_revoked';
+    case SupporterProfileUpdated = 'supporter_profile_updated';
+    case SupporterConsentPreferencesUpdated = 'supporter_consent_preferences_updated';
+    case SupporterRegistrationCancelled = 'supporter_registration_cancelled';
 
     /** @return array<string, string> */
     public function payloadSchema(): array
@@ -134,6 +140,30 @@ enum TenantAuditEventType: string
             self::DemoOrganisationReset => [
                 'generation' => 'integer',
                 'template' => 'string',
+            ],
+            self::PortalAccessIssued => [
+                'grant_id' => 'string',
+                'party_uuid' => 'string',
+                'user_id' => 'integer',
+                'expires_at' => 'string',
+            ],
+            self::PortalAccessVerified, self::PortalAccessRevoked => [
+                'grant_id' => 'string',
+                'party_uuid' => 'string',
+                'user_id' => 'integer',
+            ],
+            self::SupporterProfileUpdated => [
+                'party_uuid' => 'string',
+                'changed_fields' => 'string_list',
+            ],
+            self::SupporterConsentPreferencesUpdated => [
+                'party_uuid' => 'string',
+                'channels' => 'string_list',
+            ],
+            self::SupporterRegistrationCancelled => [
+                'registration_id' => 'string',
+                'party_uuid' => 'string',
+                'kind' => 'string',
             ],
         };
     }

--- a/app/Http/Controllers/Organisations/PartyController.php
+++ b/app/Http/Controllers/Organisations/PartyController.php
@@ -103,6 +103,7 @@ class PartyController extends Controller
             'timelineEvents' => fn ($query) => $query->latest('occurred_at')->latest('id')->limit(100),
         ]);
         $canManageSafeContact = Gate::allows('manageSafeContact', $party);
+        $canManagePortalAccess = Gate::allows('managePortalAccess', $party);
         $canUpdate = Gate::allows('update', $party);
 
         if ($canManageSafeContact) {
@@ -172,6 +173,8 @@ class PartyController extends Controller
             'canUpdate' => $canUpdate,
             'canRecordConsent' => Gate::allows('recordConsent', $party),
             'canManageSafeContact' => $canManageSafeContact,
+            'canManagePortalAccess' => $canManagePortalAccess,
+            'portalAccessUrl' => $canManagePortalAccess ? $request->session()->get('portal_access_url') : null,
             'relationshipCandidates' => $serviceProjection ? $this->visibleParties($request->user(), $currentOrganisation)
                 ->whereKeyNot($party->id)
                 ->orderBy('display_name')

--- a/app/Http/Controllers/Organisations/PortalAccessGrantController.php
+++ b/app/Http/Controllers/Organisations/PortalAccessGrantController.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Portal\IssuePortalAccessGrant;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\StorePortalAccessGrantRequest;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+
+class PortalAccessGrantController extends Controller
+{
+    public function store(
+        StorePortalAccessGrantRequest $request,
+        Organisation $currentOrganisation,
+        string $party,
+        IssuePortalAccessGrant $issuePortalAccessGrant,
+    ): RedirectResponse {
+        $party = Party::query()->where('uuid', $party)->firstOrFail();
+        Gate::authorize('managePortalAccess', $party);
+        $user = User::query()->where('email', $request->string('email')->toString())->firstOrFail();
+        $issued = $issuePortalAccessGrant->handle($party, $user, $request->user());
+        $url = route('portal.access.use', [
+            'public_organisation' => $currentOrganisation->slug,
+            'token' => $issued['token'],
+        ]);
+
+        $request->session()->flash('portal_access_url', $url);
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Supporter portal link created.')]);
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Portal/PortalAccessController.php
+++ b/app/Http/Controllers/Portal/PortalAccessController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Http\Controllers\Portal;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Actions\Parties\RecordPartyTimelineEvent;
+use App\Actions\Portal\RevokePortalAccessGrant;
+use App\Enums\PartyKind;
+use App\Enums\PartyTimelineEventType;
+use App\Enums\TenantAuditEventType;
+use App\Http\Controllers\Controller;
+use App\Models\Organisation;
+use App\Models\PortalAccessGrant;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+class PortalAccessController extends Controller
+{
+    public function use(
+        Request $request,
+        string $publicOrganisation,
+        string $token,
+        RecordPartyTimelineEvent $recordTimeline,
+        RecordTenantAuditEvent $recordAudit,
+    ): RedirectResponse {
+        $organisation = $request->attributes->get('public_organisation');
+        abort_unless($organisation instanceof Organisation, 404);
+
+        $grant = DB::transaction(function () use ($organisation, $recordAudit, $recordTimeline, $token): PortalAccessGrant {
+            $grant = PortalAccessGrant::query()
+                ->withoutGlobalScopes()
+                ->with(['organisation', 'personParty', 'user'])
+                ->where('organisation_id', $organisation->id)
+                ->where('token_hash', hash('sha256', $token))
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            abort_unless(
+                $grant->revoked_at === null
+                && $grant->token_used_at === null
+                && $grant->token_expires_at->isFuture()
+                && $grant->user->hasVerifiedEmail()
+                && $grant->personParty->kind === PartyKind::Person
+                && ! $grant->personParty->trashed(),
+                410,
+                'This portal link is no longer available.',
+            );
+
+            $grant->update(['verified_at' => now(), 'token_used_at' => now()]);
+            $recordTimeline->handle(
+                $grant->personParty,
+                PartyTimelineEventType::PortalAccessChanged,
+                'Supporter verified their portal access.',
+                $grant->user,
+                'portal_access_grant',
+                $grant->id,
+                ['status' => 'verified'],
+            );
+            $recordAudit->handle(
+                $grant->organisation,
+                TenantAuditEventType::PortalAccessVerified,
+                'portal_access_grant',
+                $grant->id,
+                [
+                    'grant_id' => $grant->id,
+                    'party_uuid' => $grant->personParty->uuid,
+                    'user_id' => $grant->user_id,
+                ],
+                $grant->user,
+            );
+
+            return $grant;
+        });
+
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+        Auth::login($grant->user);
+        $request->session()->regenerate();
+        $request->session()->put('portal_access_grant_id', $grant->id);
+        $request->session()->put('portal_access_version', $grant->access_version);
+
+        return to_route('portal.show', ['public_organisation' => $organisation->slug]);
+    }
+
+    public function destroy(
+        Request $request,
+        string $publicOrganisation,
+        RevokePortalAccessGrant $revokePortalAccessGrant,
+    ): RedirectResponse {
+        $organisation = $request->attributes->get('public_organisation');
+        $grant = $request->attributes->get('portal_access_grant');
+        abort_unless($organisation instanceof Organisation && $grant instanceof PortalAccessGrant, 404);
+
+        $revokePortalAccessGrant->handle($grant);
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return to_route('public.organisations.show', ['public_organisation' => $organisation->slug]);
+    }
+}

--- a/app/Http/Controllers/Portal/PortalConsentPreferenceController.php
+++ b/app/Http/Controllers/Portal/PortalConsentPreferenceController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Portal;
+
+use App\Actions\Portal\UpdatePortalConsentPreferences;
+use App\Enums\ConsentChannel;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Portal\UpdatePortalConsentPreferencesRequest;
+use App\Models\PortalAccessGrant;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+
+class PortalConsentPreferenceController extends Controller
+{
+    public function update(
+        UpdatePortalConsentPreferencesRequest $request,
+        UpdatePortalConsentPreferences $updatePortalConsentPreferences,
+    ): RedirectResponse {
+        $grant = $request->attributes->get('portal_access_grant');
+        abort_unless($grant instanceof PortalAccessGrant, 404);
+        $channels = array_values(array_map(
+            fn (string $channel): ConsentChannel => ConsentChannel::from($channel),
+            $request->array('channels'),
+        ));
+        $updatePortalConsentPreferences->handle($grant, $channels);
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Communication preferences updated.')]);
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Portal/PortalController.php
+++ b/app/Http/Controllers/Portal/PortalController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers\Portal;
+
+use App\Enums\ConsentChannel;
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use App\Enums\PartyContactType;
+use App\Enums\RecurringMandateStatus;
+use App\Http\Controllers\Controller;
+use App\Models\Organisation;
+use App\Models\PartyConsent;
+use App\Models\PartyContactPoint;
+use App\Models\PortalAccessGrant;
+use App\Models\RecurringMandate;
+use App\Models\SupporterRegistration;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class PortalController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     */
+    public function __invoke(Request $request): Response
+    {
+        $organisation = $request->attributes->get('public_organisation');
+        $grant = $request->attributes->get('portal_access_grant');
+        abort_unless($organisation instanceof Organisation && $grant instanceof PortalAccessGrant, 404);
+        $party = $grant->personParty;
+
+        $contacts = PartyContactPoint::query()
+            ->where('party_id', $party->id)
+            ->whereIn('type', [PartyContactType::Email, PartyContactType::Telephone])
+            ->get()
+            ->keyBy(fn (PartyContactPoint $contact): string => $contact->type->value);
+        $preferences = collect([ConsentChannel::Email, ConsentChannel::Sms, ConsentChannel::Telephone])
+            ->mapWithKeys(function (ConsentChannel $channel) use ($party): array {
+                $latest = PartyConsent::query()
+                    ->where('party_id', $party->id)
+                    ->where('purpose', ConsentPurpose::SupporterUpdates)
+                    ->where('channel', $channel)
+                    ->latest('occurred_at')
+                    ->latest('id')
+                    ->first();
+
+                return [$channel->value => $latest?->decision === ConsentDecision::Granted];
+            });
+
+        return Inertia::render('portal/show', [
+            'organisation' => ['name' => $organisation->name, 'slug' => $organisation->slug],
+            'profile' => [
+                'displayName' => $party->display_name,
+                'email' => $contacts->get(PartyContactType::Email->value)?->encrypted_value->reveal(),
+                'telephone' => $contacts->get(PartyContactType::Telephone->value)?->encrypted_value->reveal(),
+            ],
+            'preferences' => $preferences,
+            'recurringMandates' => RecurringMandate::query()
+                ->where('party_id', $party->id)
+                ->latest()
+                ->get()
+                ->map(fn (RecurringMandate $mandate): array => [
+                    'id' => $mandate->id,
+                    'amountMinor' => $mandate->amount_minor,
+                    'currency' => $mandate->currency,
+                    'interval' => $mandate->interval,
+                    'status' => str($mandate->status->value)->headline()->toString(),
+                    'canCancel' => $mandate->status !== RecurringMandateStatus::Cancelled,
+                ]),
+            'registrations' => SupporterRegistration::query()
+                ->where('party_id', $party->id)
+                ->orderByRaw('starts_at asc nulls last')
+                ->get()
+                ->map(fn (SupporterRegistration $registration): array => [
+                    'id' => $registration->id,
+                    'kind' => $registration->kind->label(),
+                    'title' => $registration->title,
+                    'status' => $registration->status->label(),
+                    'startsAt' => $registration->starts_at?->toAtomString(),
+                    'canCancel' => $registration->status->canCancel(),
+                ]),
+        ]);
+    }
+}

--- a/app/Http/Controllers/Portal/PortalProfileController.php
+++ b/app/Http/Controllers/Portal/PortalProfileController.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Http\Controllers\Portal;
+
+use App\Actions\Portal\UpdatePortalProfile;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Portal\UpdatePortalProfileRequest;
+use App\Models\PortalAccessGrant;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+
+class PortalProfileController extends Controller
+{
+    public function update(UpdatePortalProfileRequest $request, UpdatePortalProfile $updatePortalProfile): RedirectResponse
+    {
+        $grant = $request->attributes->get('portal_access_grant');
+        abort_unless($grant instanceof PortalAccessGrant, 404);
+        $updatePortalProfile->handle($grant, [
+            'display_name' => $request->string('display_name')->toString(),
+            'email' => $request->filled('email') ? $request->string('email')->toString() : null,
+            'telephone' => $request->filled('telephone') ? $request->string('telephone')->toString() : null,
+        ]);
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Profile updated.')]);
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Portal/PortalRecurringMandateController.php
+++ b/app/Http/Controllers/Portal/PortalRecurringMandateController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\Portal;
+
+use App\Actions\Donations\TransitionRecurringMandate;
+use App\Enums\RecurringMandateStatus;
+use App\Http\Controllers\Controller;
+use App\Models\PortalAccessGrant;
+use App\Models\RecurringMandate;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Ramsey\Uuid\Uuid;
+
+class PortalRecurringMandateController extends Controller
+{
+    public function destroy(
+        Request $request,
+        string $publicOrganisation,
+        string $mandate,
+        TransitionRecurringMandate $transitionRecurringMandate,
+    ): RedirectResponse {
+        $grant = $request->attributes->get('portal_access_grant');
+        abort_unless($grant instanceof PortalAccessGrant, 404);
+        $mandate = RecurringMandate::query()
+            ->whereKey($mandate)
+            ->where('organisation_id', $grant->organisation_id)
+            ->where('party_id', $grant->person_party_id)
+            ->firstOrFail();
+        $transitionRecurringMandate->handle(
+            $mandate,
+            RecurringMandateStatus::Cancelled,
+            Uuid::uuid5(Uuid::NAMESPACE_URL, "supporter-portal:{$grant->id}:recurring-mandate:{$mandate->id}:cancel")->toString(),
+            now(),
+            actor: $grant->user,
+        );
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Recurring gift cancelled.')]);
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Portal/PortalRegistrationController.php
+++ b/app/Http/Controllers/Portal/PortalRegistrationController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Portal;
+
+use App\Actions\Portal\CancelSupporterRegistration;
+use App\Http\Controllers\Controller;
+use App\Models\PortalAccessGrant;
+use App\Models\SupporterRegistration;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class PortalRegistrationController extends Controller
+{
+    public function destroy(
+        Request $request,
+        string $publicOrganisation,
+        string $registration,
+        CancelSupporterRegistration $cancelSupporterRegistration,
+    ): RedirectResponse {
+        $grant = $request->attributes->get('portal_access_grant');
+        abort_unless($grant instanceof PortalAccessGrant, 404);
+        $registration = SupporterRegistration::query()->whereKey($registration)->firstOrFail();
+        $cancelSupporterRegistration->handle($grant, $registration);
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Registration cancelled.')]);
+
+        return back();
+    }
+}

--- a/app/Http/Middleware/EnforcePortalSession.php
+++ b/app/Http/Middleware/EnforcePortalSession.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnforcePortalSession
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($request->session()->has('portal_access_grant_id') && ! $request->routeIs('portal.*')) {
+            abort(Response::HTTP_NOT_FOUND);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/EnsurePortalAccess.php
+++ b/app/Http/Middleware/EnsurePortalAccess.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Actions\Portal\ResolvePortalAccess;
+use App\Models\Organisation;
+use Closure;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+class EnsurePortalAccess
+{
+    public function __construct(private readonly ResolvePortalAccess $resolvePortalAccess) {}
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  Closure(Request): (Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $organisation = $request->attributes->get('public_organisation');
+        $grantId = $request->session()->get('portal_access_grant_id');
+        $version = $request->session()->get('portal_access_version');
+        $user = $request->user();
+
+        if (! $organisation instanceof Organisation || ! is_string($grantId) || ! is_int($version) || $user === null) {
+            $this->endSession($request);
+            abort(404);
+        }
+
+        try {
+            $grant = $this->resolvePortalAccess->handle($grantId, $version, $organisation, $user);
+        } catch (ModelNotFoundException|HttpExceptionInterface $exception) {
+            $this->endSession($request);
+
+            throw $exception;
+        }
+        $request->attributes->set('portal_access_grant', $grant);
+        $request->attributes->set('portal_party', $grant->personParty);
+
+        return $next($request);
+    }
+
+    private function endSession(Request $request): void
+    {
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+    }
+}

--- a/app/Http/Middleware/EnsureTrustedApplicationHost.php
+++ b/app/Http/Middleware/EnsureTrustedApplicationHost.php
@@ -22,7 +22,7 @@ class EnsureTrustedApplicationHost
             return $next($request);
         }
 
-        if (is_string($routeName) && str_starts_with($routeName, 'public.')) {
+        if (is_string($routeName) && (str_starts_with($routeName, 'public.') || str_starts_with($routeName, 'portal.'))) {
             return $next($request);
         }
 

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -46,6 +46,26 @@ class HandleInertiaRequests extends Middleware
      */
     public function share(Request $request): array
     {
+        if ($request->session()->has('portal_access_grant_id')) {
+            return [
+                ...parent::share($request),
+                'name' => config('app.name'),
+                'auth' => ['user' => null],
+                'sidebarOpen' => false,
+                'canCreateOrganisation' => false,
+                'currentOrganisation' => null,
+                'organisations' => [],
+                'demoSandbox' => null,
+                'canViewParties' => false,
+                'canViewPrograms' => false,
+                'canViewIntakes' => false,
+                'canViewDonations' => false,
+                'canViewAudienceSegments' => false,
+                'canViewSupporterJourneys' => false,
+                'canViewAudit' => false,
+            ];
+        }
+
         $user = $request->user();
         $organisationData = null;
         $organisations = function () use ($user, &$organisationData): Collection {

--- a/app/Http/Middleware/ResolvePublicOrganisation.php
+++ b/app/Http/Middleware/ResolvePublicOrganisation.php
@@ -76,7 +76,11 @@ class ResolvePublicOrganisation
         $route = $request->route();
         $routeName = $route?->getName();
 
-        abort_unless(is_string($routeName) && str_starts_with($routeName, 'public.'), Response::HTTP_NOT_FOUND);
+        abort_unless(
+            is_string($routeName)
+            && (str_starts_with($routeName, 'public.') || str_starts_with($routeName, 'portal.')),
+            Response::HTTP_NOT_FOUND,
+        );
 
         $parameters = $route->parameters();
         $parameters['public_organisation'] = $organisation->slug;

--- a/app/Http/Requests/Organisations/StorePortalAccessGrantRequest.php
+++ b/app/Http/Requests/Organisations/StorePortalAccessGrantRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Models\User;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StorePortalAccessGrantRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => [
+                'required',
+                'string',
+                'lowercase',
+                'email:rfc',
+                'max:255',
+                Rule::exists(User::class, 'email')->whereNotNull('email_verified_at'),
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/Portal/UpdatePortalConsentPreferencesRequest.php
+++ b/app/Http/Requests/Portal/UpdatePortalConsentPreferencesRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Http\Requests\Portal;
+
+use App\Enums\ConsentChannel;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdatePortalConsentPreferencesRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->attributes->has('portal_access_grant');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'channels' => ['present', 'array', 'max:3'],
+            'channels.*' => [
+                'string',
+                'distinct',
+                Rule::enum(ConsentChannel::class)->only([
+                    ConsentChannel::Email,
+                    ConsentChannel::Sms,
+                    ConsentChannel::Telephone,
+                ]),
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/Portal/UpdatePortalProfileRequest.php
+++ b/app/Http/Requests/Portal/UpdatePortalProfileRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests\Portal;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdatePortalProfileRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return $this->attributes->has('portal_access_grant');
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'display_name' => ['required', 'string', 'max:255'],
+            'email' => ['nullable', 'string', 'lowercase', 'email:rfc', 'max:255'],
+            'telephone' => ['nullable', 'string', 'max:50'],
+        ];
+    }
+}

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -39,6 +39,8 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, OrganisationInvitation> $invitations
  * @property-read Collection<int, Membership> $memberships
  * @property-read Collection<int, User> $members
+ * @property-read Collection<int, PortalAccessGrant> $portalAccessGrants
+ * @property-read Collection<int, SupporterRegistration> $supporterRegistrations
  */
 #[Fillable(['name', 'slug', 'status', 'status_changed_at', 'deletion_scheduled_for', 'signed_links_invalidated_at', 'access_version', 'sandbox_pair_id', 'sandbox_template', 'demo_generation', 'is_synthetic'])]
 class Organisation extends Model
@@ -186,6 +188,18 @@ class Organisation extends Model
     public function auditEvents(): HasMany
     {
         return $this->hasMany(TenantAuditEvent::class);
+    }
+
+    /** @return HasMany<PortalAccessGrant, $this> */
+    public function portalAccessGrants(): HasMany
+    {
+        return $this->hasMany(PortalAccessGrant::class);
+    }
+
+    /** @return HasMany<SupporterRegistration, $this> */
+    public function supporterRegistrations(): HasMany
+    {
+        return $this->hasMany(SupporterRegistration::class);
     }
 
     /** @return HasMany<OrganisationOwnershipTransfer, $this> */

--- a/app/Models/Party.php
+++ b/app/Models/Party.php
@@ -25,6 +25,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property-read Organisation $organisation
  * @property-read Collection<int, Membership> $memberships
  * @property-read Collection<int, PartyContactPoint> $contactPoints
+ * @property-read Collection<int, PortalAccessGrant> $portalAccessGrants
+ * @property-read Collection<int, SupporterRegistration> $supporterRegistrations
  */
 #[Fillable(['organisation_id', 'kind', 'display_name'])]
 class Party extends Model
@@ -54,6 +56,18 @@ class Party extends Model
     public function contactPoints(): HasMany
     {
         return $this->hasMany(PartyContactPoint::class);
+    }
+
+    /** @return HasMany<PortalAccessGrant, $this> */
+    public function portalAccessGrants(): HasMany
+    {
+        return $this->hasMany(PortalAccessGrant::class, 'person_party_id');
+    }
+
+    /** @return HasMany<SupporterRegistration, $this> */
+    public function supporterRegistrations(): HasMany
+    {
+        return $this->hasMany(SupporterRegistration::class);
     }
 
     /** @return BelongsToMany<Program, $this> */

--- a/app/Models/PortalAccessGrant.php
+++ b/app/Models/PortalAccessGrant.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\PartyKind;
+use Database\Factories\PortalAccessGrantFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property int $user_id
+ * @property int $person_party_id
+ * @property string $token_hash
+ * @property int $access_version
+ * @property Carbon $token_expires_at
+ * @property Carbon|null $verified_at
+ * @property Carbon|null $token_used_at
+ * @property Carbon|null $revoked_at
+ * @property int|null $created_by_user_id
+ * @property int|null $revoked_by_user_id
+ * @property-read Organisation $organisation
+ * @property-read User $user
+ * @property-read Party $personParty
+ */
+#[Fillable(['organisation_id', 'user_id', 'person_party_id', 'token_hash', 'access_version', 'token_expires_at', 'verified_at', 'token_used_at', 'revoked_at', 'created_by_user_id', 'revoked_by_user_id'])]
+class PortalAccessGrant extends Model
+{
+    /** @use HasFactory<PortalAccessGrantFactory> */
+    use BelongsToOrganisation, HasFactory, HasUlids;
+
+    protected static function booted(): void
+    {
+        static::updating(function (PortalAccessGrant $grant): void {
+            if ($grant->isDirty(['organisation_id', 'user_id', 'person_party_id', 'token_hash', 'created_by_user_id'])) {
+                throw new LogicException('Portal Access Grant identity is immutable.');
+            }
+        });
+        static::deleting(fn () => throw new LogicException('Portal Access Grant history is immutable.'));
+    }
+
+    public function hasActiveAccess(): bool
+    {
+        return $this->verified_at !== null
+            && $this->token_used_at !== null
+            && $this->revoked_at === null
+            && $this->user->hasVerifiedEmail()
+            && $this->personParty->kind === PartyKind::Person
+            && ! $this->personParty->trashed();
+    }
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /** @return BelongsTo<Party, $this> */
+    public function personParty(): BelongsTo
+    {
+        return $this->belongsTo(Party::class, 'person_party_id');
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
+    }
+
+    /** @return BelongsTo<User, $this> */
+    public function revokedBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'revoked_by_user_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'access_version' => 'integer',
+            'token_expires_at' => 'datetime',
+            'verified_at' => 'datetime',
+            'token_used_at' => 'datetime',
+            'revoked_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/SupporterRegistration.php
+++ b/app/Models/SupporterRegistration.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\SupporterRegistrationKind;
+use App\Enums\SupporterRegistrationStatus;
+use Database\Factories\SupporterRegistrationFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property int $party_id
+ * @property SupporterRegistrationKind $kind
+ * @property string $title
+ * @property SupporterRegistrationStatus $status
+ * @property int $version
+ * @property Carbon|null $starts_at
+ * @property Carbon|null $cancelled_at
+ * @property-read Party $party
+ */
+#[Fillable(['organisation_id', 'party_id', 'kind', 'title', 'status', 'version', 'starts_at', 'cancelled_at'])]
+class SupporterRegistration extends Model
+{
+    /** @use HasFactory<SupporterRegistrationFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected static function booted(): void
+    {
+        static::updating(function (SupporterRegistration $registration): void {
+            if ($registration->isDirty(['organisation_id', 'party_id', 'kind', 'title', 'starts_at'])) {
+                throw new LogicException('Supporter Registration identity is immutable.');
+            }
+        });
+        static::deleting(fn () => throw new LogicException('Supporter Registration history is immutable.'));
+    }
+
+    /** @return BelongsTo<Party, $this> */
+    public function party(): BelongsTo
+    {
+        return $this->belongsTo(Party::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'kind' => SupporterRegistrationKind::class,
+            'status' => SupporterRegistrationStatus::class,
+            'version' => 'integer',
+            'starts_at' => 'datetime',
+            'cancelled_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Support\Carbon;
@@ -32,6 +33,7 @@ use Laravel\Fortify\TwoFactorAuthenticatable;
  * @property-read Collection<int, Organisation> $ownedOrganisations
  * @property-read Collection<int, Membership> $organisationMemberships
  * @property-read Collection<int, Organisation> $organisations
+ * @property-read Collection<int, PortalAccessGrant> $portalAccessGrants
  */
 #[Fillable(['name', 'email', 'password', 'current_organisation_id', 'recovery_codes_acknowledged_at'])]
 #[Hidden(['password', 'two_factor_secret', 'two_factor_recovery_codes', 'remember_token'])]
@@ -67,5 +69,11 @@ class User extends Authenticatable implements MustVerifyEmail
     public function hasAcknowledgedRecoveryCodes(): bool
     {
         return $this->recovery_codes_acknowledged_at !== null;
+    }
+
+    /** @return HasMany<PortalAccessGrant, $this> */
+    public function portalAccessGrants(): HasMany
+    {
+        return $this->hasMany(PortalAccessGrant::class);
     }
 }

--- a/app/Policies/PartyPolicy.php
+++ b/app/Policies/PartyPolicy.php
@@ -91,6 +91,11 @@ class PartyPolicy
             ->contains(fn (ServiceCase $case): bool => $this->caseAccess->canViewSensitive($user, $case));
     }
 
+    public function managePortalAccess(User $user, Party $party): bool
+    {
+        return $this->supporterSafe($user, $party);
+    }
+
     public function supporterSafe(User $user, Party $party): bool
     {
         return $this->hasRoleInAnyScope($user, $party->organisation, OrganisationRole::EngagementOfficer)

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 use App\Http\Middleware\EnforceAbsoluteSessionLifetime;
 use App\Http\Middleware\EnforceDemoSandbox;
+use App\Http\Middleware\EnforcePortalSession;
 use App\Http\Middleware\EnsureInstallationAccess;
 use App\Http\Middleware\EnsureTrustedApplicationHost;
 use App\Http\Middleware\HandleAppearance;
@@ -29,6 +30,7 @@ return Application::configure(basePath: dirname(__DIR__))
             EnsureInstallationAccess::class,
             EnforceAbsoluteSessionLifetime::class,
             EnforceDemoSandbox::class,
+            EnforcePortalSession::class,
             ProtectSensitiveFortifyRoutes::class,
             HandleAppearance::class,
             HandleInertiaRequests::class,

--- a/config/portal.php
+++ b/config/portal.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'link_lifetime_minutes' => 30,
+];

--- a/database/factories/PortalAccessGrantFactory.php
+++ b/database/factories/PortalAccessGrantFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Party;
+use App\Models\PortalAccessGrant;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<PortalAccessGrant>
+ */
+class PortalAccessGrantFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'user_id' => User::factory(),
+            'person_party_id' => fn (array $attributes): int => Party::factory()->create([
+                'organisation_id' => $attributes['organisation_id'],
+            ])->id,
+            'token_hash' => hash('sha256', Str::random(64)),
+            'access_version' => 1,
+            'token_expires_at' => now()->addMinutes(30),
+        ];
+    }
+}

--- a/database/factories/SupporterRegistrationFactory.php
+++ b/database/factories/SupporterRegistrationFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\SupporterRegistrationKind;
+use App\Enums\SupporterRegistrationStatus;
+use App\Models\Party;
+use App\Models\SupporterRegistration;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SupporterRegistration>
+ */
+class SupporterRegistrationFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'party_id' => fn (array $attributes): int => Party::factory()->create([
+                'organisation_id' => $attributes['organisation_id'],
+            ])->id,
+            'kind' => SupporterRegistrationKind::Volunteer,
+            'title' => fake()->sentence(3),
+            'status' => SupporterRegistrationStatus::Confirmed,
+            'version' => 1,
+            'starts_at' => now()->addWeek(),
+        ];
+    }
+}

--- a/database/migrations/2026_08_31_171911_create_portal_access_grants_table.php
+++ b/database/migrations/2026_08_31_171911_create_portal_access_grants_table.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('portal_access_grants', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->restrictOnDelete();
+            $table->foreignId('person_party_id');
+            $table->char('token_hash', 64)->unique();
+            $table->unsignedInteger('access_version')->default(1);
+            $table->timestamp('token_expires_at')->index();
+            $table->timestamp('verified_at')->nullable();
+            $table->timestamp('token_used_at')->nullable();
+            $table->timestamp('revoked_at')->nullable();
+            $table->foreignId('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('revoked_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->unique(['organisation_id', 'id']);
+            $table->foreign(['organisation_id', 'person_party_id'])
+                ->references(['organisation_id', 'id'])->on('parties')->restrictOnDelete();
+            $table->index(['organisation_id', 'user_id', 'revoked_at']);
+            $table->index(['organisation_id', 'person_party_id', 'revoked_at']);
+        });
+
+        DB::statement('CREATE UNIQUE INDEX portal_access_grants_active_user_unique ON portal_access_grants (organisation_id, user_id) WHERE revoked_at IS NULL');
+        DB::statement('CREATE UNIQUE INDEX portal_access_grants_active_party_unique ON portal_access_grants (organisation_id, person_party_id) WHERE revoked_at IS NULL');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('portal_access_grants');
+    }
+};

--- a/database/migrations/2026_08_31_171912_create_supporter_registrations_table.php
+++ b/database/migrations/2026_08_31_171912_create_supporter_registrations_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('supporter_registrations', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('party_id');
+            $table->string('kind', 32);
+            $table->string('title');
+            $table->string('status', 32);
+            $table->unsignedInteger('version')->default(1);
+            $table->timestamp('starts_at')->nullable();
+            $table->timestamp('cancelled_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['organisation_id', 'id']);
+            $table->foreign(['organisation_id', 'party_id'])
+                ->references(['organisation_id', 'id'])->on('parties')->restrictOnDelete();
+            $table->index(['organisation_id', 'party_id', 'starts_at']);
+            $table->index(['organisation_id', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('supporter_registrations');
+    }
+};

--- a/resources/js/page-layout.test.ts
+++ b/resources/js/page-layout.test.ts
@@ -10,4 +10,8 @@ describe('resolvePageLayout', () => {
     it('keeps the unauthenticated demo persona chooser out of the staff shell', () => {
         expect(resolvePageLayout('demo/personas')).toBeNull();
     });
+
+    it('keeps the supporter portal out of the staff shell', () => {
+        expect(resolvePageLayout('portal/show')).toBeNull();
+    });
 });

--- a/resources/js/page-layout.ts
+++ b/resources/js/page-layout.ts
@@ -6,6 +6,7 @@ export function resolvePageLayout(name: string) {
     switch (true) {
         case name === 'welcome':
         case name.startsWith('demo/'):
+        case name.startsWith('portal/'):
             return null;
         case name.startsWith('auth/'):
             return AuthLayout;

--- a/resources/js/pages/parties/show.tsx
+++ b/resources/js/pages/parties/show.tsx
@@ -10,6 +10,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { index, update } from '@/routes/parties';
 import { store as storeAddress } from '@/routes/parties/addresses';
 import { store as storeConsent } from '@/routes/parties/consents';
+import { store as storePortalAccessGrant } from '@/routes/parties/portal-access-grants';
 import { store as storeRelationship } from '@/routes/parties/relationships';
 import { store as storeSafeContact } from '@/routes/parties/safe-contact-instructions';
 
@@ -20,6 +21,8 @@ type Props = {
     canUpdate: boolean;
     canRecordConsent: boolean;
     canManageSafeContact: boolean;
+    canManagePortalAccess: boolean;
+    portalAccessUrl: string | null;
     programs: Program[];
     partyKinds: Option[];
     partyRoles: Option[];
@@ -48,6 +51,8 @@ export default function PartyShow({
     canUpdate,
     canRecordConsent,
     canManageSafeContact,
+    canManagePortalAccess,
+    portalAccessUrl,
     programs,
     partyKinds,
     partyRoles,
@@ -274,6 +279,70 @@ export default function PartyShow({
                                     </>
                                 )}
                             </Form>
+                        </CardContent>
+                    </Card>
+                ) : null}
+                {canManagePortalAccess ? (
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Supporter portal access</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-4">
+                            <p className="text-muted-foreground text-sm">
+                                Create a short-lived, single-use link for a
+                                verified user. Creating another link replaces
+                                the previous grant for this person and user.
+                            </p>
+                            <Form
+                                {...storePortalAccessGrant.form(args)}
+                                className="flex flex-col gap-3 sm:flex-row"
+                            >
+                                {({ errors, processing }) => (
+                                    <>
+                                        <div className="flex-1">
+                                            <Label htmlFor="portal-user-email">
+                                                Verified user email
+                                            </Label>
+                                            <Input
+                                                id="portal-user-email"
+                                                name="email"
+                                                type="email"
+                                                autoComplete="off"
+                                                required
+                                            />
+                                            <InputError
+                                                message={errors.email}
+                                            />
+                                        </div>
+                                        <Button
+                                            className="self-end"
+                                            type="submit"
+                                            disabled={processing}
+                                        >
+                                            Create portal link
+                                        </Button>
+                                    </>
+                                )}
+                            </Form>
+                            {portalAccessUrl ? (
+                                <div>
+                                    <Label htmlFor="portal-access-url">
+                                        New portal link
+                                    </Label>
+                                    <Input
+                                        id="portal-access-url"
+                                        value={portalAccessUrl}
+                                        readOnly
+                                        onFocus={(event) =>
+                                            event.currentTarget.select()
+                                        }
+                                    />
+                                    <p className="text-muted-foreground mt-1 text-xs">
+                                        Share this link securely. It is shown
+                                        only once and expires shortly.
+                                    </p>
+                                </div>
+                            ) : null}
                         </CardContent>
                     </Card>
                 ) : null}

--- a/resources/js/pages/portal/show.tsx
+++ b/resources/js/pages/portal/show.tsx
@@ -1,0 +1,355 @@
+import { Form, Head } from '@inertiajs/react';
+import InputError from '@/components/input-error';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { destroy as revokeAccess } from '@/routes/portal/access';
+import { update as updatePreferences } from '@/routes/portal/consent-preferences';
+import { update as updateProfile } from '@/routes/portal/profile';
+import { destroy as cancelMandate } from '@/routes/portal/recurring-mandates';
+import { destroy as cancelRegistration } from '@/routes/portal/registrations';
+
+type Profile = {
+    displayName: string;
+    email: string | null;
+    telephone: string | null;
+};
+type RecurringMandate = {
+    id: string;
+    amountMinor: number;
+    currency: string;
+    interval: string;
+    status: string;
+    canCancel: boolean;
+};
+type Registration = {
+    id: string;
+    kind: string;
+    title: string;
+    status: string;
+    startsAt: string | null;
+    canCancel: boolean;
+};
+type Props = {
+    organisation: { name: string; slug: string };
+    profile: Profile;
+    preferences: Record<'email' | 'sms' | 'telephone', boolean>;
+    recurringMandates: RecurringMandate[];
+    registrations: Registration[];
+};
+
+const formArray = (value: unknown): string[] =>
+    Array.isArray(value)
+        ? value.map(String)
+        : typeof value === 'string' && value !== ''
+          ? [value]
+          : [];
+
+export default function PortalShow({
+    organisation,
+    profile,
+    preferences,
+    recurringMandates,
+    registrations,
+}: Props) {
+    const slug = organisation.slug;
+
+    return (
+        <>
+            <Head title={`My supporter profile · ${organisation.name}`} />
+            <div className="min-h-screen bg-slate-50 text-slate-950 dark:bg-slate-950 dark:text-slate-50">
+                <header className="border-b border-slate-200 bg-white dark:border-slate-800 dark:bg-slate-900">
+                    <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6">
+                        <p className="text-sm font-medium text-emerald-700 dark:text-emerald-400">
+                            {organisation.name}
+                        </p>
+                        <h1 className="mt-1 text-3xl font-semibold tracking-tight">
+                            My supporter profile
+                        </h1>
+                        <p className="mt-2 max-w-2xl text-sm text-slate-600 dark:text-slate-300">
+                            Manage your contact details, communication choices,
+                            recurring gifts, and registrations.
+                        </p>
+                    </div>
+                </header>
+
+                <main className="mx-auto grid max-w-5xl gap-6 px-4 py-8 sm:px-6 lg:grid-cols-2">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Contact details</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <Form
+                                {...updateProfile.form(slug)}
+                                className="space-y-4"
+                            >
+                                {({ errors, processing }) => (
+                                    <>
+                                        <div>
+                                            <Label htmlFor="display_name">
+                                                Name
+                                            </Label>
+                                            <Input
+                                                id="display_name"
+                                                name="display_name"
+                                                defaultValue={
+                                                    profile.displayName
+                                                }
+                                                autoComplete="name"
+                                                required
+                                            />
+                                            <InputError
+                                                message={errors.display_name}
+                                            />
+                                        </div>
+                                        <div>
+                                            <Label htmlFor="email">Email</Label>
+                                            <Input
+                                                id="email"
+                                                name="email"
+                                                type="email"
+                                                defaultValue={
+                                                    profile.email ?? ''
+                                                }
+                                                autoComplete="email"
+                                            />
+                                            <InputError
+                                                message={errors.email}
+                                            />
+                                        </div>
+                                        <div>
+                                            <Label htmlFor="telephone">
+                                                Telephone
+                                            </Label>
+                                            <Input
+                                                id="telephone"
+                                                name="telephone"
+                                                type="tel"
+                                                defaultValue={
+                                                    profile.telephone ?? ''
+                                                }
+                                                autoComplete="tel"
+                                            />
+                                            <InputError
+                                                message={errors.telephone}
+                                            />
+                                        </div>
+                                        <Button
+                                            type="submit"
+                                            disabled={processing}
+                                        >
+                                            Save contact details
+                                        </Button>
+                                    </>
+                                )}
+                            </Form>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Communication preferences</CardTitle>
+                        </CardHeader>
+                        <CardContent>
+                            <Form
+                                {...updatePreferences.form(slug)}
+                                transform={(data) => ({
+                                    ...data,
+                                    channels: formArray(data.channels),
+                                })}
+                                className="space-y-4"
+                            >
+                                {({ errors, processing }) => (
+                                    <>
+                                        <fieldset>
+                                            <legend className="text-sm text-slate-600 dark:text-slate-300">
+                                                Send me supporter updates by:
+                                            </legend>
+                                            {[
+                                                ['email', 'Email'],
+                                                ['sms', 'SMS'],
+                                                ['telephone', 'Telephone'],
+                                            ].map(([value, label]) => (
+                                                <label
+                                                    key={value}
+                                                    className="mt-3 flex items-center gap-3 rounded-md border border-slate-200 p-3 text-sm dark:border-slate-700"
+                                                >
+                                                    <input
+                                                        type="checkbox"
+                                                        name="channels[]"
+                                                        value={value}
+                                                        defaultChecked={
+                                                            preferences[
+                                                                value as keyof typeof preferences
+                                                            ]
+                                                        }
+                                                        className="size-4 accent-emerald-600"
+                                                    />
+                                                    {label}
+                                                </label>
+                                            ))}
+                                        </fieldset>
+                                        <InputError
+                                            message={
+                                                errors.channels ??
+                                                errors['channels.0']
+                                            }
+                                        />
+                                        <Button
+                                            type="submit"
+                                            disabled={processing}
+                                        >
+                                            Save communication choices
+                                        </Button>
+                                    </>
+                                )}
+                            </Form>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Recurring gifts</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-3">
+                            {recurringMandates.length === 0 ? (
+                                <p className="text-sm text-slate-600 dark:text-slate-300">
+                                    You have no recurring gifts with this
+                                    organisation.
+                                </p>
+                            ) : null}
+                            {recurringMandates.map((mandate) => (
+                                <div
+                                    key={mandate.id}
+                                    className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-slate-200 p-4 dark:border-slate-700"
+                                >
+                                    <div>
+                                        <p className="font-medium">
+                                            {new Intl.NumberFormat(undefined, {
+                                                style: 'currency',
+                                                currency: mandate.currency,
+                                            }).format(
+                                                mandate.amountMinor / 100,
+                                            )}{' '}
+                                            / {mandate.interval}
+                                        </p>
+                                        <Badge variant="outline">
+                                            {mandate.status}
+                                        </Badge>
+                                    </div>
+                                    {mandate.canCancel ? (
+                                        <Form
+                                            {...cancelMandate.form([
+                                                slug,
+                                                mandate.id,
+                                            ])}
+                                        >
+                                            {({ processing }) => (
+                                                <Button
+                                                    type="submit"
+                                                    variant="outline"
+                                                    disabled={processing}
+                                                >
+                                                    Cancel recurring gift
+                                                </Button>
+                                            )}
+                                        </Form>
+                                    ) : null}
+                                </div>
+                            ))}
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Registrations</CardTitle>
+                        </CardHeader>
+                        <CardContent className="space-y-3">
+                            {registrations.length === 0 ? (
+                                <p className="text-sm text-slate-600 dark:text-slate-300">
+                                    You have no volunteer or event
+                                    registrations.
+                                </p>
+                            ) : null}
+                            {registrations.map((registration) => (
+                                <div
+                                    key={registration.id}
+                                    className="rounded-md border border-slate-200 p-4 dark:border-slate-700"
+                                >
+                                    <div className="flex flex-wrap items-start justify-between gap-3">
+                                        <div>
+                                            <p className="text-xs font-medium tracking-wide text-emerald-700 uppercase dark:text-emerald-400">
+                                                {registration.kind}
+                                            </p>
+                                            <p className="font-medium">
+                                                {registration.title}
+                                            </p>
+                                            {registration.startsAt ? (
+                                                <p className="text-sm text-slate-600 dark:text-slate-300">
+                                                    {new Date(
+                                                        registration.startsAt,
+                                                    ).toLocaleString()}
+                                                </p>
+                                            ) : null}
+                                            <Badge variant="outline">
+                                                {registration.status}
+                                            </Badge>
+                                        </div>
+                                        {registration.canCancel ? (
+                                            <Form
+                                                {...cancelRegistration.form([
+                                                    slug,
+                                                    registration.id,
+                                                ])}
+                                            >
+                                                {({ processing }) => (
+                                                    <Button
+                                                        type="submit"
+                                                        variant="outline"
+                                                        disabled={processing}
+                                                    >
+                                                        Cancel registration
+                                                    </Button>
+                                                )}
+                                            </Form>
+                                        ) : null}
+                                    </div>
+                                </div>
+                            ))}
+                        </CardContent>
+                    </Card>
+
+                    <section
+                        aria-labelledby="portal-access-heading"
+                        className="rounded-lg border border-red-200 bg-red-50 p-5 lg:col-span-2 dark:border-red-900 dark:bg-red-950/30"
+                    >
+                        <h2
+                            id="portal-access-heading"
+                            className="font-semibold"
+                        >
+                            Portal access
+                        </h2>
+                        <p className="mt-1 text-sm text-slate-600 dark:text-slate-300">
+                            Revoking access signs you out and permanently
+                            invalidates this portal grant. Staff can issue a new
+                            link later.
+                        </p>
+                        <Form {...revokeAccess.form(slug)} className="mt-4">
+                            {({ processing }) => (
+                                <Button
+                                    type="submit"
+                                    variant="destructive"
+                                    disabled={processing}
+                                >
+                                    Revoke my portal access
+                                </Button>
+                            )}
+                        </Form>
+                    </section>
+                </main>
+            </div>
+        </>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,15 +23,23 @@ use App\Http\Controllers\Organisations\PartyController;
 use App\Http\Controllers\Organisations\PartyDuplicateReviewController;
 use App\Http\Controllers\Organisations\PartyRelationshipController;
 use App\Http\Controllers\Organisations\PartySafeContactInstructionController;
+use App\Http\Controllers\Organisations\PortalAccessGrantController as OrganisationPortalAccessGrantController;
 use App\Http\Controllers\Organisations\ProgramController;
 use App\Http\Controllers\Organisations\ServiceCaseController;
 use App\Http\Controllers\Organisations\ServiceOperationsExportController;
 use App\Http\Controllers\Organisations\SupporterJourneyController;
 use App\Http\Controllers\Organisations\TenantAuditEventController;
+use App\Http\Controllers\Portal\PortalAccessController;
+use App\Http\Controllers\Portal\PortalConsentPreferenceController;
+use App\Http\Controllers\Portal\PortalController;
+use App\Http\Controllers\Portal\PortalProfileController;
+use App\Http\Controllers\Portal\PortalRecurringMandateController;
+use App\Http\Controllers\Portal\PortalRegistrationController;
 use App\Http\Controllers\Public\DonationController as PublicDonationController;
 use App\Http\Controllers\Public\OrganisationController as PublicOrganisationController;
 use App\Http\Middleware\EnsureOrganisationAccess;
 use App\Http\Middleware\EnsureOrganisationMembership;
+use App\Http\Middleware\EnsurePortalAccess;
 use App\Http\Middleware\EnsureRecentPassword;
 use App\Http\Middleware\EnsureStaffSecurityRequirements;
 use App\Http\Middleware\ResolvePublicOrganisation;
@@ -73,6 +81,17 @@ Route::domain('{public_organisation}.'.config('organisations.public_domain'))
         Route::get('/', PublicOrganisationController::class)->name('public.organisations.show');
         Route::get('/donate', [PublicDonationController::class, 'create'])->name('public.donations.create');
         Route::post('/donate', [PublicDonationController::class, 'store'])->middleware('throttle:10,1')->name('public.donations.store');
+        Route::get('/portal/access/{token}', [PortalAccessController::class, 'use'])
+            ->middleware('throttle:20,1')
+            ->name('portal.access.use');
+        Route::middleware(EnsurePortalAccess::class)->group(function (): void {
+            Route::get('/portal', PortalController::class)->name('portal.show');
+            Route::patch('/portal/profile', [PortalProfileController::class, 'update'])->name('portal.profile.update');
+            Route::put('/portal/consent-preferences', [PortalConsentPreferenceController::class, 'update'])->name('portal.consent-preferences.update');
+            Route::delete('/portal/recurring-mandates/{mandate}', [PortalRecurringMandateController::class, 'destroy'])->name('portal.recurring-mandates.destroy');
+            Route::delete('/portal/registrations/{registration}', [PortalRegistrationController::class, 'destroy'])->name('portal.registrations.destroy');
+            Route::delete('/portal/access', [PortalAccessController::class, 'destroy'])->name('portal.access.destroy');
+        });
         Route::get('/.well-known/security.txt', $securityText)->name('public.security.txt');
         Route::get('/security-policy', $securityPolicy)->name('public.security.policy');
     });
@@ -134,6 +153,7 @@ Route::prefix('{current_organisation}')
         Route::post('duplicate-reviews/{duplicate_review}', [PartyDuplicateReviewController::class, 'store'])->name('duplicate-reviews.store');
         Route::delete('duplicate-reviews/{duplicate_review}', [PartyDuplicateReviewController::class, 'destroy'])->name('duplicate-reviews.destroy');
         Route::post('parties/{party}/consents', [PartyConsentController::class, 'store'])->name('parties.consents.store');
+        Route::post('parties/{party}/portal-access-grants', [OrganisationPortalAccessGrantController::class, 'store'])->name('parties.portal-access-grants.store');
         Route::post('parties/{party}/addresses', [PartyAddressController::class, 'store'])->name('parties.addresses.store');
         Route::post('parties/{party}/relationships', [PartyRelationshipController::class, 'store'])->name('parties.relationships.store');
         Route::post('parties/{party}/safe-contact-instructions', [PartySafeContactInstructionController::class, 'store'])->name('parties.safe-contact-instructions.store');

--- a/tests/Feature/PortalAccessTest.php
+++ b/tests/Feature/PortalAccessTest.php
@@ -1,0 +1,246 @@
+<?php
+
+use App\Actions\Engagement\EvaluateAudienceSegment;
+use App\Actions\Parties\RecordPartyConsent;
+use App\Actions\Parties\SyncPartyContacts;
+use App\Actions\Portal\IssuePortalAccessGrant;
+use App\Enums\ConsentChannel;
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use App\Enums\OrganisationRole;
+use App\Enums\PartyBusinessRole;
+use App\Enums\RecurringMandateStatus;
+use App\Enums\SupporterRegistrationKind;
+use App\Enums\SupporterRegistrationStatus;
+use App\Enums\TenantAuditEventType;
+use App\Models\AudienceSegment;
+use App\Models\Donation;
+use App\Models\Organisation;
+use App\Models\Party;
+use App\Models\PartyRole;
+use App\Models\PortalAccessGrant;
+use App\Models\RecurringMandate;
+use App\Models\SupporterRegistration;
+use App\Models\TenantAuditEvent;
+use App\Models\User;
+use App\OrganisationContext;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/** @return array{organisation: Organisation, otherOrganisation: Organisation, party: Party, otherParty: Party, staff: User, supporter: User, grant: PortalAccessGrant, token: string} */
+function supporterPortalFixture(): array
+{
+    $organisation = Organisation::factory()->active()->create(['slug' => 'supporter-home']);
+    $otherOrganisation = Organisation::factory()->active()->create(['slug' => 'other-home']);
+    $staff = User::factory()->create();
+    $supporter = User::factory()->create(['email' => 'supporter@example.test']);
+    $organisation->memberships()->create(['user_id' => $staff->id, 'role' => OrganisationRole::EngagementOfficer]);
+
+    [$party, $otherParty] = app(OrganisationContext::class)->run($organisation, function () use ($organisation): array {
+        $party = Party::factory()->for($organisation)->create(['display_name' => 'Amina Supporter']);
+        $otherParty = Party::factory()->for($organisation)->create(['display_name' => 'Private Other Person']);
+        PartyRole::factory()->create(['party_id' => $party->id, 'role' => PartyBusinessRole::Donor]);
+        PartyRole::factory()->create(['party_id' => $otherParty->id, 'role' => PartyBusinessRole::Client]);
+        app(SyncPartyContacts::class)->handle($party, ['email' => 'amina@example.test', 'telephone' => '+27 82 555 0100']);
+
+        return [$party, $otherParty];
+    });
+
+    $issued = app(OrganisationContext::class)->run(
+        $organisation,
+        fn (): array => app(IssuePortalAccessGrant::class)->handle($party, $supporter, $staff),
+    );
+
+    return [
+        'organisation' => $organisation,
+        'otherOrganisation' => $otherOrganisation,
+        'party' => $party,
+        'otherParty' => $otherParty,
+        'staff' => $staff,
+        'supporter' => $supporter,
+        'grant' => $issued['grant'],
+        'token' => $issued['token'],
+    ];
+}
+
+function supporterPortalUrl(array $fixture, string $path = '/portal'): string
+{
+    return "https://{$fixture['organisation']->slug}.community-kind.test{$path}";
+}
+
+it('issues a hashed single-use grant only to a verified user and replaces an earlier grant', function () {
+    $fixture = supporterPortalFixture();
+
+    expect($fixture['grant']->token_hash)->toBe(hash('sha256', $fixture['token']))
+        ->not->toContain($fixture['token'])
+        ->and($fixture['grant']->token_expires_at->isFuture())->toBeTrue();
+
+    $unverified = User::factory()->unverified()->create();
+    expect(fn () => app(OrganisationContext::class)->run(
+        $fixture['organisation'],
+        fn () => app(IssuePortalAccessGrant::class)->handle($fixture['party'], $unverified, $fixture['staff']),
+    ))->toThrow(LogicException::class, 'verified User');
+
+    $replacement = app(OrganisationContext::class)->run(
+        $fixture['organisation'],
+        fn (): array => app(IssuePortalAccessGrant::class)->handle($fixture['party'], $fixture['supporter'], $fixture['staff']),
+    );
+    expect($fixture['grant']->refresh()->revoked_at)->not->toBeNull()
+        ->and($replacement['grant']->revoked_at)->toBeNull();
+});
+
+it('binds portal verification to the tenant host and rejects reused or expired links', function () {
+    $fixture = supporterPortalFixture();
+    $crossTenantUrl = "https://{$fixture['otherOrganisation']->slug}.community-kind.test/portal/access/{$fixture['token']}";
+    $url = supporterPortalUrl($fixture, "/portal/access/{$fixture['token']}");
+
+    $this->get($crossTenantUrl)->assertNotFound();
+    $this->get($url)
+        ->assertRedirect(supporterPortalUrl($fixture))
+        ->assertSessionHas('portal_access_grant_id', $fixture['grant']->id);
+    $this->assertAuthenticatedAs($fixture['supporter']);
+    $this->get($url)->assertGone();
+
+    $expired = app(OrganisationContext::class)->run(
+        $fixture['organisation'],
+        fn (): array => app(IssuePortalAccessGrant::class)->handle($fixture['party'], $fixture['supporter'], $fixture['staff']),
+    );
+    app(OrganisationContext::class)->run(
+        $fixture['organisation'],
+        fn () => $expired['grant']->update(['token_expires_at' => now()->subMinute()]),
+    );
+    $this->get(supporterPortalUrl($fixture, "/portal/access/{$expired['token']}"))->assertGone();
+});
+
+it('shows only the linked supporter projection and no staff or other-party data', function () {
+    $fixture = supporterPortalFixture();
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): void {
+        $donation = Donation::factory()->create(['party_id' => $fixture['party']->id]);
+        RecurringMandate::factory()->create([
+            'donation_id' => $donation->id,
+            'party_id' => $fixture['party']->id,
+            'status' => RecurringMandateStatus::Active,
+        ]);
+        SupporterRegistration::factory()->create([
+            'party_id' => $fixture['party']->id,
+            'kind' => SupporterRegistrationKind::Volunteer,
+            'title' => 'Saturday food garden',
+            'status' => SupporterRegistrationStatus::Confirmed,
+        ]);
+    });
+
+    $this->get(supporterPortalUrl($fixture, "/portal/access/{$fixture['token']}"));
+    $this->get(supporterPortalUrl($fixture))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('portal/show')
+            ->where('auth.user', null)
+            ->where('organisations', [])
+            ->where('currentOrganisation', null)
+            ->where('profile.displayName', 'Amina Supporter')
+            ->where('profile.email', 'amina@example.test')
+            ->has('recurringMandates', 1)
+            ->where('registrations.0.title', 'Saturday food garden')
+            ->missing('party')
+            ->missing('roles')
+            ->missing('programs')
+            ->missing('cases'));
+    $this->get('/')->assertNotFound();
+    $this->get("https://{$fixture['otherOrganisation']->slug}.community-kind.test/portal")->assertNotFound();
+});
+
+it('lets the supporter update safe profile fields and preferences which immediately affect segments', function () {
+    $fixture = supporterPortalFixture();
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): void {
+        app(RecordPartyConsent::class)->handle($fixture['party'], [
+            'purpose' => ConsentPurpose::SupporterUpdates,
+            'channel' => ConsentChannel::Email,
+            'decision' => ConsentDecision::Granted,
+            'wording_version' => 'fixture-v1',
+            'wording' => 'Email updates',
+            'source' => 'fixture',
+            'occurred_at' => now()->subMinute()->toAtomString(),
+        ], $fixture['staff']);
+    });
+    $this->get(supporterPortalUrl($fixture, "/portal/access/{$fixture['token']}"));
+
+    $this->patch(supporterPortalUrl($fixture, '/portal/profile'), [
+        'display_name' => 'Amina Updated',
+        'email' => 'updated@example.test',
+        'telephone' => null,
+        'roles' => ['client'],
+    ])->assertRedirect();
+    $this->put(supporterPortalUrl($fixture, '/portal/consent-preferences'), ['channels' => []])->assertRedirect();
+
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($fixture): void {
+        $party = $fixture['party']->refresh();
+        $segment = AudienceSegment::factory()->create([
+            'criteria' => [
+                'purpose' => ConsentPurpose::SupporterUpdates->value,
+                'channel' => ConsentChannel::Email->value,
+                'role' => PartyBusinessRole::Donor->value,
+                'service_area' => null,
+                'interest' => null,
+                'donation_activity' => false,
+                'campaign_source' => null,
+            ],
+        ]);
+        expect($party->display_name)->toBe('Amina Updated')
+            ->and($party->businessRoles()->pluck('role')->all())->toBe([PartyBusinessRole::Donor])
+            ->and(app(EvaluateAudienceSegment::class)->handle($segment))->toBeEmpty()
+            ->and(TenantAuditEvent::query()->where('type', TenantAuditEventType::SupporterProfileUpdated)->exists())->toBeTrue()
+            ->and(TenantAuditEvent::query()->where('type', TenantAuditEventType::SupporterConsentPreferencesUpdated)->exists())->toBeTrue();
+    });
+});
+
+it('restricts cancellation to the linked supporter records', function () {
+    $fixture = supporterPortalFixture();
+    [$mandate, $registration, $otherRegistration] = app(OrganisationContext::class)->run(
+        $fixture['organisation'],
+        function () use ($fixture): array {
+            $donation = Donation::factory()->create(['party_id' => $fixture['party']->id]);
+            $mandate = RecurringMandate::factory()->create([
+                'donation_id' => $donation->id,
+                'party_id' => $fixture['party']->id,
+                'status' => RecurringMandateStatus::Active,
+            ]);
+            $registration = SupporterRegistration::factory()->create(['party_id' => $fixture['party']->id]);
+            $otherRegistration = SupporterRegistration::factory()->create(['party_id' => $fixture['otherParty']->id]);
+
+            return [$mandate, $registration, $otherRegistration];
+        },
+    );
+    $this->get(supporterPortalUrl($fixture, "/portal/access/{$fixture['token']}"));
+
+    $this->delete(supporterPortalUrl($fixture, "/portal/recurring-mandates/{$mandate->id}"))->assertRedirect();
+    $this->delete(supporterPortalUrl($fixture, "/portal/recurring-mandates/{$mandate->id}"))->assertRedirect();
+    $this->delete(supporterPortalUrl($fixture, "/portal/registrations/{$registration->id}"))->assertRedirect();
+    $this->delete(supporterPortalUrl($fixture, "/portal/registrations/{$otherRegistration->id}"))->assertNotFound();
+
+    app(OrganisationContext::class)->run($fixture['organisation'], function () use ($mandate, $registration): void {
+        expect($mandate->refresh()->status)->toBe(RecurringMandateStatus::Cancelled)
+            ->and($registration->refresh()->status)->toBe(SupporterRegistrationStatus::Cancelled);
+    });
+});
+
+it('revokes the grant, signs the supporter out, and rejects stale sessions', function () {
+    $fixture = supporterPortalFixture();
+    $this->get(supporterPortalUrl($fixture, "/portal/access/{$fixture['token']}"));
+
+    $this->delete(supporterPortalUrl($fixture, '/portal/access'))
+        ->assertRedirect("https://{$fixture['organisation']->slug}.community-kind.test");
+    $this->assertGuest();
+    expect($fixture['grant']->refresh()->revoked_at)->not->toBeNull();
+    $this->get(supporterPortalUrl($fixture))->assertNotFound();
+});
+
+it('allows only supporter-safe engagement staff to issue a portal link', function () {
+    $fixture = supporterPortalFixture();
+    $caseWorker = User::factory()->create();
+    $fixture['organisation']->memberships()->create(['user_id' => $caseWorker->id, 'role' => OrganisationRole::CaseWorker]);
+    $url = route('parties.portal-access-grants.store', [$fixture['organisation'], $fixture['party']]);
+
+    $this->actingAs($caseWorker)->post($url, ['email' => $fixture['supporter']->email])->assertForbidden();
+    $this->actingAs($fixture['staff'])->post($url, ['email' => $fixture['supporter']->email])
+        ->assertRedirect()
+        ->assertSessionHas('portal_access_url');
+});


### PR DESCRIPTION
Closes #24

## Summary
- add tenant-bound, single-use Portal Access Grants with one-to-one active bindings and isolated portal sessions
- add a privacy-safe supporter portal for contact details, consent preferences, recurring gifts, and registrations
- audit portal lifecycle and self-service changes, with consent updates immediately affecting audience suppression
- add staff link issuance for supporter-safe engagement officers

## Verification
- reviewed the complete diff against `origin/main` and fixed all findings
- `composer types:check`
- `npm run check`
- `npm run types:check`
- `npm test`
- `npm run build:ssr`
- `npm run licenses:check`
- full PostgreSQL suite: 334 tests, 2059 assertions
- focused portal suite: 7 tests, 65 assertions

## Local setup
- applied the two new migrations to the local PostgreSQL database