### PR TITLE
Add configurable journeys, richer segments, and extended reporting

### DIFF
--- a/app/Actions/Auditing/BuildTenantAuditView.php
+++ b/app/Actions/Auditing/BuildTenantAuditView.php
@@ -131,7 +131,11 @@ class BuildTenantAuditView
             TenantAuditEventType::EventReminderRecorded,
             TenantAuditEventType::InKindOfferTransitioned,
             TenantAuditEventType::PartnerProfileCreated,
-            TenantAuditEventType::PartnerCommitmentRecorded => 'engagement',
+            TenantAuditEventType::PartnerCommitmentRecorded,
+            TenantAuditEventType::OrganisationConfigurationCreated,
+            TenantAuditEventType::OrganisationConfigurationActivated,
+            TenantAuditEventType::ImpactSnapshotPublished,
+            TenantAuditEventType::SupporterJourneyTransitioned => 'engagement',
             default => 'service',
         };
     }

--- a/app/Actions/Configuration/ActivateOrganisationConfiguration.php
+++ b/app/Actions/Configuration/ActivateOrganisationConfiguration.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Actions\Configuration;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Enums\TenantAuditEventType;
+use App\Models\OrganisationConfiguration;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+final class ActivateOrganisationConfiguration
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly ValidateConfigurationDefinition $validate, private readonly RecordTenantAuditEvent $recordAudit) {}
+
+    public function handle(OrganisationConfiguration $configuration, User $actor): OrganisationConfiguration
+    {
+        $this->context->ensureOwns($configuration->organisation_id);
+
+        return DB::transaction(function () use ($actor, $configuration): OrganisationConfiguration {
+            $latest = OrganisationConfiguration::query()->where('area', $configuration->area)->where('configuration_key', $configuration->configuration_key)->lockForUpdate()->latest('version')->firstOrFail();
+            $locked = OrganisationConfiguration::query()->findOrFail($configuration->id);
+            if ($locked->status !== OrganisationConfigurationStatus::Draft) {
+                throw new LogicException('Only a draft configuration version can be activated.');
+            }
+            if ($locked->id !== $latest->id) {
+                throw new LogicException('Only the latest configuration version can be activated. Create a new version to roll back.');
+            }
+            $this->validate->handle($locked->area, $locked->definition);
+            OrganisationConfiguration::query()
+                ->where('area', $locked->area)
+                ->where('configuration_key', $locked->configuration_key)
+                ->where('status', OrganisationConfigurationStatus::Active)
+                ->update(['status' => OrganisationConfigurationStatus::Superseded]);
+            $locked->update(['status' => OrganisationConfigurationStatus::Active, 'activated_by_user_id' => $actor->id, 'activated_at' => now()]);
+            $this->recordAudit->handle($locked->organisation, TenantAuditEventType::OrganisationConfigurationActivated, 'organisation_configuration', $locked->id, ['configuration_id' => $locked->id, 'area' => $locked->area->value, 'configuration_key' => $locked->configuration_key, 'version' => $locked->version], $actor);
+
+            return $locked->refresh();
+        });
+    }
+}

--- a/app/Actions/Configuration/CreateOrganisationConfiguration.php
+++ b/app/Actions/Configuration/CreateOrganisationConfiguration.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Actions\Configuration;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Enums\TenantAuditEventType;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+
+final class CreateOrganisationConfiguration
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly ValidateConfigurationDefinition $validate, private readonly RecordTenantAuditEvent $recordAudit) {}
+
+    /** @param array<string, mixed> $definition */
+    public function handle(Organisation $organisation, OrganisationConfigurationArea $area, string $key, array $definition, User $actor): OrganisationConfiguration
+    {
+        $this->context->ensureOwns($organisation->id);
+        $definition = $this->validate->handle($area, $definition);
+
+        return DB::transaction(function () use ($actor, $area, $definition, $key, $organisation): OrganisationConfiguration {
+            $latest = OrganisationConfiguration::query()->where('area', $area)->where('configuration_key', $key)->lockForUpdate()->latest('version')->first();
+            $nextVersion = $latest instanceof OrganisationConfiguration ? $latest->version + 1 : 1;
+            $supersedesId = $latest instanceof OrganisationConfiguration ? $latest->id : null;
+            $configuration = OrganisationConfiguration::query()->create([
+                'organisation_id' => $organisation->id,
+                'area' => $area,
+                'configuration_key' => $key,
+                'version' => $nextVersion,
+                'definition' => $definition,
+                'status' => OrganisationConfigurationStatus::Draft,
+                'supersedes_id' => $supersedesId,
+                'created_by_user_id' => $actor->id,
+            ]);
+            $this->recordAudit->handle($organisation, TenantAuditEventType::OrganisationConfigurationCreated, 'organisation_configuration', $configuration->id, ['configuration_id' => $configuration->id, 'area' => $area->value, 'configuration_key' => $key, 'version' => $configuration->version], $actor);
+
+            return $configuration;
+        });
+    }
+}

--- a/app/Actions/Configuration/ValidateConfigurationDefinition.php
+++ b/app/Actions/Configuration/ValidateConfigurationDefinition.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Actions\Configuration;
+
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\SupporterJourneyKind;
+use App\Reporting\MetricRegistry;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
+
+final class ValidateConfigurationDefinition
+{
+    public function __construct(private readonly MetricRegistry $metrics) {}
+
+    /** @param array<string, mixed> $definition
+     * @return array<string, mixed>
+     */
+    public function handle(OrganisationConfigurationArea $area, array $definition): array
+    {
+        $rules = match ($area) {
+            OrganisationConfigurationArea::PublicForm => ['form' => ['required', Rule::in(['event_registration', 'volunteer_registration', 'in_kind_offer', 'supporter_profile'])], 'required_fields' => ['required', 'array', 'min:1'], 'required_fields.*' => ['required', 'string', 'distinct']],
+            OrganisationConfigurationArea::MessageTemplate => ['channel' => ['required', Rule::in(['email', 'sms'])], 'subject' => ['nullable', 'string', 'max:160'], 'body' => ['required', 'string', 'max:4000'], 'journey_kind' => ['required', Rule::enum(SupporterJourneyKind::class)]],
+            OrganisationConfigurationArea::SupporterJourney => ['default_kind' => ['required', Rule::enum(SupporterJourneyKind::class)], 'default_channel' => ['required', Rule::in(['email', 'sms'])], 'require_approval' => ['required', 'accepted'], 'dispatch_rechecks_consent' => ['required', 'accepted'], 'frequency_cap_days' => ['required', 'integer', 'min:'.config('engagement.frequency_cap_days'), 'max:365']],
+            OrganisationConfigurationArea::IntakeRules => ['required_fields' => ['required', 'array', 'min:2'], 'required_fields.*' => ['required', Rule::in(['party_uuid', 'email', 'telephone', 'source', 'narrative', 'presenting_needs', 'program_id']), 'distinct'], 'default_urgency' => ['required', Rule::in(['routine', 'priority', 'urgent'])], 'allow_restricted_access_bypass' => ['required', 'declined']],
+            OrganisationConfigurationArea::Reporting => ['public_metric_ids' => ['required', 'array'], 'public_metric_ids.*' => ['required', Rule::in($this->metrics->ids()), 'distinct'], 'pack_metric_ids' => ['required', 'array', 'min:1'], 'pack_metric_ids.*' => ['required', Rule::in($this->metrics->ids()), 'distinct']],
+        };
+        $validator = Validator::make($definition, $rules);
+        $validator->after(function ($validator) use ($area, $definition): void {
+            $requiredFields = is_array($definition['required_fields'] ?? null) ? $definition['required_fields'] : [];
+            if ($area === OrganisationConfigurationArea::PublicForm) {
+                $required = collect($requiredFields);
+                if (! $required->contains('name') || ! $required->contains('email')) {
+                    $validator->errors()->add('required_fields', 'Public forms must keep name and email required.');
+                }
+                if ($required->intersect(['organisation_id', 'party_id', 'status', 'consent_decision'])->isNotEmpty()) {
+                    $validator->errors()->add('required_fields', 'System and consent safeguards cannot be configured as form fields.');
+                }
+                $allowed = match ($definition['form'] ?? null) {
+                    'event_registration' => ['name', 'email'],
+                    'volunteer_registration' => ['name', 'email', 'interests', 'availability'],
+                    'in_kind_offer' => ['name', 'email', 'category', 'description', 'quantity', 'unit', 'estimated_value_minor', 'currency', 'condition'],
+                    'supporter_profile' => ['name', 'email', 'telephone'],
+                    default => [],
+                };
+                if ($required->diff($allowed)->isNotEmpty()) {
+                    $validator->errors()->add('required_fields', 'The form contains unsupported fields.');
+                }
+            }
+            if ($area === OrganisationConfigurationArea::MessageTemplate && ($definition['channel'] ?? null) === 'sms' && mb_strlen((string) ($definition['body'] ?? '')) > 480) {
+                $validator->errors()->add('body', 'SMS templates may not exceed 480 characters.');
+            }
+            if ($area === OrganisationConfigurationArea::MessageTemplate && ($definition['channel'] ?? null) === 'email' && blank($definition['subject'] ?? null)) {
+                $validator->errors()->add('subject', 'Email templates require a subject.');
+            }
+            if ($area === OrganisationConfigurationArea::IntakeRules && ! collect($requiredFields)->contains('presenting_needs')) {
+                $validator->errors()->add('required_fields', 'Intake rules must keep presenting needs required.');
+            }
+            if ($area === OrganisationConfigurationArea::IntakeRules && ! collect($requiredFields)->contains('party_uuid')) {
+                $validator->errors()->add('required_fields', 'Intake rules must keep the Party identity required.');
+            }
+        });
+
+        if ($validator->fails()) {
+            throw new ValidationException($validator);
+        }
+
+        return $validator->validated();
+    }
+}

--- a/app/Actions/Engagement/ApproveSupporterJourney.php
+++ b/app/Actions/Engagement/ApproveSupporterJourney.php
@@ -32,6 +32,8 @@ class ApproveSupporterJourney
                     'uuid' => $supporter['uuid'],
                     'displayName' => $supporter['displayName'],
                     'donationCount' => $supporter['donationCount'],
+                    'activityFrequency' => $supporter['activityFrequency'],
+                    'activityValue' => $supporter['activityValue'],
                 ])->values()->all();
             $locked->update([
                 'status' => SupporterJourneyStatus::Approved,
@@ -39,10 +41,14 @@ class ApproveSupporterJourney
                 'approval_hash' => hash('sha256', json_encode([
                     'subject' => $locked->subject,
                     'body' => $locked->body,
+                    'journey_kind' => $locked->journey_kind->value,
+                    'channel' => $locked->channel,
+                    'experiment' => $locked->experiment,
                     'audience' => array_column($snapshot, 'uuid'),
                 ], JSON_THROW_ON_ERROR)),
                 'approved_at' => now(),
                 'approved_by_user_id' => $actor->id,
+                'version' => $locked->version + 1,
             ]);
 
             if ($locked->audience_snapshot === null) {

--- a/app/Actions/Engagement/CreateAudienceSegment.php
+++ b/app/Actions/Engagement/CreateAudienceSegment.php
@@ -17,7 +17,7 @@ class CreateAudienceSegment
         private readonly RecordTenantAuditEvent $recordAudit,
     ) {}
 
-    /** @param array{purpose: string, channel: string, role: string, service_area: string|null, interest: string|null, donation_activity: bool, campaign_source: string|null} $criteria */
+    /** @param array{purpose: string, channel: string, role: string, service_area: string|null, interest: string|null, donation_activity: bool, campaign_source: string|null, activity_type: string, recency_days: int|null, minimum_frequency: int, minimum_value: int|null} $criteria */
     public function handle(Organisation $organisation, string $name, array $criteria, User $actor): AudienceSegment
     {
         $this->context->ensureOwns($organisation->id);

--- a/app/Actions/Engagement/DispatchSupporterJourney.php
+++ b/app/Actions/Engagement/DispatchSupporterJourney.php
@@ -2,9 +2,12 @@
 
 namespace App\Actions\Engagement;
 
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
 use App\Enums\SupporterJourneyEventType;
 use App\Enums\SupporterJourneyRecipientStatus;
 use App\Enums\SupporterJourneyStatus;
+use App\Models\OrganisationConfiguration;
 use App\Models\Party;
 use App\Models\SupporterJourney;
 use App\Models\SupporterJourneyRecipient;
@@ -31,8 +34,11 @@ class DispatchSupporterJourney
             throw new LogicException('Supporter journeys are restricted to local simulation.');
         }
 
-        if ($journey->status === SupporterJourneyStatus::Draft || $journey->audience_snapshot === null) {
+        if (! in_array($journey->status, [SupporterJourneyStatus::Approved, SupporterJourneyStatus::Scheduled], true) || $journey->audience_snapshot === null) {
             throw new LogicException('Only an approved journey can be simulated.');
+        }
+        if ($journey->status === SupporterJourneyStatus::Scheduled && ($journey->scheduled_for === null || $journey->scheduled_for->isFuture())) {
+            throw new LogicException('The scheduled journey is not due for dispatch.');
         }
 
         $eligibleUuids = $this->evaluate->handle($journey->audienceSegment)->pluck('uuid');
@@ -48,6 +54,7 @@ class DispatchSupporterJourney
                     [
                         'organisation_id' => $journey->organisation_id,
                         'status' => SupporterJourneyRecipientStatus::Queued,
+                        'variant' => $journey->experiment === null ? null : ((hexdec(substr(hash('sha256', $party->uuid), 0, 2)) % 2 === 0) ? 'A' : 'B'),
                     ],
                 );
                 $eligible = $eligibleUuids->contains($uuid) && ! $this->frequencyCapped($recipient);
@@ -64,11 +71,14 @@ class DispatchSupporterJourney
 
     private function frequencyCapped(SupporterJourneyRecipient $recipient): bool
     {
+        $configuredDays = OrganisationConfiguration::query()->where('area', OrganisationConfigurationArea::SupporterJourney)->where('configuration_key', 'default')->where('status', OrganisationConfigurationStatus::Active)->latest('version')->value('definition->frequency_cap_days');
+        $frequencyCapDays = max((int) config('engagement.frequency_cap_days'), (int) ($configuredDays ?? 0));
+
         return SupporterJourneyRecipient::query()
             ->where('party_id', $recipient->party_id)
             ->where('supporter_journey_id', '!=', $recipient->supporter_journey_id)
             ->where('status', SupporterJourneyRecipientStatus::Delivered)
-            ->where('updated_at', '>=', now()->subDays(config('engagement.frequency_cap_days')))
+            ->where('updated_at', '>=', now()->subDays($frequencyCapDays))
             ->exists();
     }
 }

--- a/app/Actions/Engagement/EvaluateAudienceSegment.php
+++ b/app/Actions/Engagement/EvaluateAudienceSegment.php
@@ -2,34 +2,38 @@
 
 namespace App\Actions\Engagement;
 
+use App\Enums\AudienceActivityType;
 use App\Enums\ConsentDecision;
 use App\Enums\DonationPaymentStatus;
 use App\Enums\PartyContactType;
 use App\Models\AudienceSegment;
 use App\Models\Donation;
+use App\Models\EventRegistration;
 use App\Models\Party;
 use App\Models\PartyAddress;
 use App\Models\PartyConsent;
 use App\Models\PartyInterest;
+use App\Models\VolunteerHourEntry;
 use App\OrganisationContext;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Collection;
 
 class EvaluateAudienceSegment
 {
     public function __construct(private readonly OrganisationContext $context) {}
 
-    /** @return Collection<int, array{uuid: string, displayName: string, role: string, serviceAreas: array<int, string>, interests: array<int, string>, donationCount: int<0, max>, consentedAt: string}> */
+    /** @return Collection<int, covariant array{uuid: string, displayName: string, role: string, serviceAreas: list<string>, interests: list<string>, donationCount: int<0, max>, activityType: 'any'|'donation'|'event'|'volunteer', activityFrequency: int, activityValue: int|null, latestActivityAt: string|null, consentedAt: string}> */
     public function handle(AudienceSegment $segment): Collection
     {
         $this->context->ensureOwns($segment->organisation_id);
-        $criteria = $segment->criteria;
+        $criteria = $this->criteria($segment->criteria);
         $contactType = $criteria['channel'] === 'email' ? PartyContactType::Email : PartyContactType::Telephone;
-        $evaluatedAt = now();
+        $evaluatedAt = CarbonImmutable::instance(now());
 
         return Party::query()
             ->whereHas('businessRoles', fn ($query) => $query->where('role', $criteria['role']))
             ->whereHas('contactPoints', fn ($query) => $query->where('type', $contactType))
-            ->with(['addresses', 'businessRoles', 'consents', 'contactPoints', 'donations.payments', 'interests', 'safeContactInstructions'])
+            ->with(['addresses', 'businessRoles', 'consents', 'contactPoints', 'donations.payments', 'eventRegistrations', 'interests', 'safeContactInstructions', 'volunteerHourEntries'])
             ->orderBy('display_name')
             ->orderBy('id')
             ->get()
@@ -39,37 +43,89 @@ class EvaluateAudienceSegment
                 if ($latestConsent?->decision !== ConsentDecision::Granted) {
                     return false;
                 }
-
                 if ($party->safeContactInstructions->contains(fn ($instruction): bool => $instruction->effective_at->lte($evaluatedAt) && ($instruction->ended_at === null || $instruction->ended_at->gt($evaluatedAt)))) {
                     return false;
                 }
-
                 if ($criteria['service_area'] !== null && ! $party->addresses->contains('service_area', $criteria['service_area'])) {
                     return false;
                 }
-
                 if ($criteria['interest'] !== null && ! $party->interests->contains('slug', $criteria['interest'])) {
                     return false;
                 }
 
-                return (! $criteria['donation_activity'] && $criteria['campaign_source'] === null)
-                    || $this->eligibleDonations($party, $criteria['campaign_source'])->isNotEmpty();
-            })
-            ->map(function (Party $party) use ($criteria): array {
-                $consent = $this->latestConsent($party, $criteria['purpose'], $criteria['channel']);
-                $donations = $this->eligibleDonations($party, $criteria['campaign_source']);
+                $activity = $this->activity($party, $criteria, $evaluatedAt);
 
-                return [
-                    'uuid' => $party->uuid,
-                    'displayName' => $party->display_name,
-                    'role' => $criteria['role'],
-                    'serviceAreas' => $party->addresses->map(fn (PartyAddress $address): ?string => $address->service_area)->filter(fn (?string $area): bool => $area !== null)->unique()->values()->all(),
-                    'interests' => $party->interests->map(fn (PartyInterest $interest): string => $interest->label)->unique()->values()->all(),
-                    'donationCount' => $donations->count(),
-                    'consentedAt' => $consent?->occurred_at->toAtomString() ?? '',
-                ];
+                return $activity['frequency'] >= $criteria['minimum_frequency']
+                    && ($criteria['minimum_value'] === null || ($activity['value'] !== null && $activity['value'] >= $criteria['minimum_value']));
             })
+            ->map(fn (Party $party) => $this->supporterResult($party, $criteria, $evaluatedAt))
             ->values();
+    }
+
+    /**
+     * @param  array{purpose: string, channel: string, role: string, campaign_source: string|null, activity_type: AudienceActivityType, recency_days: int|null, minimum_value: int|null}  $criteria
+     * @return array{uuid: string, displayName: string, role: string, serviceAreas: list<string>, interests: list<string>, donationCount: int<0, max>, activityType: 'any'|'donation'|'event'|'volunteer', activityFrequency: int, activityValue: int|null, latestActivityAt: string|null, consentedAt: string}
+     */
+    private function supporterResult(Party $party, array $criteria, CarbonImmutable $evaluatedAt): array
+    {
+        $consent = $this->latestConsent($party, $criteria['purpose'], $criteria['channel']);
+        $activity = $this->activity($party, $criteria, $evaluatedAt);
+
+        return [
+            'uuid' => $party->uuid,
+            'displayName' => $party->display_name,
+            'role' => $criteria['role'],
+            'serviceAreas' => array_values($party->addresses->map(fn (PartyAddress $address): ?string => $address->service_area)->filter(fn (?string $area): bool => $area !== null)->unique()->all()),
+            'interests' => array_values($party->interests->map(fn (PartyInterest $interest): string => $interest->label)->unique()->all()),
+            'donationCount' => $this->eligibleDonations($party, $criteria['campaign_source'], $criteria['recency_days'], $evaluatedAt)->count(),
+            'activityType' => $criteria['activity_type']->value,
+            'activityFrequency' => $activity['frequency'],
+            'activityValue' => $activity['value'],
+            'latestActivityAt' => $activity['latest_at']?->toAtomString(),
+            'consentedAt' => $consent?->occurred_at->toAtomString() ?? '',
+        ];
+    }
+
+    /** @param array<string, mixed> $stored
+     * @return array{purpose: string, channel: string, role: string, service_area: string|null, interest: string|null, donation_activity: bool, campaign_source: string|null, activity_type: AudienceActivityType, recency_days: int|null, minimum_frequency: int, minimum_value: int|null}
+     */
+    private function criteria(array $stored): array
+    {
+        $legacyDonationRequired = (bool) ($stored['donation_activity'] ?? false);
+
+        return [
+            'purpose' => (string) $stored['purpose'],
+            'channel' => (string) $stored['channel'],
+            'role' => (string) $stored['role'],
+            'service_area' => isset($stored['service_area']) ? (string) $stored['service_area'] : null,
+            'interest' => isset($stored['interest']) ? (string) $stored['interest'] : null,
+            'donation_activity' => $legacyDonationRequired,
+            'campaign_source' => isset($stored['campaign_source']) ? (string) $stored['campaign_source'] : null,
+            'activity_type' => AudienceActivityType::from((string) ($stored['activity_type'] ?? ($legacyDonationRequired ? 'donation' : 'any'))),
+            'recency_days' => isset($stored['recency_days']) ? (int) $stored['recency_days'] : null,
+            'minimum_frequency' => (int) ($stored['minimum_frequency'] ?? ($legacyDonationRequired || isset($stored['campaign_source']) ? 1 : 0)),
+            'minimum_value' => isset($stored['minimum_value']) ? (int) $stored['minimum_value'] : null,
+        ];
+    }
+
+    /** @param array{activity_type: AudienceActivityType, campaign_source: string|null, recency_days: int|null, minimum_value: int|null} $criteria
+     * @return array{frequency: int, value: int|null, latest_at: CarbonImmutable|null}
+     */
+    private function activity(Party $party, array $criteria, CarbonImmutable $evaluatedAt): array
+    {
+        $donations = $this->eligibleDonations($party, $criteria['campaign_source'], $criteria['recency_days'], $evaluatedAt)
+            ->flatMap->payments
+            ->filter(fn ($payment): bool => $payment->status === DonationPaymentStatus::Succeeded
+                && $this->withinRecency($payment->settled_at ?? $payment->updated_at, $criteria['recency_days'], $evaluatedAt));
+        $events = $party->eventRegistrations->filter(fn (EventRegistration $registration): bool => $registration->attended_at !== null && $this->withinRecency($registration->attended_at, $criteria['recency_days'], $evaluatedAt));
+        $volunteerHours = $party->volunteerHourEntries->filter(fn (VolunteerHourEntry $entry): bool => $this->withinRecency($entry->occurred_at, $criteria['recency_days'], $evaluatedAt));
+
+        return match ($criteria['activity_type']) {
+            AudienceActivityType::Donation => ['frequency' => $donations->count(), 'value' => (int) $donations->sum('amount_minor'), 'latest_at' => $this->latestDate($donations->map(fn ($payment) => $payment->settled_at ?? $payment->updated_at))],
+            AudienceActivityType::Event => ['frequency' => $events->count(), 'value' => $events->count(), 'latest_at' => $this->latestDate($events->pluck('attended_at'))],
+            AudienceActivityType::Volunteer => ['frequency' => $volunteerHours->count(), 'value' => (int) $volunteerHours->sum('minutes'), 'latest_at' => $this->latestDate($volunteerHours->pluck('occurred_at'))],
+            AudienceActivityType::Any => ['frequency' => $donations->count() + $events->count() + $volunteerHours->count(), 'value' => null, 'latest_at' => $this->latestDate(collect([...$donations->map(fn ($payment) => $payment->settled_at ?? $payment->updated_at), ...$events->pluck('attended_at'), ...$volunteerHours->pluck('occurred_at')]))],
+        };
     }
 
     private function latestConsent(Party $party, string $purpose, string $channel): ?PartyConsent
@@ -81,9 +137,22 @@ class EvaluateAudienceSegment
     }
 
     /** @return Collection<int, Donation> */
-    private function eligibleDonations(Party $party, ?string $campaignSource): Collection
+    private function eligibleDonations(Party $party, ?string $campaignSource, ?int $recencyDays, CarbonImmutable $evaluatedAt): Collection
     {
-        return $party->donations->filter(fn ($donation): bool => ($campaignSource === null || $donation->source_code === $campaignSource)
-            && $donation->payments->contains('status', DonationPaymentStatus::Succeeded));
+        return $party->donations->filter(fn (Donation $donation): bool => ($campaignSource === null || $donation->source_code === $campaignSource)
+            && $donation->payments->contains(fn ($payment): bool => $payment->status === DonationPaymentStatus::Succeeded && $this->withinRecency($payment->settled_at ?? $payment->updated_at, $recencyDays, $evaluatedAt)));
+    }
+
+    private function withinRecency(mixed $occurredAt, ?int $recencyDays, CarbonImmutable $evaluatedAt): bool
+    {
+        return $occurredAt !== null && ($recencyDays === null || CarbonImmutable::instance($occurredAt)->gte($evaluatedAt->subDays($recencyDays)));
+    }
+
+    /** @param Collection<int, mixed> $dates */
+    private function latestDate(Collection $dates): ?CarbonImmutable
+    {
+        $latest = $dates->filter()->sortDesc()->first();
+
+        return $latest === null ? null : CarbonImmutable::instance($latest);
     }
 }

--- a/app/Actions/Engagement/TransitionSupporterJourney.php
+++ b/app/Actions/Engagement/TransitionSupporterJourney.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Actions\Engagement;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Enums\SupporterJourneyStatus;
+use App\Enums\TenantAuditEventType;
+use App\Models\SupporterJourney;
+use App\Models\User;
+use App\OrganisationContext;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+final class TransitionSupporterJourney
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly RecordTenantAuditEvent $recordAudit) {}
+
+    public function handle(SupporterJourney $journey, SupporterJourneyStatus $to, ?string $scheduledFor, User $actor): SupporterJourney
+    {
+        $this->context->ensureOwns($journey->organisation_id);
+
+        return DB::transaction(function () use ($actor, $journey, $scheduledFor, $to): SupporterJourney {
+            $locked = SupporterJourney::query()->lockForUpdate()->findOrFail($journey->id);
+            $from = $locked->status;
+            if (! in_array($to, $from->allowedTransitions(), true)) {
+                throw new LogicException("Cannot transition supporter journey from {$from->value} to {$to->value}.");
+            }
+            if ($to === SupporterJourneyStatus::Scheduled && (blank($scheduledFor) || CarbonImmutable::parse($scheduledFor)->isPast())) {
+                throw new LogicException('A scheduled journey requires a future dispatch time.');
+            }
+            $locked->update([
+                'status' => $to,
+                'scheduled_for' => $to === SupporterJourneyStatus::Scheduled ? $scheduledFor : null,
+                'paused_at' => $to === SupporterJourneyStatus::Paused ? now() : null,
+                'version' => $locked->version + 1,
+            ]);
+            $this->recordAudit->handle($locked->organisation, TenantAuditEventType::SupporterJourneyTransitioned, 'supporter_journey', $locked->id, ['journey_id' => $locked->id, 'from_status' => $from->value, 'to_status' => $to->value, 'scheduled_for' => $locked->scheduled_for?->toAtomString()], $actor);
+
+            return $locked->refresh();
+        });
+    }
+}

--- a/app/Actions/Intake/CreateIntakeRequest.php
+++ b/app/Actions/Intake/CreateIntakeRequest.php
@@ -6,6 +6,7 @@ use App\Actions\Parties\FindPartiesByContact;
 use App\Cryptography\ClassifiedDataEncrypter;
 use App\Data\Values\ClassifiedValue;
 use App\Enums\IntakeStatus;
+use App\Enums\IntakeUrgency;
 use App\Enums\PartyContactType;
 use App\Models\IntakeRequest;
 use App\Models\Organisation;
@@ -26,7 +27,7 @@ class CreateIntakeRequest
     ) {}
 
     /**
-     * @param  array{source: string, narrative: string, presenting_needs: string, intake_fields: array<string, mixed>, eligibility_context: array<string, mixed>, risk_flags: list<string>, email: string|null, telephone: string|null, idempotency_key: string|null, consent_granted: bool, consent_source: string}  $attributes
+     * @param  array{source: string, narrative: string, presenting_needs: string, urgency?: IntakeUrgency, intake_fields: array<string, mixed>, eligibility_context: array<string, mixed>, risk_flags: list<string>, email: string|null, telephone: string|null, idempotency_key: string|null, consent_granted: bool, consent_source: string}  $attributes
      */
     public function handle(Organisation $organisation, Program $program, Party $party, array $attributes, User $actor): IntakeRequest
     {
@@ -55,6 +56,7 @@ class CreateIntakeRequest
                     'eligibility_context' => $attributes['eligibility_context'],
                     'risk_flags' => $attributes['risk_flags'],
                     'status' => IntakeStatus::Draft,
+                    'urgency' => $attributes['urgency'] ?? IntakeUrgency::Routine,
                     'source' => $attributes['source'],
                     'idempotency_key' => $attributes['idempotency_key'],
                     'created_by_user_id' => $actor->id,

--- a/app/Actions/Reporting/BuildImpactDashboard.php
+++ b/app/Actions/Reporting/BuildImpactDashboard.php
@@ -73,6 +73,17 @@ class BuildImpactDashboard
                 ] : null,
             ];
         })->values()->all();
+        $cohortComparisons = collect(PartyBusinessRole::cases())->map(function (PartyBusinessRole $cohort) use ($definitions, $end, $filters, $start): array {
+            $cohortFilters = [...$filters, 'cohort' => $cohort->value];
+            $values = collect($definitions)->filter(fn (array $definition): bool => in_array('cohort', $definition['dimensions'], true))->mapWithKeys(function (array $definition) use ($cohortFilters, $end, $start): array {
+                $metric = $this->calculate($definition['id'], $start, $end, $cohortFilters);
+                $suppressed = $metric['sampleSize'] > 0 && $metric['sampleSize'] < config('reporting.minimum_cohort');
+
+                return [$definition['id'] => ['value' => $suppressed ? null : $metric['value'], 'availability' => $suppressed ? 'suppressed' : ($metric['value'] === null ? 'unavailable' : 'available'), 'sampleSize' => $suppressed ? null : $metric['sampleSize']]];
+            })->all();
+
+            return ['cohort' => $cohort->value, 'label' => $cohort->label(), 'metrics' => $values];
+        })->values()->all();
 
         return [
             'registryVersion' => MetricRegistry::VERSION,
@@ -87,6 +98,7 @@ class BuildImpactDashboard
             'filters' => collect($filters)->except('_program_ids')->all(),
             'minimumCohort' => config('reporting.minimum_cohort'),
             'metrics' => $metrics,
+            'cohortComparisons' => $cohortComparisons,
             'options' => $this->options($user, $organisation, $role),
         ];
     }
@@ -127,6 +139,8 @@ class BuildImpactDashboard
             'engagement.event_attendance' => $this->eventAttendance($start, $end, $filters),
             'engagement.in_kind_fulfilments' => $this->inKindFulfilments($start, $end, $filters),
             'engagement.partner_commitments' => $this->partnerCommitments($start, $end, $filters),
+            'data.missing_service_area_rate' => $this->missingDataRate('service_area', $start, $end, $filters),
+            'data.missing_contact_rate' => $this->missingDataRate('contact', $start, $end, $filters),
             default => ['value' => null, 'sampleSize' => 0],
         };
     }
@@ -183,6 +197,24 @@ class BuildImpactDashboard
         $records = PartnerCommitment::query()->with(['partner.party.addresses', 'partner.party.businessRoles'])->where('created_at', '>=', $start)->where('created_at', '<', $end)->get()->filter(fn (PartnerCommitment $commitment): bool => $this->matchesParty($commitment->partner->party, $filters));
 
         return ['value' => (float) $records->count(), 'sampleSize' => $records->pluck('partner.party_id')->unique()->count()];
+    }
+
+    /** @param array<string, mixed> $filters
+     * @return array{value: float|null, sampleSize: int}
+     */
+    private function missingDataRate(string $field, CarbonImmutable $start, CarbonImmutable $end, array $filters): array
+    {
+        $parties = Party::query()->with(['addresses', 'businessRoles', 'contactPoints'])
+            ->where('created_at', '>=', $start)->where('created_at', '<', $end)->get()
+            ->filter(fn (Party $party): bool => $this->matchesParty($party, $filters));
+        if ($parties->isEmpty()) {
+            return ['value' => null, 'sampleSize' => 0];
+        }
+        $missing = $parties->filter(fn (Party $party): bool => $field === 'service_area'
+            ? ! $party->addresses->contains(fn (PartyAddress $address): bool => filled($address->service_area))
+            : $party->contactPoints->isEmpty());
+
+        return ['value' => round($missing->count() / $parties->count() * 100, 2), 'sampleSize' => $parties->count()];
     }
 
     /** @param array<string, mixed> $filters

--- a/app/Actions/Reporting/BuildImpactReportPack.php
+++ b/app/Actions/Reporting/BuildImpactReportPack.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Actions\Reporting;
+
+use App\Models\PublishedImpactSnapshot;
+use App\OrganisationContext;
+use LogicException;
+
+final class BuildImpactReportPack
+{
+    public function __construct(private readonly OrganisationContext $context) {}
+
+    /** @return list<list<string|int|float|null>> */
+    public function handle(PublishedImpactSnapshot $snapshot): array
+    {
+        $this->context->ensureOwns($snapshot->organisation_id);
+        if (! in_array($snapshot->audience, ['board', 'funder'], true)) {
+            throw new LogicException('Only board and funder snapshots can be downloaded as packs.');
+        }
+        $rows = [['section', 'cohort', 'metric', 'value', 'availability', 'unit', 'registry_version', 'period_start', 'period_end_exclusive']];
+        foreach ($snapshot->metrics as $metric) {
+            $rows[] = ['headline', '', $metric['definition']['label'], $metric['value'], $metric['availability'], $metric['definition']['unit'], $snapshot->registry_version, $snapshot->period['start'], $snapshot->period['endExclusive']];
+        }
+        foreach ($snapshot->cohort_comparisons as $cohort) {
+            foreach ($cohort['metrics'] as $metricId => $metric) {
+                $rows[] = ['cohort', $cohort['label'], $metricId, $metric['value'], $metric['availability'], '', $snapshot->registry_version, $snapshot->period['start'], $snapshot->period['endExclusive']];
+            }
+        }
+
+        return $rows;
+    }
+}

--- a/app/Actions/Reporting/PublishImpactSnapshot.php
+++ b/app/Actions/Reporting/PublishImpactSnapshot.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Actions\Reporting;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Enums\TenantAuditEventType;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use App\Models\PublishedImpactSnapshot;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+final class PublishImpactSnapshot
+{
+    public function __construct(private readonly OrganisationContext $context, private readonly BuildImpactDashboard $dashboard, private readonly RecordTenantAuditEvent $recordAudit) {}
+
+    /** @param array<string, mixed> $filters */
+    public function handle(Organisation $organisation, User $actor, string $audience, array $filters): PublishedImpactSnapshot
+    {
+        $this->context->ensureOwns($organisation->id);
+        if (! in_array($audience, ['board', 'funder', 'public'], true)) {
+            throw new LogicException('Impact snapshot audience is invalid.');
+        }
+        $configuration = OrganisationConfiguration::query()->where('area', OrganisationConfigurationArea::Reporting)->where('configuration_key', 'impact')->where('status', OrganisationConfigurationStatus::Active)->latest('version')->first();
+        if ($configuration === null) {
+            throw new LogicException('An active impact reporting configuration is required.');
+        }
+        $configuredIds = $configuration->definition[$audience === 'public' ? 'public_metric_ids' : 'pack_metric_ids'] ?? null;
+        $allowedIds = collect(is_array($configuredIds) ? array_values(array_filter($configuredIds, is_string(...))) : []);
+        $reconciled = $this->dashboard->handle($actor, $organisation, $filters);
+        $reconciledMetrics = $reconciled['metrics'] ?? null;
+        $reconciledCohorts = $reconciled['cohortComparisons'] ?? null;
+        if (! is_array($reconciledMetrics) || ! is_array($reconciledCohorts)) {
+            throw new LogicException('Reconciled impact data is malformed.');
+        }
+        $metrics = collect($reconciledMetrics)->filter(fn (mixed $metric): bool => is_array($metric) && is_array($metric['definition'] ?? null) && $allowedIds->contains($metric['definition']['id'] ?? null))->values();
+        if ($metrics->isEmpty()) {
+            throw new LogicException('The active reporting configuration does not approve any available metrics for this audience.');
+        }
+        $cohorts = collect($reconciledCohorts)->filter(fn (mixed $cohort): bool => is_array($cohort))->map(function (array $cohort) use ($allowedIds): array {
+            $cohortMetrics = is_array($cohort['metrics'] ?? null) ? $cohort['metrics'] : [];
+
+            return [...$cohort, 'metrics' => collect($cohortMetrics)->only($allowedIds->all())->all()];
+        })->values()->all();
+
+        return DB::transaction(function () use ($actor, $audience, $cohorts, $filters, $metrics, $organisation, $reconciled): PublishedImpactSnapshot {
+            $snapshot = PublishedImpactSnapshot::query()->create([
+                'organisation_id' => $organisation->id,
+                'audience' => $audience,
+                'registry_version' => $reconciled['registryVersion'],
+                'metrics' => $metrics->all(),
+                'cohort_comparisons' => $cohorts,
+                'period' => $reconciled['period'],
+                'filters' => $filters,
+                'approved_at' => now(),
+                'approved_by_user_id' => $actor->id,
+                'published_at' => $audience === 'public' ? now() : null,
+            ]);
+            $this->recordAudit->handle($organisation, TenantAuditEventType::ImpactSnapshotPublished, 'published_impact_snapshot', $snapshot->id, ['snapshot_id' => $snapshot->id, 'audience' => $audience, 'registry_version' => $snapshot->registry_version, 'metric_count' => $metrics->count()], $actor);
+
+            return $snapshot;
+        });
+    }
+}

--- a/app/Enums/AudienceActivityType.php
+++ b/app/Enums/AudienceActivityType.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Enums;
+
+enum AudienceActivityType: string
+{
+    case Any = 'any';
+    case Donation = 'donation';
+    case Event = 'event';
+    case Volunteer = 'volunteer';
+
+    public function label(): string
+    {
+        return str($this->value)->title()->toString();
+    }
+}

--- a/app/Enums/OrganisationConfigurationArea.php
+++ b/app/Enums/OrganisationConfigurationArea.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Enums;
+
+enum OrganisationConfigurationArea: string
+{
+    case PublicForm = 'public_form';
+    case MessageTemplate = 'message_template';
+    case SupporterJourney = 'supporter_journey';
+    case IntakeRules = 'intake_rules';
+    case Reporting = 'reporting';
+
+    public function label(): string
+    {
+        return str($this->value)->replace('_', ' ')->title()->toString();
+    }
+}

--- a/app/Enums/OrganisationConfigurationStatus.php
+++ b/app/Enums/OrganisationConfigurationStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum OrganisationConfigurationStatus: string
+{
+    case Draft = 'draft';
+    case Active = 'active';
+    case Superseded = 'superseded';
+}

--- a/app/Enums/SupporterJourneyKind.php
+++ b/app/Enums/SupporterJourneyKind.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Enums;
+
+enum SupporterJourneyKind: string
+{
+    case General = 'general';
+    case ReEngagement = 're_engagement';
+    case Event = 'event';
+    case Volunteer = 'volunteer';
+
+    public function label(): string
+    {
+        return str($this->value)->replace('_', ' ')->title()->toString();
+    }
+}

--- a/app/Enums/SupporterJourneyStatus.php
+++ b/app/Enums/SupporterJourneyStatus.php
@@ -6,4 +6,17 @@ enum SupporterJourneyStatus: string
 {
     case Draft = 'draft';
     case Approved = 'approved';
+    case Scheduled = 'scheduled';
+    case Paused = 'paused';
+
+    /** @return list<self> */
+    public function allowedTransitions(): array
+    {
+        return match ($this) {
+            self::Draft => [self::Approved],
+            self::Approved => [self::Scheduled, self::Paused],
+            self::Scheduled => [self::Paused, self::Approved],
+            self::Paused => [self::Approved, self::Scheduled],
+        };
+    }
 }

--- a/app/Enums/TenantAuditEventType.php
+++ b/app/Enums/TenantAuditEventType.php
@@ -47,6 +47,10 @@ enum TenantAuditEventType: string
     case InKindOfferTransitioned = 'in_kind_offer_transitioned';
     case PartnerProfileCreated = 'partner_profile_created';
     case PartnerCommitmentRecorded = 'partner_commitment_recorded';
+    case OrganisationConfigurationCreated = 'organisation_configuration_created';
+    case OrganisationConfigurationActivated = 'organisation_configuration_activated';
+    case ImpactSnapshotPublished = 'impact_snapshot_published';
+    case SupporterJourneyTransitioned = 'supporter_journey_transitioned';
 
     /** @return array<string, string> */
     public function payloadSchema(): array
@@ -193,6 +197,10 @@ enum TenantAuditEventType: string
             self::InKindOfferTransitioned => ['offer_id' => 'string', 'from_status' => 'string', 'to_status' => 'string'],
             self::PartnerProfileCreated => ['partner_profile_id' => 'string', 'party_uuid' => 'string'],
             self::PartnerCommitmentRecorded => ['commitment_id' => 'string', 'partner_profile_id' => 'string', 'status' => 'string'],
+            self::OrganisationConfigurationCreated => ['configuration_id' => 'string', 'area' => 'string', 'configuration_key' => 'string', 'version' => 'integer'],
+            self::OrganisationConfigurationActivated => ['configuration_id' => 'string', 'area' => 'string', 'configuration_key' => 'string', 'version' => 'integer'],
+            self::ImpactSnapshotPublished => ['snapshot_id' => 'string', 'audience' => 'string', 'registry_version' => 'string', 'metric_count' => 'integer'],
+            self::SupporterJourneyTransitioned => ['journey_id' => 'string', 'from_status' => 'string', 'to_status' => 'string', 'scheduled_for' => 'nullable_string'],
         };
     }
 }

--- a/app/Http/Controllers/Organisations/AudienceSegmentController.php
+++ b/app/Http/Controllers/Organisations/AudienceSegmentController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Organisations;
 
 use App\Actions\Engagement\CreateAudienceSegment;
 use App\Actions\Engagement\EvaluateAudienceSegment;
+use App\Enums\AudienceActivityType;
 use App\Enums\ConsentChannel;
 use App\Enums\ConsentPurpose;
 use App\Enums\PartyBusinessRole;
@@ -39,6 +40,7 @@ class AudienceSegmentController extends Controller
                 'serviceAreas' => PartyAddress::query()->whereNotNull('service_area')->distinct()->orderBy('service_area')->pluck('service_area'),
                 'interests' => PartyInterest::query()->select(['slug', 'label'])->distinct()->orderBy('label')->get(),
                 'campaignSources' => Donation::query()->distinct()->orderBy('source_code')->pluck('source_code'),
+                'activityTypes' => collect(AudienceActivityType::cases())->map(fn (AudienceActivityType $type): array => ['value' => $type->value, 'label' => $type->label()]),
             ],
         ]);
     }
@@ -58,6 +60,10 @@ class AudienceSegmentController extends Controller
                 'interest' => $validated['interest'] ?? null,
                 'donation_activity' => (bool) $validated['donation_activity'],
                 'campaign_source' => $validated['campaign_source'] ?? null,
+                'activity_type' => $validated['activity_type'],
+                'recency_days' => isset($validated['recency_days']) ? (int) $validated['recency_days'] : null,
+                'minimum_frequency' => (int) $validated['minimum_frequency'],
+                'minimum_value' => isset($validated['minimum_value']) ? (int) $validated['minimum_value'] : null,
             ],
             $request->user(),
         );

--- a/app/Http/Controllers/Organisations/IntakeRequestController.php
+++ b/app/Http/Controllers/Organisations/IntakeRequestController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Organisations;
 
 use App\Actions\Intake\CreateIntakeRequest;
+use App\Enums\IntakeUrgency;
 use App\Enums\OrganisationRole;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Organisations\StoreIntakeRequestRequest;
@@ -76,6 +77,7 @@ class IntakeRequestController extends Controller
             'source' => $request->string('source')->toString(),
             'narrative' => $request->string('narrative')->toString(),
             'presenting_needs' => $request->string('presenting_needs')->toString(),
+            'urgency' => IntakeUrgency::from($request->string('urgency')->toString()),
             'intake_fields' => $request->array('intake_fields'),
             'eligibility_context' => [],
             'risk_flags' => array_values(array_map(strval(...), $request->array('risk_flags'))),

--- a/app/Http/Controllers/Organisations/OrganisationConfigurationController.php
+++ b/app/Http/Controllers/Organisations/OrganisationConfigurationController.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Configuration\ActivateOrganisationConfiguration;
+use App\Actions\Configuration\CreateOrganisationConfiguration;
+use App\Enums\OrganisationConfigurationArea;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\StoreOrganisationConfigurationRequest;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\ValidationException;
+use Inertia\Inertia;
+use Inertia\Response;
+use JsonException;
+
+class OrganisationConfigurationController extends Controller
+{
+    public function index(Organisation $currentOrganisation): Response
+    {
+        Gate::authorize('viewAny', [OrganisationConfiguration::class, $currentOrganisation]);
+
+        return Inertia::render('organisation-configurations/index', [
+            'configurations' => OrganisationConfiguration::query()->latest()->get()->map(fn (OrganisationConfiguration $configuration): array => [
+                'id' => $configuration->id,
+                'area' => $configuration->area->value,
+                'key' => $configuration->configuration_key,
+                'version' => $configuration->version,
+                'status' => $configuration->status->value,
+                'definition' => $configuration->definition,
+                'activatedAt' => $configuration->activated_at?->toAtomString(),
+            ]),
+            'areas' => collect(OrganisationConfigurationArea::cases())->map(fn (OrganisationConfigurationArea $area): array => ['value' => $area->value, 'label' => $area->label()]),
+        ]);
+    }
+
+    /** @throws JsonException */
+    public function store(StoreOrganisationConfigurationRequest $request, Organisation $currentOrganisation, CreateOrganisationConfiguration $create): RedirectResponse
+    {
+        Gate::authorize('create', [OrganisationConfiguration::class, $currentOrganisation]);
+        $definition = json_decode($request->string('definition_json')->toString(), true, flags: JSON_THROW_ON_ERROR);
+        abort_unless(is_array($definition), 422);
+        try {
+            $create->handle($currentOrganisation, OrganisationConfigurationArea::from($request->string('area')->toString()), $request->string('configuration_key')->toString(), $definition, $request->user());
+        } catch (ValidationException $exception) {
+            throw ValidationException::withMessages([
+                'definition_json' => collect($exception->errors())->flatten()->implode(' '),
+            ]);
+        }
+
+        return back();
+    }
+
+    public function activate(Organisation $currentOrganisation, string $configuration, ActivateOrganisationConfiguration $activate): RedirectResponse
+    {
+        $version = OrganisationConfiguration::query()->findOrFail($configuration);
+        Gate::authorize('update', $version);
+        $activate->handle($version, request()->user());
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Organisations/PublishedImpactSnapshotController.php
+++ b/app/Http/Controllers/Organisations/PublishedImpactSnapshotController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Reporting\BuildImpactReportPack;
+use App\Actions\Reporting\PublishImpactSnapshot;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\StoreImpactSnapshotRequest;
+use App\Models\Organisation;
+use App\Models\PublishedImpactSnapshot;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class PublishedImpactSnapshotController extends Controller
+{
+    public function index(Organisation $currentOrganisation): Response
+    {
+        Gate::authorize('viewAny', [PublishedImpactSnapshot::class, $currentOrganisation]);
+
+        return Inertia::render('impact-snapshots/index', ['snapshots' => PublishedImpactSnapshot::query()->latest()->get()->map(fn (PublishedImpactSnapshot $snapshot): array => ['id' => $snapshot->id, 'audience' => $snapshot->audience, 'registryVersion' => $snapshot->registry_version, 'metricCount' => count($snapshot->metrics), 'approvedAt' => $snapshot->approved_at->toAtomString(), 'publishedAt' => $snapshot->published_at?->toAtomString()])]);
+    }
+
+    public function store(StoreImpactSnapshotRequest $request, Organisation $currentOrganisation, PublishImpactSnapshot $publish): RedirectResponse
+    {
+        Gate::authorize('create', [PublishedImpactSnapshot::class, $currentOrganisation]);
+        $validated = $request->validated();
+        $publish->handle($currentOrganisation, $request->user(), (string) $validated['audience'], collect($validated)->except('audience')->all());
+
+        return back();
+    }
+
+    public function download(Organisation $currentOrganisation, string $snapshot, BuildImpactReportPack $pack): StreamedResponse
+    {
+        $impactSnapshot = PublishedImpactSnapshot::query()->findOrFail($snapshot);
+        Gate::authorize('view', $impactSnapshot);
+        $rows = $pack->handle($impactSnapshot);
+
+        return response()->streamDownload(function () use ($rows): void {
+            $stream = fopen('php://output', 'wb');
+            if ($stream === false) {
+                return;
+            }
+            foreach ($rows as $row) {
+                fputcsv($stream, $row);
+            }
+            fclose($stream);
+        }, "fictional-{$impactSnapshot->audience}-impact-pack.csv", ['Content-Type' => 'text/csv; charset=UTF-8', 'Cache-Control' => 'private, no-store', 'X-Content-Type-Options' => 'nosniff']);
+    }
+}

--- a/app/Http/Controllers/Organisations/SupporterJourneyController.php
+++ b/app/Http/Controllers/Organisations/SupporterJourneyController.php
@@ -5,13 +5,19 @@ namespace App\Http\Controllers\Organisations;
 use App\Actions\Engagement\ApproveSupporterJourney;
 use App\Actions\Engagement\DispatchSupporterJourney;
 use App\Actions\Engagement\EvaluateAudienceSegment;
+use App\Actions\Engagement\TransitionSupporterJourney;
 use App\Actions\Engagement\TransitionSupporterJourneyRecipient;
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
 use App\Enums\SupporterJourneyEventType;
+use App\Enums\SupporterJourneyStatus;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Organisations\StoreSupporterJourneyRequest;
 use App\Http\Requests\Organisations\TransitionSupporterJourneyRecipientRequest;
+use App\Http\Requests\Organisations\TransitionSupporterJourneyRequest;
 use App\Models\AudienceSegment;
 use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
 use App\Models\SupporterJourney;
 use App\Models\SupporterJourneyEvent;
 use App\Models\SupporterJourneyRecipient;
@@ -35,6 +41,7 @@ class SupporterJourneyController extends Controller
                 'recipientCount' => $journey->recipients_count,
             ]),
             'segments' => AudienceSegment::query()->orderBy('name')->get(['id', 'name']),
+            'templates' => OrganisationConfiguration::query()->where('area', OrganisationConfigurationArea::MessageTemplate)->where('status', OrganisationConfigurationStatus::Active)->orderBy('configuration_key')->get()->map(fn (OrganisationConfiguration $configuration): array => ['key' => $configuration->configuration_key, 'channel' => $configuration->definition['channel'], 'journeyKind' => $configuration->definition['journey_kind']]),
         ]);
     }
 
@@ -43,7 +50,15 @@ class SupporterJourneyController extends Controller
         Gate::authorize('create', [SupporterJourney::class, $currentOrganisation]);
         $journey = SupporterJourney::query()->create([
             'organisation_id' => $currentOrganisation->id,
-            ...$request->validated(),
+            'audience_segment_id' => $request->validated('audience_segment_id'),
+            'name' => $request->validated('name'),
+            'journey_kind' => $request->validated('journey_kind'),
+            'channel' => $request->validated('channel'),
+            'subject' => (string) $request->validated('subject'),
+            'body' => $request->validated('body'),
+            'status' => SupporterJourneyStatus::Draft,
+            'version' => 1,
+            'experiment' => $request->boolean('experiment_enabled') ? ['subject' => $request->validated('variant_subject'), 'body' => $request->validated('variant_body')] : null,
             'created_by_user_id' => $request->user()->id,
         ]);
 
@@ -59,6 +74,8 @@ class SupporterJourneyController extends Controller
                 'uuid' => $supporter['uuid'],
                 'displayName' => $supporter['displayName'],
                 'donationCount' => $supporter['donationCount'],
+                'activityFrequency' => $supporter['activityFrequency'],
+                'activityValue' => $supporter['activityValue'],
             ])->values()->all();
 
         return Inertia::render('supporter-journeys/show', [
@@ -68,6 +85,11 @@ class SupporterJourneyController extends Controller
                 'subject' => $journey->subject,
                 'body' => $journey->body,
                 'status' => $journey->status->value,
+                'kind' => $journey->journey_kind->value,
+                'channel' => $journey->channel,
+                'scheduledFor' => $journey->scheduled_for?->toAtomString(),
+                'pausedAt' => $journey->paused_at?->toAtomString(),
+                'experiment' => $journey->experiment,
                 'audienceName' => $journey->audienceSegment->name,
                 'audienceSnapshot' => $previewAudience,
                 'approvalHash' => $journey->approval_hash,
@@ -75,6 +97,7 @@ class SupporterJourneyController extends Controller
                     'id' => $recipient->id,
                     'displayName' => $recipient->party->display_name,
                     'status' => $recipient->status->value,
+                    'variant' => $recipient->variant,
                     'attemptCount' => $recipient->attempt_count,
                     'events' => $recipient->events->map(fn (SupporterJourneyEvent $event): array => ['id' => $event->id, 'type' => $event->type->value]),
                     'actionKeys' => collect(SupporterJourneyEventType::cases())->mapWithKeys(fn (SupporterJourneyEventType $type): array => [$type->value => Str::uuid()->toString()]),
@@ -98,6 +121,16 @@ class SupporterJourneyController extends Controller
         $journey = SupporterJourney::query()->findOrFail($supporterJourney);
         Gate::authorize('update', $journey);
         $dispatch->handle($journey);
+
+        return back();
+    }
+
+    public function transitionJourney(TransitionSupporterJourneyRequest $request, Organisation $currentOrganisation, string $supporterJourney, TransitionSupporterJourney $transition): RedirectResponse
+    {
+        $journey = SupporterJourney::query()->findOrFail($supporterJourney);
+        Gate::authorize('update', $journey);
+        $scheduledFor = $request->validated('scheduled_for');
+        $transition->handle($journey, SupporterJourneyStatus::from($request->string('status')->toString()), is_string($scheduledFor) ? $scheduledFor : null, $request->user());
 
         return back();
     }

--- a/app/Http/Controllers/Public/ImpactController.php
+++ b/app/Http/Controllers/Public/ImpactController.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Public;
+
+use App\Http\Controllers\Controller;
+use App\Models\Organisation;
+use App\Models\PublishedImpactSnapshot;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+
+class ImpactController extends Controller
+{
+    public function __invoke(Request $request): View
+    {
+        $organisation = $request->attributes->get('public_organisation');
+        abort_unless($organisation instanceof Organisation, 404);
+        $snapshot = PublishedImpactSnapshot::query()->where('audience', 'public')->whereNotNull('published_at')->latest('published_at')->firstOrFail();
+
+        return view('public.impact', compact('organisation', 'snapshot'));
+    }
+}

--- a/app/Http/Controllers/Public/OrganisationController.php
+++ b/app/Http/Controllers/Public/OrganisationController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Public;
 
 use App\Http\Controllers\Controller;
 use App\Models\Organisation;
+use App\Models\PublishedImpactSnapshot;
 use Illuminate\Contracts\View\View;
 use Illuminate\Http\Request;
 
@@ -28,6 +29,7 @@ class OrganisationController extends Controller
             'volunteerUrl' => route('public.volunteers.index', ['public_organisation' => $organisation->slug]),
             'eventsUrl' => route('public.events.index', ['public_organisation' => $organisation->slug]),
             'inKindUrl' => route('public.in-kind.create', ['public_organisation' => $organisation->slug]),
+            'impactUrl' => PublishedImpactSnapshot::query()->where('audience', 'public')->whereNotNull('published_at')->exists() ? route('public.impact.show', ['public_organisation' => $organisation->slug]) : null,
         ]);
     }
 }

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -6,8 +6,10 @@ use App\Models\AudienceSegment;
 use App\Models\Donation;
 use App\Models\IntakeRequest;
 use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
 use App\Models\Party;
 use App\Models\Program;
+use App\Models\PublishedImpactSnapshot;
 use App\Models\SandboxPair;
 use App\Models\SupporterJourney;
 use App\Models\TenantAuditEvent;
@@ -65,6 +67,8 @@ class HandleInertiaRequests extends Middleware
                 'canViewSupporterJourneys' => false,
                 'canViewAudit' => false,
                 'canViewVolunteers' => false,
+                'canViewOrganisationConfigurations' => false,
+                'canViewImpactSnapshots' => false,
             ];
         }
 
@@ -123,6 +127,10 @@ class HandleInertiaRequests extends Middleware
                 && Gate::allows('viewAny', [TenantAuditEvent::class, $routeOrganisation]),
             'canViewVolunteers' => fn (): bool => $routeOrganisation instanceof Organisation
                 && Gate::allows('viewAny', [VolunteerOpportunity::class, $routeOrganisation]),
+            'canViewOrganisationConfigurations' => fn (): bool => $routeOrganisation instanceof Organisation
+                && Gate::allows('viewAny', [OrganisationConfiguration::class, $routeOrganisation]),
+            'canViewImpactSnapshots' => fn (): bool => $routeOrganisation instanceof Organisation
+                && Gate::allows('viewAny', [PublishedImpactSnapshot::class, $routeOrganisation]),
         ];
     }
 }

--- a/app/Http/Requests/Organisations/StoreAudienceSegmentRequest.php
+++ b/app/Http/Requests/Organisations/StoreAudienceSegmentRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests\Organisations;
 
+use App\Enums\AudienceActivityType;
 use App\Enums\ConsentChannel;
 use App\Enums\ConsentPurpose;
 use App\Enums\PartyBusinessRole;
@@ -9,9 +10,21 @@ use App\Models\Organisation;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class StoreAudienceSegmentRequest extends FormRequest
 {
+    protected function prepareForValidation(): void
+    {
+        if (! $this->has('activity_type')) {
+            $requiresDonation = $this->boolean('donation_activity') || filled($this->input('campaign_source'));
+            $this->merge([
+                'activity_type' => $requiresDonation ? AudienceActivityType::Donation->value : AudienceActivityType::Any->value,
+                'minimum_frequency' => $requiresDonation ? 1 : 0,
+            ]);
+        }
+    }
+
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -39,6 +52,24 @@ class StoreAudienceSegmentRequest extends FormRequest
             'interest' => ['nullable', 'string', 'max:100', Rule::exists('party_interests', 'slug')->where('organisation_id', $organisationId)],
             'donation_activity' => ['required', 'boolean'],
             'campaign_source' => ['nullable', 'string', 'max:64', Rule::exists('donations', 'source_code')->where('organisation_id', $organisationId)],
+            'activity_type' => ['required', Rule::enum(AudienceActivityType::class)],
+            'recency_days' => ['nullable', 'integer', 'min:1', 'max:3650'],
+            'minimum_frequency' => ['required', 'integer', 'min:0', 'max:10000'],
+            'minimum_value' => ['nullable', 'integer', 'min:0', 'max:1000000000'],
         ];
+    }
+
+    /** @return array<int, callable(Validator): void> */
+    public function after(): array
+    {
+        return [function (Validator $validator): void {
+            $activity = $this->input('activity_type');
+            if ($activity === AudienceActivityType::Any->value && filled($this->input('minimum_value'))) {
+                $validator->errors()->add('minimum_value', 'Any-activity segments cannot compare values with different units.');
+            }
+            if (filled($this->input('campaign_source')) && ! in_array($activity, [AudienceActivityType::Donation->value, AudienceActivityType::Any->value], true)) {
+                $validator->errors()->add('campaign_source', 'Donation source is only available for donation activity.');
+            }
+        }];
     }
 }

--- a/app/Http/Requests/Organisations/StoreImpactSnapshotRequest.php
+++ b/app/Http/Requests/Organisations/StoreImpactSnapshotRequest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Http\Requests\DashboardMetricsRequest;
+use Illuminate\Validation\Rule;
+
+class StoreImpactSnapshotRequest extends DashboardMetricsRequest
+{
+    public function rules(): array
+    {
+        return ['audience' => ['required', Rule::in(['board', 'funder', 'public'])], ...parent::rules()];
+    }
+}

--- a/app/Http/Requests/Organisations/StoreIntakeRequestRequest.php
+++ b/app/Http/Requests/Organisations/StoreIntakeRequestRequest.php
@@ -2,7 +2,11 @@
 
 namespace App\Http\Requests\Organisations;
 
+use App\Enums\IntakeUrgency;
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
 use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
 use App\Models\Program;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
@@ -10,6 +14,12 @@ use Illuminate\Validation\Rule;
 
 class StoreIntakeRequestRequest extends FormRequest
 {
+    protected function prepareForValidation(): void
+    {
+        $configuration = $this->activeRules();
+        $this->merge(['urgency' => $this->input('urgency', $configuration?->definition['default_urgency'] ?? IntakeUrgency::Routine->value)]);
+    }
+
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -31,14 +41,16 @@ class StoreIntakeRequestRequest extends FormRequest
         $fieldDefinitions = $program === null ? [] : $this->configuredFields($program, 'intake_fields');
         $fieldKeys = $this->configuredFieldKeys($fieldDefinitions);
         $riskKeys = $program === null ? [] : $this->configuredFieldKeys($this->configuredFields($program, 'risk_flags'));
+        $required = array_values(array_map('strval', $this->activeRules()?->definition['required_fields'] ?? []));
         $rules = [
             'program_id' => ['required', 'integer', Rule::exists('programs', 'id')->where('organisation_id', $organisationId)],
             'party_uuid' => ['required', 'uuid', Rule::exists('parties', 'uuid')->where('organisation_id', $organisationId)],
             'source' => ['required', Rule::in(['staff_referral', 'self_referral', 'partner_referral', 'phone', 'walk_in', 'online'])],
             'narrative' => ['required', 'string', 'max:10000'],
             'presenting_needs' => ['required', 'string', 'max:10000'],
-            'email' => ['nullable', 'email:rfc', 'max:255'],
-            'telephone' => ['nullable', 'string', 'max:50'],
+            'urgency' => ['required', Rule::enum(IntakeUrgency::class)],
+            'email' => [Rule::requiredIf(in_array('email', $required, true)), 'nullable', 'email:rfc', 'max:255'],
+            'telephone' => [Rule::requiredIf(in_array('telephone', $required, true)), 'nullable', 'string', 'max:50'],
             'intake_fields' => [$fieldKeys === [] ? 'array' : 'array:'.implode(',', $fieldKeys)],
             'risk_flags' => ['present', 'array', 'max:20'],
             'risk_flags.*' => ['string', 'distinct', Rule::in($riskKeys)],
@@ -93,5 +105,10 @@ class StoreIntakeRequestRequest extends FormRequest
         }
 
         return $keys;
+    }
+
+    private function activeRules(): ?OrganisationConfiguration
+    {
+        return OrganisationConfiguration::query()->where('area', OrganisationConfigurationArea::IntakeRules)->where('configuration_key', 'default')->where('status', OrganisationConfigurationStatus::Active)->latest('version')->first();
     }
 }

--- a/app/Http/Requests/Organisations/StoreOrganisationConfigurationRequest.php
+++ b/app/Http/Requests/Organisations/StoreOrganisationConfigurationRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Enums\OrganisationConfigurationArea;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreOrganisationConfigurationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, ValidationRule|array<mixed>|string> */
+    public function rules(): array
+    {
+        return [
+            'area' => ['required', Rule::enum(OrganisationConfigurationArea::class)],
+            'configuration_key' => ['required', 'string', 'alpha_dash:ascii', 'max:100'],
+            'definition_json' => ['required', 'string', 'json', 'max:20000'],
+        ];
+    }
+}

--- a/app/Http/Requests/Organisations/StoreSupporterJourneyRequest.php
+++ b/app/Http/Requests/Organisations/StoreSupporterJourneyRequest.php
@@ -2,7 +2,12 @@
 
 namespace App\Http\Requests\Organisations;
 
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Enums\SupporterJourneyKind;
+use App\Models\AudienceSegment;
 use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -10,6 +15,24 @@ use Illuminate\Validation\Validator;
 
 class StoreSupporterJourneyRequest extends FormRequest
 {
+    protected function prepareForValidation(): void
+    {
+        $defaultConfiguration = OrganisationConfiguration::query()->where('area', OrganisationConfigurationArea::SupporterJourney)->where('configuration_key', 'default')->where('status', OrganisationConfigurationStatus::Active)->latest('version')->first();
+        $defaults = $defaultConfiguration instanceof OrganisationConfiguration ? $defaultConfiguration->definition : [];
+        $template = null;
+        if ($this->filled('message_template_key')) {
+            $templateConfiguration = OrganisationConfiguration::query()->where('area', OrganisationConfigurationArea::MessageTemplate)->where('configuration_key', $this->input('message_template_key'))->where('status', OrganisationConfigurationStatus::Active)->latest('version')->first();
+            $template = $templateConfiguration instanceof OrganisationConfiguration ? $templateConfiguration->definition : null;
+        }
+        $this->merge([
+            'journey_kind' => $template['journey_kind'] ?? $this->input('journey_kind', $defaults['default_kind'] ?? SupporterJourneyKind::General->value),
+            'channel' => $template['channel'] ?? $this->input('channel', $defaults['default_channel'] ?? 'email'),
+            'subject' => $template['subject'] ?? $this->input('subject', ''),
+            'body' => $template['body'] ?? $this->input('body'),
+            'experiment_enabled' => $this->input('experiment_enabled', false),
+        ]);
+    }
+
     /**
      * Determine if the user is authorized to make this request.
      */
@@ -30,9 +53,15 @@ class StoreSupporterJourneyRequest extends FormRequest
 
         return [
             'audience_segment_id' => ['required', 'uuid', Rule::exists('audience_segments', 'id')->where('organisation_id', $organisationId)],
+            'message_template_key' => ['nullable', 'string', 'max:100', Rule::exists('organisation_configurations', 'configuration_key')->where(fn ($query) => $query->where('organisation_id', $organisationId)->where('area', OrganisationConfigurationArea::MessageTemplate->value)->where('status', OrganisationConfigurationStatus::Active->value))],
             'name' => ['required', 'string', 'max:120', Rule::unique('supporter_journeys', 'name')->where('organisation_id', $organisationId)],
-            'subject' => ['required', 'string', 'max:160'],
+            'journey_kind' => ['required', Rule::enum(SupporterJourneyKind::class)],
+            'channel' => ['required', Rule::in(['email', 'sms'])],
+            'subject' => ['nullable', 'string', 'max:160', 'required_if:channel,email'],
             'body' => ['required', 'string', 'max:4000'],
+            'experiment_enabled' => ['required', 'boolean'],
+            'variant_subject' => ['nullable', 'string', 'max:160', 'required_if:experiment_enabled,1'],
+            'variant_body' => ['nullable', 'string', 'max:4000', 'required_if:experiment_enabled,1'],
         ];
     }
 
@@ -40,12 +69,22 @@ class StoreSupporterJourneyRequest extends FormRequest
     public function after(): array
     {
         return [function (Validator $validator): void {
-            foreach (['subject', 'body'] as $field) {
+            foreach (['subject', 'body', 'variant_subject', 'variant_body'] as $field) {
                 $template = (string) $this->input($field);
-                $remainder = str_replace(['{{ supporter_name }}', '{{ donation_count }}'], '', $template);
+                $remainder = str_replace(['{{ supporter_name }}', '{{ donation_count }}', '{{ activity_frequency }}', '{{ activity_value }}'], '', $template);
 
                 if (str_contains($remainder, '{{') || str_contains($remainder, '}}')) {
-                    $validator->errors()->add($field, 'Only the supporter_name and donation_count placeholders are available.');
+                    $validator->errors()->add($field, 'Only supporter_name, donation_count, activity_frequency, and activity_value placeholders are available.');
+                }
+            }
+            if ($this->input('channel') === 'sms' && (mb_strlen((string) $this->input('body')) > 480 || mb_strlen((string) $this->input('variant_body')) > 480)) {
+                $validator->errors()->add('body', 'SMS journey messages may not exceed 480 characters.');
+            }
+            $organisation = $this->route('current_organisation');
+            if ($organisation instanceof Organisation) {
+                $segment = AudienceSegment::query()->where('organisation_id', $organisation->id)->find($this->input('audience_segment_id'));
+                if ($segment !== null && ($segment->criteria['channel'] ?? null) !== $this->input('channel')) {
+                    $validator->errors()->add('channel', 'Journey channel must match the saved audience consent channel.');
                 }
             }
         }];

--- a/app/Http/Requests/Organisations/TransitionSupporterJourneyRequest.php
+++ b/app/Http/Requests/Organisations/TransitionSupporterJourneyRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Enums\SupporterJourneyStatus;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TransitionSupporterJourneyRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /** @return array<string, ValidationRule|array<mixed>|string> */
+    public function rules(): array
+    {
+        return [
+            'status' => ['required', Rule::in([SupporterJourneyStatus::Approved->value, SupporterJourneyStatus::Scheduled->value, SupporterJourneyStatus::Paused->value])],
+            'scheduled_for' => ['nullable', 'date', 'after:now', 'required_if:status,scheduled'],
+        ];
+    }
+}

--- a/app/Http/Requests/Public/StoreInKindOfferRequest.php
+++ b/app/Http/Requests/Public/StoreInKindOfferRequest.php
@@ -2,9 +2,13 @@
 
 namespace App\Http\Requests\Public;
 
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
 use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreInKindOfferRequest extends FormRequest
 {
@@ -23,6 +27,9 @@ class StoreInKindOfferRequest extends FormRequest
      */
     public function rules(): array
     {
-        return ['name' => ['required', 'string', 'max:255'], 'email' => ['required', 'string', 'lowercase', 'email:rfc', 'max:255'], 'category' => ['required', 'string', 'max:100'], 'description' => ['required', 'string', 'max:2000'], 'quantity' => ['required', 'numeric', 'gt:0', 'max:1000000'], 'unit' => ['required', 'string', 'max:50'], 'estimated_value_minor' => ['nullable', 'integer', 'min:0', 'max:1000000000', 'required_with:currency'], 'currency' => ['nullable', 'string', 'size:3', 'required_with:estimated_value_minor'], 'condition' => ['required', 'string', 'max:100'], 'consent_email' => ['required', 'boolean']];
+        $configuration = OrganisationConfiguration::query()->where('area', OrganisationConfigurationArea::PublicForm)->where('configuration_key', 'in_kind_offer')->where('status', OrganisationConfigurationStatus::Active)->latest('version')->first();
+        $required = array_values(array_map('strval', $configuration?->definition['required_fields'] ?? []));
+
+        return ['name' => ['required', 'string', 'max:255'], 'email' => ['required', 'string', 'lowercase', 'email:rfc', 'max:255'], 'category' => ['required', 'string', 'max:100'], 'description' => ['required', 'string', 'max:2000'], 'quantity' => ['required', 'numeric', 'gt:0', 'max:1000000'], 'unit' => ['required', 'string', 'max:50'], 'estimated_value_minor' => [Rule::requiredIf(in_array('estimated_value_minor', $required, true)), 'nullable', 'integer', 'min:0', 'max:1000000000', 'required_with:currency'], 'currency' => [Rule::requiredIf(in_array('currency', $required, true)), 'nullable', 'string', 'size:3', 'required_with:estimated_value_minor'], 'condition' => ['required', 'string', 'max:100'], 'consent_email' => ['required', 'boolean']];
     }
 }

--- a/app/Http/Requests/Public/StoreVolunteerApplicationRequest.php
+++ b/app/Http/Requests/Public/StoreVolunteerApplicationRequest.php
@@ -2,9 +2,13 @@
 
 namespace App\Http\Requests\Public;
 
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
 use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class StoreVolunteerApplicationRequest extends FormRequest
 {
@@ -23,14 +27,24 @@ class StoreVolunteerApplicationRequest extends FormRequest
      */
     public function rules(): array
     {
+        $required = $this->requiredFields('volunteer_registration');
+
         return [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email:rfc', 'max:255'],
-            'interests' => ['sometimes', 'array', 'max:10'],
+            'interests' => [Rule::requiredIf(in_array('interests', $required, true)), 'array', 'max:10'],
             'interests.*' => ['string', 'max:100', 'distinct'],
             'availability' => ['required', 'array', 'min:1', 'max:7'],
             'availability.*' => ['string', 'max:50', 'distinct'],
             'consent_email' => ['required', 'boolean'],
         ];
+    }
+
+    /** @return list<string> */
+    private function requiredFields(string $form): array
+    {
+        $configuration = OrganisationConfiguration::query()->where('area', OrganisationConfigurationArea::PublicForm)->where('configuration_key', $form)->where('status', OrganisationConfigurationStatus::Active)->latest('version')->first();
+
+        return array_values(array_map('strval', $configuration?->definition['required_fields'] ?? []));
     }
 }

--- a/app/Models/AudienceSegment.php
+++ b/app/Models/AudienceSegment.php
@@ -15,7 +15,7 @@ use LogicException;
  * @property string $id
  * @property int $organisation_id
  * @property string $name
- * @property array{purpose: string, channel: string, role: string, service_area: string|null, interest: string|null, donation_activity: bool, campaign_source: string|null} $criteria
+ * @property array{purpose: string, channel: string, role: string, service_area: string|null, interest: string|null, donation_activity: bool, campaign_source: string|null, activity_type?: string, recency_days?: int|null, minimum_frequency?: int, minimum_value?: int|null} $criteria
  */
 #[Fillable(['organisation_id', 'name', 'criteria', 'created_by_user_id'])]
 class AudienceSegment extends Model

--- a/app/Models/OrganisationConfiguration.php
+++ b/app/Models/OrganisationConfiguration.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use Carbon\CarbonImmutable;
+use Database\Factories\OrganisationConfigurationFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property OrganisationConfigurationArea $area
+ * @property string $configuration_key
+ * @property int $version
+ * @property array<string, mixed> $definition
+ * @property OrganisationConfigurationStatus $status
+ * @property string|null $supersedes_id
+ * @property CarbonImmutable|null $activated_at
+ * @property-read Organisation $organisation
+ */
+#[Fillable(['organisation_id', 'area', 'configuration_key', 'version', 'definition', 'status', 'supersedes_id', 'created_by_user_id', 'activated_by_user_id', 'activated_at'])]
+class OrganisationConfiguration extends Model
+{
+    /** @use HasFactory<OrganisationConfigurationFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected static function booted(): void
+    {
+        static::updating(function (OrganisationConfiguration $configuration): void {
+            if ($configuration->isDirty(['organisation_id', 'area', 'configuration_key', 'version', 'definition', 'supersedes_id', 'created_by_user_id'])) {
+                throw new LogicException('Configuration definitions are immutable; create a new version instead.');
+            }
+            if ($configuration->isDirty('status')) {
+                $from = OrganisationConfigurationStatus::from((string) $configuration->getRawOriginal('status'));
+                $allowed = match ($from) {
+                    OrganisationConfigurationStatus::Draft => [OrganisationConfigurationStatus::Active],
+                    OrganisationConfigurationStatus::Active => [OrganisationConfigurationStatus::Superseded],
+                    OrganisationConfigurationStatus::Superseded => [],
+                };
+                if (! in_array($configuration->status, $allowed, true)) {
+                    throw new LogicException("Cannot transition configuration from {$from->value} to {$configuration->status->value}.");
+                }
+            }
+        });
+        static::deleting(fn () => throw new LogicException('Configuration version history is immutable.'));
+    }
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    /** @return BelongsTo<OrganisationConfiguration, $this> */
+    public function supersedes(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'supersedes_id');
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'area' => OrganisationConfigurationArea::class,
+            'version' => 'integer',
+            'definition' => 'array',
+            'status' => OrganisationConfigurationStatus::class,
+            'activated_at' => 'immutable_datetime',
+        ];
+    }
+}

--- a/app/Models/Party.php
+++ b/app/Models/Party.php
@@ -132,6 +132,24 @@ class Party extends Model
         return $this->hasMany(Donation::class);
     }
 
+    /** @return HasMany<EventRegistration, $this> */
+    public function eventRegistrations(): HasMany
+    {
+        return $this->hasMany(EventRegistration::class);
+    }
+
+    /** @return HasMany<VolunteerApplication, $this> */
+    public function volunteerApplications(): HasMany
+    {
+        return $this->hasMany(VolunteerApplication::class);
+    }
+
+    /** @return HasMany<VolunteerHourEntry, $this> */
+    public function volunteerHourEntries(): HasMany
+    {
+        return $this->hasMany(VolunteerHourEntry::class);
+    }
+
     /** @return array<string, string> */
     protected function casts(): array
     {

--- a/app/Models/PublishedImpactSnapshot.php
+++ b/app/Models/PublishedImpactSnapshot.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use Carbon\CarbonImmutable;
+use Database\Factories\PublishedImpactSnapshotFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use LogicException;
+
+/**
+ * @property string $id
+ * @property int $organisation_id
+ * @property string $audience
+ * @property string $registry_version
+ * @property list<array<string, mixed>> $metrics
+ * @property list<array<string, mixed>> $cohort_comparisons
+ * @property array<string, string> $period
+ * @property array<string, mixed> $filters
+ * @property CarbonImmutable $approved_at
+ * @property CarbonImmutable|null $published_at
+ * @property-read Organisation $organisation
+ */
+#[Fillable(['organisation_id', 'audience', 'registry_version', 'metrics', 'cohort_comparisons', 'period', 'filters', 'approved_at', 'approved_by_user_id', 'published_at'])]
+class PublishedImpactSnapshot extends Model
+{
+    /** @use HasFactory<PublishedImpactSnapshotFactory> */
+    use BelongsToOrganisation, HasFactory, HasUuids;
+
+    protected static function booted(): void
+    {
+        static::updating(fn () => throw new LogicException('Published impact snapshots are immutable.'));
+        static::deleting(fn () => throw new LogicException('Published impact snapshots are immutable.'));
+    }
+
+    /** @return BelongsTo<Organisation, $this> */
+    public function organisation(): BelongsTo
+    {
+        return $this->belongsTo(Organisation::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'metrics' => 'array',
+            'cohort_comparisons' => 'array',
+            'period' => 'array',
+            'filters' => 'array',
+            'approved_at' => 'immutable_datetime',
+            'published_at' => 'immutable_datetime',
+        ];
+    }
+}

--- a/app/Models/SupporterJourney.php
+++ b/app/Models/SupporterJourney.php
@@ -3,7 +3,9 @@
 namespace App\Models;
 
 use App\Concerns\BelongsToOrganisation;
+use App\Enums\SupporterJourneyKind;
 use App\Enums\SupporterJourneyStatus;
+use Carbon\CarbonImmutable;
 use Database\Factories\SupporterJourneyFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
@@ -20,13 +22,19 @@ use LogicException;
  * @property string $name
  * @property string $subject
  * @property string $body
+ * @property SupporterJourneyKind $journey_kind
+ * @property string $channel
  * @property SupporterJourneyStatus $status
- * @property list<array{uuid: string, displayName: string, donationCount: int<0, max>}>|null $audience_snapshot
+ * @property int $version
+ * @property array<string, string>|null $experiment
+ * @property CarbonImmutable|null $scheduled_for
+ * @property CarbonImmutable|null $paused_at
+ * @property list<array{uuid: string, displayName: string, donationCount: int<0, max>, activityFrequency: int, activityValue: int|null}>|null $audience_snapshot
  * @property string|null $approval_hash
  * @property-read AudienceSegment $audienceSegment
  * @property-read int $recipients_count
  */
-#[Fillable(['organisation_id', 'audience_segment_id', 'name', 'subject', 'body', 'status', 'audience_snapshot', 'approval_hash', 'approved_at', 'approved_by_user_id', 'created_by_user_id'])]
+#[Fillable(['organisation_id', 'audience_segment_id', 'name', 'journey_kind', 'channel', 'subject', 'body', 'status', 'version', 'audience_snapshot', 'approval_hash', 'approved_at', 'scheduled_for', 'paused_at', 'experiment', 'approved_by_user_id', 'created_by_user_id'])]
 class SupporterJourney extends Model
 {
     /** @use HasFactory<SupporterJourneyFactory> */
@@ -38,7 +46,7 @@ class SupporterJourney extends Model
             $originalStatus = $journey->getRawOriginal('status');
 
             if ($originalStatus !== SupporterJourneyStatus::Draft->value
-                && $journey->isDirty(['audience_segment_id', 'subject', 'body', 'status', 'audience_snapshot', 'approval_hash'])) {
+                && $journey->isDirty(['audience_segment_id', 'journey_kind', 'channel', 'subject', 'body', 'experiment', 'audience_snapshot', 'approval_hash'])) {
                 throw new LogicException('Approved journey content and audience are immutable.');
             }
 
@@ -46,6 +54,13 @@ class SupporterJourney extends Model
                 && $journey->isDirty('status')
                 && ($journey->status !== SupporterJourneyStatus::Approved || $journey->audience_snapshot === null || $journey->approval_hash === null)) {
                 throw new LogicException('A journey can only leave draft through a complete approval.');
+            }
+
+            if ($originalStatus !== SupporterJourneyStatus::Draft->value && $journey->isDirty('status')) {
+                $original = SupporterJourneyStatus::from($originalStatus);
+                if (! in_array($journey->status, $original->allowedTransitions(), true)) {
+                    throw new LogicException("Cannot transition supporter journey from {$original->value} to {$journey->status->value}.");
+                }
             }
         });
     }
@@ -73,8 +88,13 @@ class SupporterJourney extends Model
     {
         return [
             'status' => SupporterJourneyStatus::class,
+            'journey_kind' => SupporterJourneyKind::class,
+            'version' => 'integer',
             'audience_snapshot' => 'array',
+            'experiment' => 'array',
             'approved_at' => 'immutable_datetime',
+            'scheduled_for' => 'immutable_datetime',
+            'paused_at' => 'immutable_datetime',
         ];
     }
 }

--- a/app/Models/SupporterJourneyRecipient.php
+++ b/app/Models/SupporterJourneyRecipient.php
@@ -18,11 +18,12 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  * @property string $supporter_journey_id
  * @property int $party_id
  * @property SupporterJourneyRecipientStatus $status
+ * @property string|null $variant
  * @property int $attempt_count
  * @property-read Party $party
  * @property-read SupporterJourney $journey
  */
-#[Fillable(['organisation_id', 'supporter_journey_id', 'party_id', 'status', 'attempt_count', 'last_attempted_at'])]
+#[Fillable(['organisation_id', 'supporter_journey_id', 'party_id', 'status', 'variant', 'attempt_count', 'last_attempted_at'])]
 class SupporterJourneyRecipient extends Model
 {
     /** @use HasFactory<SupporterJourneyRecipientFactory> */

--- a/app/Policies/OrganisationConfigurationPolicy.php
+++ b/app/Policies/OrganisationConfigurationPolicy.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use App\Models\User;
+
+class OrganisationConfigurationPolicy
+{
+    public function viewAny(User $user, Organisation $organisation): bool
+    {
+        return $user->hasOrganisationRole($organisation, OrganisationRole::OrganisationAdministrator);
+    }
+
+    public function view(User $user, OrganisationConfiguration $configuration): bool
+    {
+        return $this->viewAny($user, $configuration->organisation);
+    }
+
+    public function create(User $user, Organisation $organisation): bool
+    {
+        return $this->viewAny($user, $organisation);
+    }
+
+    public function update(User $user, OrganisationConfiguration $configuration): bool
+    {
+        return $this->view($user, $configuration);
+    }
+
+    public function delete(User $user, OrganisationConfiguration $configuration): bool
+    {
+        return false;
+    }
+}

--- a/app/Policies/PublishedImpactSnapshotPolicy.php
+++ b/app/Policies/PublishedImpactSnapshotPolicy.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\PublishedImpactSnapshot;
+use App\Models\User;
+
+class PublishedImpactSnapshotPolicy
+{
+    public function viewAny(User $user, Organisation $organisation): bool
+    {
+        return $user->hasOrganisationRole($organisation, OrganisationRole::ExecutiveViewer);
+    }
+
+    public function view(User $user, PublishedImpactSnapshot $snapshot): bool
+    {
+        return $this->viewAny($user, $snapshot->organisation);
+    }
+
+    public function create(User $user, Organisation $organisation): bool
+    {
+        return $this->viewAny($user, $organisation);
+    }
+
+    public function update(User $user, PublishedImpactSnapshot $snapshot): bool
+    {
+        return false;
+    }
+
+    public function delete(User $user, PublishedImpactSnapshot $snapshot): bool
+    {
+        return false;
+    }
+}

--- a/app/Reporting/MetricRegistry.php
+++ b/app/Reporting/MetricRegistry.php
@@ -6,7 +6,21 @@ use App\Enums\OrganisationRole;
 
 class MetricRegistry
 {
-    public const VERSION = '2026.3';
+    public const VERSION = '2026.4';
+
+    /** @return list<string> */
+    public function ids(): array
+    {
+        $ids = [];
+
+        foreach (OrganisationRole::cases() as $role) {
+            foreach ($this->forRole($role) as $definition) {
+                $ids[$definition['id']] = true;
+            }
+        }
+
+        return array_keys($ids);
+    }
 
     /** @return list<array{id: string, version: string, category: string, domain: string, label: string, description: string, formula: string, unit: string, dimensions: list<string>}> */
     public function forRole(?OrganisationRole $role): array
@@ -23,6 +37,8 @@ class MetricRegistry
             $this->definition('engagement.event_attendance', 'output', 'engagement', 'Event attendance', 'Event registrations entering attended state in the reporting period.', 'count(attended registrations)', 'count', ['date', 'area', 'location', 'cohort']),
             $this->definition('engagement.in_kind_fulfilments', 'output', 'engagement', 'In-kind fulfilments', 'In-kind offers fulfilled in the reporting period.', 'count(fulfilled offers)', 'count', ['date', 'area', 'location', 'cohort']),
             $this->definition('engagement.partner_commitments', 'activity', 'engagement', 'Partner commitments', 'Partner commitments recorded in the reporting period.', 'count(commitments)', 'count', ['date', 'area', 'location', 'cohort']),
+            $this->definition('data.missing_service_area_rate', 'quality', 'data', 'Missing service-area rate', 'Party records created in the reporting period without a service-area value.', 'parties missing service area / parties created', 'percent', ['date', 'cohort']),
+            $this->definition('data.missing_contact_rate', 'quality', 'data', 'Missing contact rate', 'Party records created in the reporting period without an email or telephone contact.', 'parties missing email and telephone / parties created', 'percent', ['date', 'cohort']),
             $this->definition('fundraising.net_raised', 'output', 'fundraising', 'Net raised', 'Succeeded payment value less refunds recorded in the reporting period.', 'sum(succeeded payment minor units) - sum(refund minor units)', 'currency', ['date', 'area', 'location', 'cohort', 'campaign']),
             $this->definition('engagement.meaningful_action_rate', 'outcome', 'engagement', 'Meaningful action rate', 'Recipients with a meaningful action divided by delivered recipients.', 'meaningful recipients / delivered recipients', 'percent', ['date', 'area', 'location', 'cohort', 'campaign']),
         ];
@@ -30,7 +46,7 @@ class MetricRegistry
         $domains = match ($role) {
             OrganisationRole::ProgramManager => ['service'],
             OrganisationRole::EngagementOfficer => ['fundraising', 'engagement'],
-            OrganisationRole::ExecutiveViewer => ['service', 'fundraising', 'engagement'],
+            OrganisationRole::ExecutiveViewer => ['service', 'fundraising', 'engagement', 'data'],
             default => [],
         };
 

--- a/database/factories/AudienceSegmentFactory.php
+++ b/database/factories/AudienceSegmentFactory.php
@@ -32,6 +32,10 @@ class AudienceSegmentFactory extends Factory
                 'interest' => null,
                 'donation_activity' => true,
                 'campaign_source' => null,
+                'activity_type' => 'donation',
+                'recency_days' => null,
+                'minimum_frequency' => 1,
+                'minimum_value' => null,
             ],
         ];
     }

--- a/database/factories/OrganisationConfigurationFactory.php
+++ b/database/factories/OrganisationConfigurationFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Models\OrganisationConfiguration;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<OrganisationConfiguration>
+ */
+class OrganisationConfigurationFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'area' => OrganisationConfigurationArea::Reporting,
+            'configuration_key' => 'impact',
+            'version' => 1,
+            'definition' => ['public_metric_ids' => ['engagement.event_attendance'], 'pack_metric_ids' => ['engagement.event_attendance']],
+            'status' => OrganisationConfigurationStatus::Active,
+            'activated_at' => now(),
+        ];
+    }
+}

--- a/database/factories/PublishedImpactSnapshotFactory.php
+++ b/database/factories/PublishedImpactSnapshotFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\PublishedImpactSnapshot;
+use App\OrganisationContext;
+use App\Reporting\MetricRegistry;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PublishedImpactSnapshot>
+ */
+class PublishedImpactSnapshotFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'audience' => 'board',
+            'registry_version' => MetricRegistry::VERSION,
+            'metrics' => [],
+            'cohort_comparisons' => [],
+            'period' => ['start' => now()->startOfMonth()->toAtomString(), 'endExclusive' => now()->addDay()->startOfDay()->toAtomString()],
+            'filters' => [],
+            'approved_at' => now(),
+        ];
+    }
+}

--- a/database/factories/SupporterJourneyFactory.php
+++ b/database/factories/SupporterJourneyFactory.php
@@ -2,6 +2,7 @@
 
 namespace Database\Factories;
 
+use App\Enums\SupporterJourneyKind;
 use App\Enums\SupporterJourneyStatus;
 use App\Models\AudienceSegment;
 use App\Models\SupporterJourney;
@@ -24,9 +25,12 @@ class SupporterJourneyFactory extends Factory
             'organisation_id' => app(OrganisationContext::class)->id(),
             'audience_segment_id' => AudienceSegment::factory(),
             'name' => fake()->unique()->words(3, true),
+            'journey_kind' => SupporterJourneyKind::General,
+            'channel' => 'email',
             'subject' => 'Thank you, {{ supporter_name }}',
             'body' => 'Your {{ donation_count }} contribution(s) make a difference.',
             'status' => SupporterJourneyStatus::Draft,
+            'version' => 1,
         ];
     }
 }

--- a/database/migrations/2026_08_31_200514_create_organisation_configurations_table.php
+++ b/database/migrations/2026_08_31_200514_create_organisation_configurations_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('organisation_configurations', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->string('area', 40);
+            $table->string('configuration_key', 100);
+            $table->unsignedInteger('version');
+            $table->json('definition');
+            $table->string('status', 24)->default('draft');
+            $table->uuid('supersedes_id')->nullable();
+            $table->foreignId('created_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('activated_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('activated_at')->nullable();
+            $table->timestamps();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'area', 'configuration_key', 'version'], 'org_configs_area_key_version_unique');
+            $table->index(['organisation_id', 'area', 'configuration_key', 'status'], 'org_configs_area_key_status_index');
+        });
+        Schema::table('organisation_configurations', function (Blueprint $table) {
+            $table->foreign('supersedes_id')->references('id')->on('organisation_configurations')->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('organisation_configurations');
+    }
+};

--- a/database/migrations/2026_08_31_200516_create_published_impact_snapshots_table.php
+++ b/database/migrations/2026_08_31_200516_create_published_impact_snapshots_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('published_impact_snapshots', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->string('audience', 24);
+            $table->string('registry_version', 24);
+            $table->json('metrics');
+            $table->json('cohort_comparisons');
+            $table->json('period');
+            $table->json('filters');
+            $table->timestamp('approved_at');
+            $table->foreignId('approved_by_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('published_at')->nullable();
+            $table->timestamps();
+            $table->unique(['organisation_id', 'id']);
+            $table->index(['organisation_id', 'audience', 'published_at']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('published_impact_snapshots');
+    }
+};

--- a/database/migrations/2026_08_31_202221_extend_supporter_journeys_for_scheduling_and_experiments.php
+++ b/database/migrations/2026_08_31_202221_extend_supporter_journeys_for_scheduling_and_experiments.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('supporter_journeys', function (Blueprint $table) {
+            $table->string('journey_kind', 32)->default('general')->after('name');
+            $table->string('channel', 24)->default('email')->after('journey_kind');
+            $table->unsignedInteger('version')->default(1)->after('status');
+            $table->timestamp('scheduled_for')->nullable()->after('approved_at');
+            $table->timestamp('paused_at')->nullable()->after('scheduled_for');
+            $table->json('experiment')->nullable()->after('paused_at');
+        });
+        Schema::table('supporter_journey_recipients', function (Blueprint $table) {
+            $table->string('variant', 1)->nullable()->after('status');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('supporter_journeys', function (Blueprint $table) {
+            $table->dropColumn(['journey_kind', 'channel', 'version', 'scheduled_for', 'paused_at', 'experiment']);
+        });
+        Schema::table('supporter_journey_recipients', function (Blueprint $table) {
+            $table->dropColumn('variant');
+        });
+    }
+};

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -12,6 +12,8 @@ import {
     Settings2,
     UsersRound,
     HeartHandshake,
+    SlidersHorizontal,
+    ChartNoAxesCombined,
 } from 'lucide-react';
 import AppLogo from '@/components/app-logo';
 import { NavFooter } from '@/components/nav-footer';
@@ -33,6 +35,8 @@ import { index as auditIndex } from '@/routes/audit';
 import { index as communityEngagementIndex } from '@/routes/community-engagement';
 import { index as donationsIndex } from '@/routes/donations';
 import { index as intakesIndex } from '@/routes/intakes';
+import { index as configurationsIndex } from '@/routes/organisation-configurations';
+import { index as impactSnapshotsIndex } from '@/routes/impact-snapshots';
 import { index as partiesIndex } from '@/routes/parties';
 import { index as programsIndex } from '@/routes/programs';
 import { index as supporterJourneysIndex } from '@/routes/supporter-journeys';
@@ -129,6 +133,29 @@ export function AppSidebar() {
                       title: 'Program configuration',
                       href: programsIndex(page.props.currentOrganisation.slug),
                       icon: Settings2,
+                  },
+              ]
+            : []),
+        ...(page.props.canViewOrganisationConfigurations &&
+        page.props.currentOrganisation
+            ? [
+                  {
+                      title: 'Organisation configuration',
+                      href: configurationsIndex(
+                          page.props.currentOrganisation.slug,
+                      ),
+                      icon: SlidersHorizontal,
+                  },
+              ]
+            : []),
+        ...(page.props.canViewImpactSnapshots && page.props.currentOrganisation
+            ? [
+                  {
+                      title: 'Impact packs',
+                      href: impactSnapshotsIndex(
+                          page.props.currentOrganisation.slug,
+                      ),
+                      icon: ChartNoAxesCombined,
                   },
               ]
             : []),

--- a/resources/js/pages/audience-segments/index.tsx
+++ b/resources/js/pages/audience-segments/index.tsx
@@ -8,7 +8,7 @@ import { index, show, store } from '@/routes/audience-segments';
 type Segment = {
     id: string;
     name: string;
-    criteria: Record<string, string | boolean | null>;
+    criteria: Record<string, string | boolean | number | null>;
     eligibleCount: number;
 };
 type Option = { value: string; label: string };
@@ -21,6 +21,7 @@ type Props = {
         serviceAreas: string[];
         interests: Array<{ slug: string; label: string }>;
         campaignSources: string[];
+        activityTypes: Option[];
     };
 };
 
@@ -93,6 +94,48 @@ export default function AudienceSegmentsIndex({ segments, options }: Props) {
                                         optional
                                     />
                                     <Select
+                                        name="activity_type"
+                                        label="Eligible activity"
+                                        options={options.activityTypes}
+                                    />
+                                    <label className="grid gap-1">
+                                        <span>
+                                            Recency window in days (optional)
+                                        </span>
+                                        <input
+                                            name="recency_days"
+                                            type="number"
+                                            min="1"
+                                            max="3650"
+                                            className="h-9 rounded-md border bg-transparent px-3"
+                                        />
+                                    </label>
+                                    <label className="grid gap-1">
+                                        <span>Minimum frequency</span>
+                                        <input
+                                            name="minimum_frequency"
+                                            type="number"
+                                            min="0"
+                                            defaultValue="0"
+                                            required
+                                            className="h-9 rounded-md border bg-transparent px-3"
+                                        />
+                                    </label>
+                                    <label className="grid gap-1">
+                                        <span>Minimum value (optional)</span>
+                                        <input
+                                            name="minimum_value"
+                                            type="number"
+                                            min="0"
+                                            className="h-9 rounded-md border bg-transparent px-3"
+                                        />
+                                        <small className="text-muted-foreground">
+                                            Donation minor units, event
+                                            attendances, or volunteer minutes.
+                                            Leave blank for Any.
+                                        </small>
+                                    </label>
+                                    <Select
                                         name="campaign_source"
                                         label="Donation source (optional)"
                                         options={options.campaignSources.map(
@@ -103,19 +146,11 @@ export default function AudienceSegmentsIndex({ segments, options }: Props) {
                                         )}
                                         optional
                                     />
-                                    <label className="flex items-center gap-2">
-                                        <input
-                                            type="hidden"
-                                            name="donation_activity"
-                                            value="0"
-                                        />
-                                        <input
-                                            type="checkbox"
-                                            name="donation_activity"
-                                            value="1"
-                                        />
-                                        Require a successful simulated donation
-                                    </label>
+                                    <input
+                                        type="hidden"
+                                        name="donation_activity"
+                                        value="0"
+                                    />
                                     <Button type="submit" disabled={processing}>
                                         Save and preview
                                     </Button>

--- a/resources/js/pages/audience-segments/show.tsx
+++ b/resources/js/pages/audience-segments/show.tsx
@@ -11,6 +11,10 @@ type Member = {
     serviceAreas: string[];
     interests: string[];
     donationCount: number;
+    activityType: string;
+    activityFrequency: number;
+    activityValue: number | null;
+    latestActivityAt: string | null;
     consentedAt: string;
 };
 
@@ -22,7 +26,7 @@ export default function AudienceSegmentShow({
     segment: {
         id: string;
         name: string;
-        criteria: Record<string, string | boolean | null>;
+        criteria: Record<string, string | boolean | number | null>;
     };
     audience: Member[];
     eligibleCount: number;
@@ -76,9 +80,27 @@ export default function AudienceSegmentShow({
                                     </div>
                                     <div className="text-sm">
                                         <p>
-                                            {member.donationCount} matching
-                                            donation(s)
+                                            {member.activityFrequency}{' '}
+                                            {member.activityType.replaceAll(
+                                                '_',
+                                                ' ',
+                                            )}{' '}
+                                            activity record(s)
                                         </p>
+                                        {member.activityValue !== null ? (
+                                            <p>
+                                                Declared value:{' '}
+                                                {member.activityValue}
+                                            </p>
+                                        ) : null}
+                                        {member.latestActivityAt ? (
+                                            <p>
+                                                Latest activity:{' '}
+                                                {new Date(
+                                                    member.latestActivityAt,
+                                                ).toLocaleString()}
+                                            </p>
+                                        ) : null}
                                         <p>
                                             Consent:{' '}
                                             {new Date(

--- a/resources/js/pages/impact-snapshots/index.tsx
+++ b/resources/js/pages/impact-snapshots/index.tsx
@@ -1,0 +1,113 @@
+import { Form, Head, usePage } from '@inertiajs/react';
+import Heading from '@/components/heading';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { download, index, store } from '@/routes/impact-snapshots';
+
+type Snapshot = {
+    id: string;
+    audience: string;
+    registryVersion: string;
+    metricCount: number;
+    approvedAt: string;
+    publishedAt: string | null;
+};
+
+export default function ImpactSnapshotsIndex({
+    snapshots,
+}: {
+    snapshots: Snapshot[];
+}) {
+    const organisation = usePage().props.currentOrganisation!;
+    return (
+        <div className="space-y-6 p-4">
+            <Head title="Impact packs" />
+            <Heading
+                title="Impact packs"
+                description="Approve an immutable board, funder, or public snapshot from the reconciled metric registry. Active reporting configuration controls which aggregate metrics can leave the dashboard."
+            />
+            <Card>
+                <CardHeader>
+                    <CardTitle>Approve snapshot</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Form
+                        {...store.form(organisation.slug)}
+                        className="grid gap-3 md:grid-cols-3"
+                    >
+                        <select
+                            name="audience"
+                            className="h-9 rounded border bg-transparent px-3"
+                        >
+                            <option value="board">Board pack</option>
+                            <option value="funder">Funder pack</option>
+                            <option value="public">Public impact</option>
+                        </select>
+                        <input
+                            name="period_start"
+                            type="date"
+                            className="h-9 rounded border bg-transparent px-3"
+                        />
+                        <input
+                            name="period_end"
+                            type="date"
+                            className="h-9 rounded border bg-transparent px-3"
+                        />
+                        <Button className="md:col-span-3">
+                            Approve reconciled snapshot
+                        </Button>
+                    </Form>
+                </CardContent>
+            </Card>
+            <section className="space-y-3">
+                <h2 className="text-xl font-semibold">Approved snapshots</h2>
+                {snapshots.map((snapshot) => (
+                    <Card key={snapshot.id}>
+                        <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-6">
+                            <div>
+                                <strong>{snapshot.audience} impact</strong>
+                                <p className="text-muted-foreground text-sm">
+                                    Registry {snapshot.registryVersion} ·{' '}
+                                    {snapshot.metricCount} metrics ·{' '}
+                                    {new Date(
+                                        snapshot.approvedAt,
+                                    ).toLocaleString()}
+                                </p>
+                            </div>
+                            <div className="flex gap-2">
+                                <Badge>
+                                    {snapshot.publishedAt
+                                        ? 'published'
+                                        : 'approved'}
+                                </Badge>
+                                {snapshot.audience !== 'public' ? (
+                                    <Button variant="outline" asChild>
+                                        <a
+                                            href={
+                                                download([
+                                                    organisation.slug,
+                                                    snapshot.id,
+                                                ]).url
+                                            }
+                                        >
+                                            Download CSV pack
+                                        </a>
+                                    </Button>
+                                ) : null}
+                            </div>
+                        </CardContent>
+                    </Card>
+                ))}
+            </section>
+        </div>
+    );
+}
+
+ImpactSnapshotsIndex.layout = (props: {
+    currentOrganisation: { slug: string };
+}) => ({
+    breadcrumbs: [
+        { title: 'Impact packs', href: index(props.currentOrganisation.slug) },
+    ],
+});

--- a/resources/js/pages/organisation-configurations/index.tsx
+++ b/resources/js/pages/organisation-configurations/index.tsx
@@ -1,0 +1,220 @@
+import { Form, Head, usePage } from '@inertiajs/react';
+import Heading from '@/components/heading';
+import InputError from '@/components/input-error';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { activate, index, store } from '@/routes/organisation-configurations';
+
+type Configuration = {
+    id: string;
+    area: string;
+    key: string;
+    version: number;
+    status: string;
+    definition: Record<string, unknown>;
+    activatedAt: string | null;
+};
+type Area = { value: string; label: string };
+
+const examples: Record<string, string> = {
+    public_form: JSON.stringify(
+        { form: 'event_registration', required_fields: ['name', 'email'] },
+        null,
+        2,
+    ),
+    message_template: JSON.stringify(
+        {
+            channel: 'sms',
+            subject: null,
+            body: 'Thanks {{ supporter_name }}',
+            journey_kind: 're_engagement',
+        },
+        null,
+        2,
+    ),
+    supporter_journey: JSON.stringify(
+        {
+            default_kind: 're_engagement',
+            default_channel: 'email',
+            require_approval: true,
+            dispatch_rechecks_consent: true,
+            frequency_cap_days: 7,
+        },
+        null,
+        2,
+    ),
+    intake_rules: JSON.stringify(
+        {
+            required_fields: ['party_uuid', 'email', 'presenting_needs'],
+            default_urgency: 'routine',
+            allow_restricted_access_bypass: false,
+        },
+        null,
+        2,
+    ),
+    reporting: JSON.stringify(
+        {
+            public_metric_ids: ['engagement.event_attendance'],
+            pack_metric_ids: [
+                'service.requests_received',
+                'engagement.event_attendance',
+                'data.missing_service_area_rate',
+            ],
+        },
+        null,
+        2,
+    ),
+};
+
+export default function OrganisationConfigurationsIndex({
+    configurations,
+    areas,
+}: {
+    configurations: Configuration[];
+    areas: Area[];
+}) {
+    const organisation = usePage().props.currentOrganisation!;
+    return (
+        <div className="space-y-6 p-4">
+            <Head title="Organisation configuration" />
+            <Heading
+                title="Organisation configuration"
+                description="Create immutable, validated versions. Preview the exact definition below, then explicitly activate it. Fixed consent, access, and service-data safeguards cannot be disabled."
+            />
+            <Card>
+                <CardHeader>
+                    <CardTitle>Create configuration version</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <Form
+                        {...store.form(organisation.slug)}
+                        className="grid gap-4"
+                    >
+                        {({ errors, processing }) => (
+                            <>
+                                <label className="grid gap-1">
+                                    <span>Area</span>
+                                    <select
+                                        name="area"
+                                        className="h-9 rounded border bg-transparent px-3"
+                                    >
+                                        {areas.map((area) => (
+                                            <option
+                                                key={area.value}
+                                                value={area.value}
+                                            >
+                                                {area.label}
+                                            </option>
+                                        ))}
+                                    </select>
+                                    <InputError message={errors.area} />
+                                </label>
+                                <label className="grid gap-1">
+                                    <span>Configuration key</span>
+                                    <input
+                                        name="configuration_key"
+                                        defaultValue="impact"
+                                        required
+                                        className="h-9 rounded border bg-transparent px-3"
+                                    />
+                                    <InputError
+                                        message={errors.configuration_key}
+                                    />
+                                    <small className="text-muted-foreground">
+                                        Use impact for reporting, default for
+                                        journey or intake defaults, and the form
+                                        name (for example
+                                        volunteer_registration) for public
+                                        forms. Message-template keys are your
+                                        choice.
+                                    </small>
+                                </label>
+                                <label className="grid gap-1">
+                                    <span>Validated JSON definition</span>
+                                    <textarea
+                                        name="definition_json"
+                                        rows={10}
+                                        defaultValue={examples.reporting}
+                                        required
+                                        className="rounded border bg-transparent p-3 font-mono text-sm"
+                                    />
+                                    <InputError
+                                        message={errors.definition_json}
+                                    />
+                                </label>
+                                <details>
+                                    <summary>Safe examples by area</summary>
+                                    {Object.entries(examples).map(
+                                        ([area, example]) => (
+                                            <div key={area} className="mt-3">
+                                                <strong>
+                                                    {area.replaceAll('_', ' ')}
+                                                </strong>
+                                                <pre className="bg-muted overflow-auto rounded p-3 text-xs">
+                                                    {example}
+                                                </pre>
+                                            </div>
+                                        ),
+                                    )}
+                                </details>
+                                <Button disabled={processing}>
+                                    Validate and create draft
+                                </Button>
+                            </>
+                        )}
+                    </Form>
+                </CardContent>
+            </Card>
+            <section className="space-y-3">
+                <h2 className="text-xl font-semibold">
+                    Version history and preview
+                </h2>
+                {configurations.map((configuration) => (
+                    <Card key={configuration.id}>
+                        <CardContent className="space-y-3 pt-6">
+                            <div className="flex flex-wrap items-center gap-2">
+                                <strong>
+                                    {configuration.area.replaceAll('_', ' ')} ·{' '}
+                                    {configuration.key} · v
+                                    {configuration.version}
+                                </strong>
+                                <Badge>{configuration.status}</Badge>
+                            </div>
+                            <pre className="bg-muted overflow-auto rounded p-3 text-xs">
+                                {JSON.stringify(
+                                    configuration.definition,
+                                    null,
+                                    2,
+                                )}
+                            </pre>
+                            {configuration.status === 'draft' ? (
+                                <Form
+                                    {...activate.form([
+                                        organisation.slug,
+                                        configuration.id,
+                                    ])}
+                                >
+                                    <Button variant="outline">
+                                        Activate this version
+                                    </Button>
+                                </Form>
+                            ) : null}
+                        </CardContent>
+                    </Card>
+                ))}
+            </section>
+        </div>
+    );
+}
+
+OrganisationConfigurationsIndex.layout = (props: {
+    currentOrganisation: { slug: string };
+}) => ({
+    breadcrumbs: [
+        {
+            title: 'Organisation configuration',
+            href: index(props.currentOrganisation.slug),
+        },
+    ],
+});

--- a/resources/js/pages/supporter-journeys/index.tsx
+++ b/resources/js/pages/supporter-journeys/index.tsx
@@ -13,9 +13,14 @@ type Props = {
         recipientCount: number;
     }>;
     segments: Array<{ id: string; name: string }>;
+    templates: Array<{ key: string; channel: string; journeyKind: string }>;
 };
 
-export default function SupporterJourneysIndex({ journeys, segments }: Props) {
+export default function SupporterJourneysIndex({
+    journeys,
+    segments,
+    templates,
+}: Props) {
     const organisation = usePage().props.currentOrganisation!;
 
     return (
@@ -43,6 +48,65 @@ export default function SupporterJourneysIndex({ journeys, segments }: Props) {
                                         error={errors.name}
                                     />
                                     <label className="grid gap-1">
+                                        <span>
+                                            Active message template (optional)
+                                        </span>
+                                        <select
+                                            name="message_template_key"
+                                            className="h-9 rounded-md border bg-transparent px-3"
+                                        >
+                                            <option value="">
+                                                Custom content below
+                                            </option>
+                                            {templates.map((template) => (
+                                                <option
+                                                    key={template.key}
+                                                    value={template.key}
+                                                >
+                                                    {template.key} ·{' '}
+                                                    {template.channel} ·{' '}
+                                                    {template.journeyKind.replaceAll(
+                                                        '_',
+                                                        ' ',
+                                                    )}
+                                                </option>
+                                            ))}
+                                        </select>
+                                        <small className="text-muted-foreground">
+                                            Selecting a template uses its frozen
+                                            active content and channel.
+                                        </small>
+                                    </label>
+                                    <label className="grid gap-1">
+                                        <span>Journey path</span>
+                                        <select
+                                            name="journey_kind"
+                                            className="h-9 rounded-md border bg-transparent px-3"
+                                        >
+                                            <option value="general">
+                                                General
+                                            </option>
+                                            <option value="re_engagement">
+                                                Re-engagement
+                                            </option>
+                                            <option value="event">Event</option>
+                                            <option value="volunteer">
+                                                Volunteer
+                                            </option>
+                                        </select>
+                                    </label>
+                                    <label className="grid gap-1">
+                                        <span>Channel</span>
+                                        <select
+                                            name="channel"
+                                            className="h-9 rounded-md border bg-transparent px-3"
+                                        >
+                                            <option value="email">Email</option>
+                                            <option value="sms">SMS</option>
+                                        </select>
+                                        <InputError message={errors.channel} />
+                                    </label>
+                                    <label className="grid gap-1">
                                         <span>Saved audience</span>
                                         <select
                                             name="audience_segment_id"
@@ -64,8 +128,9 @@ export default function SupporterJourneysIndex({ journeys, segments }: Props) {
                                     </label>
                                     <Field
                                         name="subject"
-                                        label="Subject"
+                                        label="Subject (email only)"
                                         error={errors.subject}
+                                        required={false}
                                     />
                                     <label className="grid gap-1">
                                         <span>Message</span>
@@ -81,8 +146,43 @@ export default function SupporterJourneysIndex({ journeys, segments }: Props) {
                                     <p className="text-muted-foreground text-sm">
                                         Safe placeholders:{' '}
                                         {'{{ supporter_name }}'} and{' '}
-                                        {'{{ donation_count }}'}.
+                                        {'{{ donation_count }}'},{' '}
+                                        {'{{ activity_frequency }}'}, and{' '}
+                                        {'{{ activity_value }}'}.
                                     </p>
+                                    <input
+                                        type="hidden"
+                                        name="experiment_enabled"
+                                        value="0"
+                                    />
+                                    <label className="flex items-center gap-2">
+                                        <input
+                                            type="checkbox"
+                                            name="experiment_enabled"
+                                            value="1"
+                                        />
+                                        Enable deterministic A/B message variant
+                                    </label>
+                                    <Field
+                                        name="variant_subject"
+                                        label="Variant B subject (when experiment enabled)"
+                                        error={errors.variant_subject}
+                                        required={false}
+                                    />
+                                    <label className="grid gap-1">
+                                        <span>
+                                            Variant B message (when experiment
+                                            enabled)
+                                        </span>
+                                        <textarea
+                                            name="variant_body"
+                                            rows={4}
+                                            className="rounded-md border bg-transparent px-3 py-2"
+                                        />
+                                        <InputError
+                                            message={errors.variant_body}
+                                        />
+                                    </label>
                                     <Button
                                         type="submit"
                                         disabled={
@@ -123,17 +223,19 @@ function Field({
     name,
     label,
     error,
+    required = true,
 }: {
     name: string;
     label: string;
     error?: string;
+    required?: boolean;
 }) {
     return (
         <label className="grid gap-1">
             <span>{label}</span>
             <input
                 name={name}
-                required
+                required={required}
                 className="h-9 rounded-md border bg-transparent px-3"
             />
             <InputError message={error} />

--- a/resources/js/pages/supporter-journeys/show.tsx
+++ b/resources/js/pages/supporter-journeys/show.tsx
@@ -5,12 +5,14 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { approve, dispatch, index, show } from '@/routes/supporter-journeys';
 import { store as transition } from '@/routes/supporter-journeys/recipients/transitions';
+import { store as transitionJourney } from '@/routes/supporter-journeys/transitions';
 
 type Recipient = {
     id: string;
     displayName: string;
     status: string;
     attemptCount: number;
+    variant: string | null;
     events: Array<{ id: string; type: string }>;
     actionKeys: Record<string, string>;
 };
@@ -20,11 +22,18 @@ type Journey = {
     subject: string;
     body: string;
     status: string;
+    kind: string;
+    channel: string;
+    scheduledFor: string | null;
+    pausedAt: string | null;
+    experiment: { subject: string; body: string } | null;
     audienceName: string;
     audienceSnapshot: Array<{
         uuid: string;
         displayName: string;
         donationCount: number;
+        activityFrequency: number;
+        activityValue: number | null;
     }>;
     approvalHash: string | null;
     recipients: Recipient[];
@@ -59,6 +68,13 @@ export default function SupporterJourneyShow({
                     </CardHeader>
                     <CardContent className="space-y-4">
                         <Badge>{journey.status}</Badge>
+                        <p className="text-muted-foreground text-sm">
+                            {journey.kind.replaceAll('_', ' ')} ·{' '}
+                            {journey.channel}
+                            {journey.scheduledFor
+                                ? ` · scheduled ${new Date(journey.scheduledFor).toLocaleString()}`
+                                : ''}
+                        </p>
                         <div className="rounded-md border p-4">
                             <strong>
                                 {render(
@@ -73,6 +89,25 @@ export default function SupporterJourneyShow({
                                 )}
                             </p>
                         </div>
+                        {journey.experiment ? (
+                            <div className="rounded-md border border-dashed p-4">
+                                <p className="text-sm font-medium">
+                                    Variant B preview
+                                </p>
+                                <strong>
+                                    {render(
+                                        journey.experiment.subject,
+                                        journey.audienceSnapshot[0],
+                                    )}
+                                </strong>
+                                <p className="mt-3 whitespace-pre-wrap">
+                                    {render(
+                                        journey.experiment.body,
+                                        journey.audienceSnapshot[0],
+                                    )}
+                                </p>
+                            </div>
+                        ) : null}
                         <p className="text-muted-foreground text-sm">
                             {journey.status === 'draft'
                                 ? 'Approval freezes this content and the currently eligible audience.'
@@ -86,7 +121,7 @@ export default function SupporterJourneyShow({
                                     </Button>
                                 )}
                             </Form>
-                        ) : (
+                        ) : journey.status !== 'paused' ? (
                             <Form {...dispatch.form(routeArgs)}>
                                 {({ processing }) => (
                                     <Button disabled={processing}>
@@ -95,7 +130,47 @@ export default function SupporterJourneyShow({
                                     </Button>
                                 )}
                             </Form>
-                        )}
+                        ) : null}
+                        {journey.status === 'approved' ? (
+                            <div className="flex flex-wrap gap-2">
+                                <Form
+                                    {...transitionJourney.form(routeArgs)}
+                                    className="flex gap-2"
+                                >
+                                    <input
+                                        type="hidden"
+                                        name="status"
+                                        value="scheduled"
+                                    />
+                                    <input
+                                        type="datetime-local"
+                                        name="scheduled_for"
+                                        required
+                                        className="h-9 rounded border bg-transparent px-2"
+                                    />
+                                    <Button variant="outline">Schedule</Button>
+                                </Form>
+                                <JourneyTransition
+                                    routeArgs={routeArgs}
+                                    status="paused"
+                                    label="Pause"
+                                />
+                            </div>
+                        ) : null}
+                        {journey.status === 'scheduled' ? (
+                            <JourneyTransition
+                                routeArgs={routeArgs}
+                                status="paused"
+                                label="Pause schedule"
+                            />
+                        ) : null}
+                        {journey.status === 'paused' ? (
+                            <JourneyTransition
+                                routeArgs={routeArgs}
+                                status="approved"
+                                label="Resume approved"
+                            />
+                        ) : null}
                     </CardContent>
                 </Card>
                 <section
@@ -116,6 +191,9 @@ export default function SupporterJourneyShow({
                                     <p className="text-muted-foreground text-sm">
                                         {recipient.status} ·{' '}
                                         {recipient.attemptCount} retries
+                                        {recipient.variant
+                                            ? ` · variant ${recipient.variant}`
+                                            : ''}
                                     </p>
                                 </div>
                                 <div className="flex flex-wrap gap-2">
@@ -164,7 +242,12 @@ export default function SupporterJourneyShow({
 
 function render(
     template: string,
-    supporter?: { displayName: string; donationCount: number },
+    supporter?: {
+        displayName: string;
+        donationCount: number;
+        activityFrequency: number;
+        activityValue: number | null;
+    },
 ) {
     return template
         .replaceAll(
@@ -174,7 +257,32 @@ function render(
         .replaceAll(
             '{{ donation_count }}',
             String(supporter?.donationCount ?? 0),
+        )
+        .replaceAll(
+            '{{ activity_frequency }}',
+            String(supporter?.activityFrequency ?? 0),
+        )
+        .replaceAll(
+            '{{ activity_value }}',
+            String(supporter?.activityValue ?? 0),
         );
+}
+
+function JourneyTransition({
+    routeArgs,
+    status,
+    label,
+}: {
+    routeArgs: [string, string];
+    status: string;
+    label: string;
+}) {
+    return (
+        <Form {...transitionJourney.form(routeArgs)}>
+            <input type="hidden" name="status" value={status} />
+            <Button variant="outline">{label}</Button>
+        </Form>
+    );
 }
 
 function actionsFor(status: string): string[] {

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -22,6 +22,8 @@ declare module '@inertiajs/core' {
             canViewSupporterJourneys: boolean;
             canViewVolunteers: boolean;
             canViewAudit: boolean;
+            canViewOrganisationConfigurations: boolean;
+            canViewImpactSnapshots: boolean;
             currentOrganisation: Organisation | null;
             organisations: Organisation[];
             demoSandbox: {

--- a/resources/views/public/impact.blade.php
+++ b/resources/views/public/impact.blade.php
@@ -1,0 +1,5 @@
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>Impact · {{ $organisation->name }}</title><style>:root{color-scheme:light dark;font-family:ui-sans-serif,system-ui,sans-serif;line-height:1.6}main{width:min(48rem,calc(100% - 2rem));margin:3rem auto}.metric{border:1px solid GrayText;border-radius:.75rem;padding:1rem;margin:1rem 0}</style></head>
+<body><main><p><a href="{{ route('public.organisations.show', $organisation->slug) }}">← {{ $organisation->name }}</a></p><h1>Published impact</h1><p>Approved aggregate metrics · registry {{ $snapshot->registry_version }} · period {{ $snapshot->period['start'] }} to {{ $snapshot->period['endExclusive'] }} exclusive.</p>@foreach($snapshot->metrics as $metric)<article class="metric"><h2>{{ $metric['definition']['label'] }}</h2><p>{{ $metric['availability'] === 'available' ? $metric['value'].' '.$metric['definition']['unit'] : ucfirst($metric['availability']) }}</p><small>{{ $metric['definition']['formula'] }}</small></article>@endforeach</main></body>
+</html>

--- a/resources/views/public/organisation.blade.php
+++ b/resources/views/public/organisation.blade.php
@@ -21,6 +21,7 @@
             <p><a href="{{ $volunteerUrl }}">Volunteer opportunities</a></p>
             <p><a href="{{ $eventsUrl }}">Community events</a></p>
             <p><a href="{{ $inKindUrl }}">Offer goods or materials</a></p>
+            @if($impactUrl)<p><a href="{{ $impactUrl }}">Published impact</a></p>@endif
             <p><a href="{{ $sourceUrl }}">Source and licence</a></p>
         </main>
     </body>

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\Organisations\ImpactChartExportController;
 use App\Http\Controllers\Organisations\ImpactReportExportController;
 use App\Http\Controllers\Organisations\IntakeRequestController;
 use App\Http\Controllers\Organisations\IntakeTransitionController;
+use App\Http\Controllers\Organisations\OrganisationConfigurationController;
 use App\Http\Controllers\Organisations\OrganisationInvitationController;
 use App\Http\Controllers\Organisations\PartyAddressController;
 use App\Http\Controllers\Organisations\PartyConsentController;
@@ -26,6 +27,7 @@ use App\Http\Controllers\Organisations\PartyRelationshipController;
 use App\Http\Controllers\Organisations\PartySafeContactInstructionController;
 use App\Http\Controllers\Organisations\PortalAccessGrantController as OrganisationPortalAccessGrantController;
 use App\Http\Controllers\Organisations\ProgramController;
+use App\Http\Controllers\Organisations\PublishedImpactSnapshotController;
 use App\Http\Controllers\Organisations\ServiceCaseController;
 use App\Http\Controllers\Organisations\ServiceOperationsExportController;
 use App\Http\Controllers\Organisations\SupporterJourneyController;
@@ -39,6 +41,7 @@ use App\Http\Controllers\Portal\PortalRecurringMandateController;
 use App\Http\Controllers\Portal\PortalRegistrationController;
 use App\Http\Controllers\Public\CommunityEventController as PublicCommunityEventController;
 use App\Http\Controllers\Public\DonationController as PublicDonationController;
+use App\Http\Controllers\Public\ImpactController as PublicImpactController;
 use App\Http\Controllers\Public\InKindOfferController as PublicInKindOfferController;
 use App\Http\Controllers\Public\OrganisationController as PublicOrganisationController;
 use App\Http\Controllers\Public\VolunteerOpportunityController as PublicVolunteerOpportunityController;
@@ -94,6 +97,7 @@ Route::domain('{public_organisation}.'.config('organisations.public_domain'))
         Route::post('/events/{event}', [PublicCommunityEventController::class, 'store'])->middleware('throttle:10,1')->name('public.events.store');
         Route::get('/in-kind', [PublicInKindOfferController::class, 'create'])->name('public.in-kind.create');
         Route::post('/in-kind', [PublicInKindOfferController::class, 'store'])->middleware('throttle:10,1')->name('public.in-kind.store');
+        Route::get('/impact', PublicImpactController::class)->name('public.impact.show');
         Route::get('/portal/access/{token}', [PortalAccessController::class, 'use'])
             ->middleware('throttle:20,1')
             ->name('portal.access.use');
@@ -150,12 +154,19 @@ Route::prefix('{current_organisation}')
         Route::post('community-engagement/in-kind-offers/{offer}/transitions', [CommunityEngagementController::class, 'transitionOffer'])->name('community-engagement.in-kind-offers.transitions.store');
         Route::post('community-engagement/partners', [CommunityEngagementController::class, 'storePartner'])->name('community-engagement.partners.store');
         Route::post('community-engagement/partners/{partner}/commitments', [CommunityEngagementController::class, 'storeCommitment'])->name('community-engagement.partners.commitments.store');
+        Route::get('organisation-configurations', [OrganisationConfigurationController::class, 'index'])->name('organisation-configurations.index');
+        Route::post('organisation-configurations', [OrganisationConfigurationController::class, 'store'])->name('organisation-configurations.store');
+        Route::post('organisation-configurations/{configuration}/activate', [OrganisationConfigurationController::class, 'activate'])->name('organisation-configurations.activate');
+        Route::get('impact-snapshots', [PublishedImpactSnapshotController::class, 'index'])->name('impact-snapshots.index');
+        Route::post('impact-snapshots', [PublishedImpactSnapshotController::class, 'store'])->name('impact-snapshots.store');
+        Route::get('impact-snapshots/{snapshot}/download', [PublishedImpactSnapshotController::class, 'download'])->name('impact-snapshots.download');
         Route::post('volunteers/{volunteer}/applications/{application}/transitions', [VolunteerOpportunityController::class, 'transitionApplication'])->name('volunteers.applications.transitions.store');
         Route::post('volunteers/{volunteer}/applications/{application}/credentials', [VolunteerOpportunityController::class, 'storeCredential'])->name('volunteers.applications.credentials.store');
         Route::post('volunteers/{volunteer}/shifts', [VolunteerOpportunityController::class, 'storeShift'])->name('volunteers.shifts.store');
         Route::post('volunteers/{volunteer}/assignments/{assignment}/transitions', [VolunteerOpportunityController::class, 'transitionAssignment'])->name('volunteers.assignments.transitions.store');
         Route::post('supporter-journeys/{supporter_journey}/approve', [SupporterJourneyController::class, 'approve'])->name('supporter-journeys.approve');
         Route::post('supporter-journeys/{supporter_journey}/dispatch', [SupporterJourneyController::class, 'dispatch'])->name('supporter-journeys.dispatch');
+        Route::post('supporter-journeys/{supporter_journey}/transitions', [SupporterJourneyController::class, 'transitionJourney'])->name('supporter-journeys.transitions.store');
         Route::post('supporter-journeys/{supporter_journey}/recipients/{recipient}/transitions', [SupporterJourneyController::class, 'transition'])->name('supporter-journeys.recipients.transitions.store');
         Route::resource('parties', PartyController::class)->only(['index', 'store', 'show', 'update']);
         Route::resource('intakes', IntakeRequestController::class)

--- a/tests/Feature/ConfigurableEngagementJourneyTest.php
+++ b/tests/Feature/ConfigurableEngagementJourneyTest.php
@@ -1,0 +1,297 @@
+<?php
+
+use App\Actions\Configuration\ActivateOrganisationConfiguration;
+use App\Actions\Configuration\CreateOrganisationConfiguration;
+use App\Actions\Engagement\ApproveSupporterJourney;
+use App\Actions\Engagement\DispatchSupporterJourney;
+use App\Actions\Engagement\EvaluateAudienceSegment;
+use App\Actions\Engagement\TransitionSupporterJourney;
+use App\Actions\Parties\RecordPartyConsent;
+use App\Actions\Parties\StorePartyContact;
+use App\Actions\Reporting\BuildImpactReportPack;
+use App\Actions\Reporting\PublishImpactSnapshot;
+use App\Enums\ConsentChannel;
+use App\Enums\ConsentDecision;
+use App\Enums\ConsentPurpose;
+use App\Enums\DonationPaymentStatus;
+use App\Enums\EventRegistrationStatus;
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Enums\OrganisationRole;
+use App\Enums\PartyBusinessRole;
+use App\Enums\PartyContactType;
+use App\Enums\SupporterJourneyRecipientStatus;
+use App\Enums\SupporterJourneyStatus;
+use App\Enums\TenantAuditEventType;
+use App\Http\Requests\Public\StoreVolunteerApplicationRequest;
+use App\Models\AudienceSegment;
+use App\Models\Donation;
+use App\Models\DonationPayment;
+use App\Models\EventRegistration;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use App\Models\Party;
+use App\Models\PublishedImpactSnapshot;
+use App\Models\SupporterJourney;
+use App\Models\TenantAuditEvent;
+use App\Models\User;
+use App\Models\VolunteerHourEntry;
+use App\OrganisationContext;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+
+beforeEach(function () {
+    $key = 'base64:'.base64_encode(str_repeat('c', 32));
+    config([
+        'classified_data.encryption.current_version' => 'configurable-v1',
+        'classified_data.encryption.keys' => ['configurable-v1' => $key],
+        'classified_data.contact_index.current_version' => 'configurable-index-v1',
+        'classified_data.contact_index.previous_version' => null,
+        'classified_data.contact_index.keys' => ['configurable-index-v1' => $key],
+        'engagement.simulation_only' => true,
+    ]);
+});
+
+it('versions, previews, audits, and protects organisation configuration', function () {
+    [$organisation, $administrator] = configurableOrganisation(OrganisationRole::OrganisationAdministrator);
+    $officer = User::factory()->create();
+    $organisation->memberships()->create(['user_id' => $officer->id, 'role' => OrganisationRole::EngagementOfficer]);
+
+    app(OrganisationContext::class)->run($organisation, function () use ($administrator, $organisation): void {
+        $create = app(CreateOrganisationConfiguration::class);
+        expect(fn () => $create->handle($organisation, OrganisationConfigurationArea::PublicForm, 'volunteer', [
+            'form' => 'volunteer_registration',
+            'required_fields' => ['name'],
+        ], $administrator))->toThrow(ValidationException::class);
+
+        $first = $create->handle($organisation, OrganisationConfigurationArea::PublicForm, 'volunteer_registration', [
+            'form' => 'volunteer_registration',
+            'required_fields' => ['name', 'email'],
+        ], $administrator);
+        app(ActivateOrganisationConfiguration::class)->handle($first, $administrator);
+        $second = $create->handle($organisation, OrganisationConfigurationArea::PublicForm, 'volunteer_registration', [
+            'form' => 'volunteer_registration',
+            'required_fields' => ['name', 'email', 'interests'],
+        ], $administrator);
+        app(ActivateOrganisationConfiguration::class)->handle($second, $administrator);
+
+        expect($first->refresh()->status)->toBe(OrganisationConfigurationStatus::Superseded)
+            ->and($second->refresh()->status)->toBe(OrganisationConfigurationStatus::Active)
+            ->and($second->version)->toBe(2)
+            ->and($second->supersedes_id)->toBe($first->id)
+            ->and(fn () => $second->update(['definition' => ['changed' => true]]))->toThrow(LogicException::class)
+            ->and(TenantAuditEvent::query()->where('type', TenantAuditEventType::OrganisationConfigurationCreated)->count())->toBe(2)
+            ->and(TenantAuditEvent::query()->where('type', TenantAuditEventType::OrganisationConfigurationActivated)->count())->toBe(2);
+        $publicFormValidator = Validator::make([
+            'name' => 'Taylor',
+            'email' => 'taylor@example.test',
+            'availability' => ['Saturday'],
+            'consent_email' => true,
+        ], (new StoreVolunteerApplicationRequest)->rules());
+        expect($publicFormValidator->errors()->has('interests'))->toBeTrue();
+    });
+
+    $this->actingAs($administrator)->get(route('organisation-configurations.index', $organisation))
+        ->assertOk()
+        ->assertSee('interests');
+    $this->actingAs($administrator)->post(route('organisation-configurations.store', $organisation), [
+        'area' => OrganisationConfigurationArea::PublicForm->value,
+        'configuration_key' => 'volunteer_registration',
+        'definition_json' => json_encode(['form' => 'volunteer_registration', 'required_fields' => ['name']], JSON_THROW_ON_ERROR),
+    ])->assertSessionHasErrors('definition_json');
+    $this->actingAs($officer)->get(route('organisation-configurations.index', $organisation))->assertForbidden();
+});
+
+it('evaluates declared donation, event, and volunteer recency-frequency-value semantics', function () {
+    [$organisation, $officer] = configurableOrganisation(OrganisationRole::EngagementOfficer);
+
+    app(OrganisationContext::class)->run($organisation, function () use ($officer, $organisation): void {
+        $donor = configurableSupporter($organisation, $officer, 'Recent donor', PartyBusinessRole::Donor);
+        $donation = Donation::factory()->create(['party_id' => $donor->id, 'amount_minor' => 6000]);
+        DonationPayment::factory()->for($donation)->create([
+            'attempt_number' => 1,
+            'amount_minor' => 10000,
+            'status' => DonationPaymentStatus::Succeeded,
+            'settled_at' => now()->subDays(90),
+        ]);
+        DonationPayment::factory()->for($donation)->create([
+            'attempt_number' => 2,
+            'amount_minor' => 6000,
+            'status' => DonationPaymentStatus::Succeeded,
+            'settled_at' => now()->subDay(),
+        ]);
+
+        $attendee = configurableSupporter($organisation, $officer, 'Event attendee', PartyBusinessRole::EventAttendee);
+        EventRegistration::factory()->create([
+            'party_id' => $attendee->id,
+            'status' => EventRegistrationStatus::Attended,
+            'attended_at' => now()->subDays(2),
+        ]);
+
+        $volunteer = configurableSupporter($organisation, $officer, 'Active volunteer', PartyBusinessRole::Volunteer);
+        VolunteerHourEntry::factory()->create([
+            'party_id' => $volunteer->id,
+            'minutes' => 180,
+            'occurred_at' => now()->subDays(3),
+        ]);
+
+        $donationAudience = app(EvaluateAudienceSegment::class)->handle(configurableSegment(PartyBusinessRole::Donor, 'donation', 30, 1, 5000));
+        $eventAudience = app(EvaluateAudienceSegment::class)->handle(configurableSegment(PartyBusinessRole::EventAttendee, 'event', 30, 1, 1));
+        $volunteerAudience = app(EvaluateAudienceSegment::class)->handle(configurableSegment(PartyBusinessRole::Volunteer, 'volunteer', 30, 1, 120));
+
+        expect($donationAudience->sole()['activityFrequency'])->toBe(1)
+            ->and($donationAudience->sole()['activityValue'])->toBe(6000)
+            ->and($eventAudience->sole()['uuid'])->toBe($attendee->uuid)
+            ->and($eventAudience->sole()['activityValue'])->toBe(1)
+            ->and($volunteerAudience->sole()['uuid'])->toBe($volunteer->uuid)
+            ->and($volunteerAudience->sole()['activityValue'])->toBe(180);
+    });
+});
+
+it('uses SMS templates, scheduling, pausing, experiments, and dispatch-time consent checks', function () {
+    [$organisation, $officer] = configurableOrganisation(OrganisationRole::EngagementOfficer);
+
+    $journey = app(OrganisationContext::class)->run($organisation, function () use ($officer, $organisation): SupporterJourney {
+        $party = configurableSupporter($organisation, $officer, 'SMS supporter', PartyBusinessRole::Donor, ConsentChannel::Sms);
+        $segment = configurableSegment(PartyBusinessRole::Donor, 'any', null, 0, null, ConsentChannel::Sms);
+        $template = app(CreateOrganisationConfiguration::class)->handle($organisation, OrganisationConfigurationArea::MessageTemplate, 're-engagement-sms', [
+            'channel' => 'sms',
+            'body' => 'Hello {{ supporter_name }}, we miss you.',
+            'journey_kind' => 're_engagement',
+        ], $officer);
+        app(ActivateOrganisationConfiguration::class)->handle($template, $officer);
+
+        $this->actingAs($officer)->post(route('supporter-journeys.store', $organisation), [
+            'audience_segment_id' => $segment->id,
+            'message_template_key' => 're-engagement-sms',
+            'name' => 'SMS re-engagement experiment',
+            'experiment_enabled' => true,
+            'variant_subject' => '',
+            'variant_body' => 'Hi {{ supporter_name }}, can we reconnect?',
+        ])->assertRedirect()->assertSessionHasNoErrors();
+        $journey = SupporterJourney::query()->where('name', 'SMS re-engagement experiment')->sole();
+        expect($journey->channel)->toBe('sms')->and($journey->subject)->toBe('');
+
+        app(ApproveSupporterJourney::class)->handle($journey, $officer);
+        app(TransitionSupporterJourney::class)->handle($journey->fresh(), SupporterJourneyStatus::Scheduled, now()->addHour()->toAtomString(), $officer);
+        expect(fn () => app(DispatchSupporterJourney::class)->handle($journey->fresh()))->toThrow(LogicException::class, 'not due');
+        app(TransitionSupporterJourney::class)->handle($journey->fresh(), SupporterJourneyStatus::Paused, null, $officer);
+        app(TransitionSupporterJourney::class)->handle($journey->fresh(), SupporterJourneyStatus::Scheduled, now()->addHour()->toAtomString(), $officer);
+
+        app(RecordPartyConsent::class)->handle($party, [
+            'purpose' => ConsentPurpose::SupporterUpdates,
+            'channel' => ConsentChannel::Sms,
+            'decision' => ConsentDecision::Withdrawn,
+            'wording_version' => 'sms-v2',
+            'wording' => 'Stop SMS supporter updates.',
+            'source' => 'preference-centre',
+            'occurred_at' => now()->addSecond()->toAtomString(),
+        ], $officer);
+
+        $this->travel(2)->hours();
+        $recipient = app(DispatchSupporterJourney::class)->handle($journey->fresh())->sole();
+        expect($recipient->status)->toBe(SupporterJourneyRecipientStatus::Cancelled)
+            ->and($recipient->variant)->toBeIn(['A', 'B']);
+
+        return $journey->fresh();
+    });
+
+    expect($journey->status)->toBe(SupporterJourneyStatus::Scheduled)
+        ->and($journey->version)->toBeGreaterThanOrEqual(5);
+});
+
+it('publishes only configured reconciled aggregates and serves tenant-safe public impact', function () {
+    [$organisation, $executive] = configurableOrganisation(OrganisationRole::ExecutiveViewer, 'configurable-impact');
+
+    [$public, $board] = app(OrganisationContext::class)->run($organisation, function () use ($executive, $organisation): array {
+        $attendee = Party::factory()->for($organisation)->create(['created_at' => now()->subDay()]);
+        $attendee->businessRoles()->create(['organisation_id' => $organisation->id, 'role' => PartyBusinessRole::EventAttendee]);
+        EventRegistration::factory()->create([
+            'party_id' => $attendee->id,
+            'status' => EventRegistrationStatus::Attended,
+            'attended_at' => now()->subDay(),
+        ]);
+        $configuration = OrganisationConfiguration::factory()->create([
+            'definition' => [
+                'public_metric_ids' => ['engagement.event_attendance'],
+                'pack_metric_ids' => ['engagement.event_attendance', 'data.missing_contact_rate'],
+            ],
+        ]);
+        $filters = ['period_start' => now()->startOfMonth()->toDateString(), 'period_end' => now()->addDay()->toDateString()];
+        $public = app(PublishImpactSnapshot::class)->handle($organisation, $executive, 'public', $filters);
+        $board = app(PublishImpactSnapshot::class)->handle($organisation, $executive, 'board', $filters);
+
+        expect($configuration->status)->toBe(OrganisationConfigurationStatus::Active)
+            ->and($public->metrics)->toHaveCount(1)
+            ->and($public->metrics[0]['definition']['id'])->toBe('engagement.event_attendance')
+            ->and(collect($public->cohort_comparisons)->firstWhere('cohort', PartyBusinessRole::EventAttendee->value)['metrics']['engagement.event_attendance']['availability'])->toBe('suppressed')
+            ->and(app(BuildImpactReportPack::class)->handle($board)[0])->toBe(['section', 'cohort', 'metric', 'value', 'availability', 'unit', 'registry_version', 'period_start', 'period_end_exclusive'])
+            ->and(fn () => $public->update(['audience' => 'board']))->toThrow(LogicException::class);
+
+        return [$public, $board];
+    });
+
+    $other = Organisation::factory()->active()->create(['slug' => 'other-impact']);
+    app(OrganisationContext::class)->run($other, fn () => PublishedImpactSnapshot::factory()->create([
+        'audience' => 'public',
+        'published_at' => now()->addMinute(),
+        'metrics' => [['definition' => ['label' => 'Other tenant secret', 'formula' => 'secret', 'unit' => 'count'], 'value' => 99, 'availability' => 'available']],
+    ]));
+
+    $this->get('https://configurable-impact.community-kind.test/impact')
+        ->assertOk()
+        ->assertSee('Event attendance')
+        ->assertDontSee('Other tenant secret');
+    expect($public->published_at)->not->toBeNull()
+        ->and($board->published_at)->toBeNull();
+});
+
+/** @return array{Organisation, User} */
+function configurableOrganisation(OrganisationRole $role, ?string $slug = null): array
+{
+    $organisation = Organisation::factory()->active()->create($slug === null ? [] : ['slug' => $slug]);
+    $user = User::factory()->create();
+    $organisation->memberships()->create(['user_id' => $user->id, 'role' => $role]);
+
+    return [$organisation, $user];
+}
+
+function configurableSupporter(Organisation $organisation, User $actor, string $name, PartyBusinessRole $role, ConsentChannel $channel = ConsentChannel::Email): Party
+{
+    $party = Party::factory()->for($organisation)->create(['display_name' => $name]);
+    $party->businessRoles()->create(['organisation_id' => $organisation->id, 'role' => $role]);
+    $contactType = $channel === ConsentChannel::Email ? PartyContactType::Email : PartyContactType::Telephone;
+    $contact = $channel === ConsentChannel::Email ? Str::slug($name).'@example.test' : '+27820000001';
+    app(StorePartyContact::class)->handle($party, $contactType, $contact);
+    app(RecordPartyConsent::class)->handle($party, [
+        'purpose' => ConsentPurpose::SupporterUpdates,
+        'channel' => $channel,
+        'decision' => ConsentDecision::Granted,
+        'wording_version' => 'v1',
+        'wording' => 'I agree to supporter updates.',
+        'source' => 'test-fixture',
+        'occurred_at' => now()->subMinute()->toAtomString(),
+    ], $actor);
+
+    return $party;
+}
+
+function configurableSegment(PartyBusinessRole $role, string $activityType, ?int $recencyDays, int $minimumFrequency, ?int $minimumValue, ConsentChannel $channel = ConsentChannel::Email): AudienceSegment
+{
+    return AudienceSegment::factory()->create([
+        'criteria' => [
+            'purpose' => ConsentPurpose::SupporterUpdates->value,
+            'channel' => $channel->value,
+            'role' => $role->value,
+            'service_area' => null,
+            'interest' => null,
+            'donation_activity' => $activityType === 'donation',
+            'campaign_source' => null,
+            'activity_type' => $activityType,
+            'recency_days' => $recencyDays,
+            'minimum_frequency' => $minimumFrequency,
+            'minimum_value' => $minimumValue,
+        ],
+    ]);
+}

--- a/tests/Feature/ImpactDashboardTest.php
+++ b/tests/Feature/ImpactDashboardTest.php
@@ -89,7 +89,7 @@ it('reconciles fixed definitions, half-open periods, comparisons, rates, money, 
 
     $empty = app(OrganisationContext::class)->run($organisation, fn () => app(BuildImpactDashboard::class)->handle($executive, $organisation, ['period_start' => '2025-01-01', 'period_end' => '2025-02-01']));
     $emptyMetrics = collect($empty['metrics'])->keyBy('definition.id');
-    expect($emptyMetrics)->toHaveCount(13)
+    expect($emptyMetrics)->toHaveCount(15)
         ->and($emptyMetrics['service.requests_received']['value'])->toBe(0.0)
         ->and($emptyMetrics['service.goal_achievement_rate']['availability'])->toBe('unavailable')
         ->and($emptyMetrics['engagement.meaningful_action_rate']['availability'])->toBe('unavailable');

--- a/tests/Feature/ImpactReportExportTest.php
+++ b/tests/Feature/ImpactReportExportTest.php
@@ -38,7 +38,7 @@ it('exports the exact privacy-safe dashboard context and audits it separately', 
         ->assertOk()->assertHeader('content-type', 'text/csv; charset=UTF-8')->streamedContent();
     expect($csv)->toContain('service.services_delivered')
         ->toContain(',2,available,count,')
-        ->toContain('2026.3')
+        ->toContain('2026.4')
         ->toContain('Fictional')
         ->not->toContain($party->uuid)
         ->not->toContain('case note');
@@ -59,7 +59,7 @@ it('exports the exact privacy-safe dashboard context and audits it separately', 
         ->toContain('<desc id="description">')
         ->toContain('Fictional data')
         ->toContain('Small Ward')
-        ->toContain('service.services_delivered v2026.3')
+        ->toContain('service.services_delivered v2026.4')
         ->toContain('Suppressed')
         ->not->toContain($party->uuid)
         ->not->toContain('case note');
@@ -67,7 +67,7 @@ it('exports the exact privacy-safe dashboard context and audits it separately', 
     app(OrganisationContext::class)->run($organisation, function (): void {
         $audits = TenantAuditEvent::query()->where('type', TenantAuditEventType::ImpactReportExported)->get();
         expect($audits)->toHaveCount(3)
-            ->and($audits->every(fn (TenantAuditEvent $audit): bool => $audit->payload['metric_count'] === 4 && $audit->payload['registry_version'] === '2026.3'))->toBeTrue()
+            ->and($audits->every(fn (TenantAuditEvent $audit): bool => $audit->payload['metric_count'] === 4 && $audit->payload['registry_version'] === '2026.4'))->toBeTrue()
             ->and($audits->pluck('payload.format')->all())->toBe(['csv', 'csv', 'svg']);
     });
 });

--- a/tests/Feature/SupporterJourneyTest.php
+++ b/tests/Feature/SupporterJourneyTest.php
@@ -202,6 +202,8 @@ function journeySegment(?string $name = null, ConsentChannel $channel = ConsentC
             ...$factory->raw()['criteria'],
             'channel' => $channel->value,
             'donation_activity' => false,
+            'activity_type' => 'any',
+            'minimum_frequency' => 0,
         ],
     ]);
 }


### PR DESCRIPTION
Closes #27

## Summary
- add immutable, audited organisation configuration versions for forms, templates, journey defaults, intake rules, and reporting
- add donation/event/volunteer RFV audiences plus scheduled, pausable, SMS, and deterministic experiment journeys with dispatch-time safety checks
- add reconciled cohort and missing-data reporting, immutable board/funder packs, and tenant-scoped public impact snapshots

## Verification
- `vendor/bin/pint --dirty --format agent`
- `composer types:check`
- `npm run check`
- `npm run types:check`
- `npm test`
- `npm run build:ssr`
- 46 focused feature tests (326 assertions) before rebase; 14 core issue tests (194 assertions) after rebase onto `main`
- PostgreSQL migrations applied successfully to the local development database

## Review
Reviewed against `main`; fixed PostgreSQL migration ordering/index naming, SMS template submission, dispatch audit schema, tenant relationships, RFV recency calculation, configuration validation feedback, and configurable required-field enforcement before opening this PR.