### PR TITLE
Make demo bootstrap links preview-safe

### DIFF
--- a/app/Http/Controllers/Demo/SandboxBootstrapController.php
+++ b/app/Http/Controllers/Demo/SandboxBootstrapController.php
@@ -10,17 +10,45 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
+use Inertia\Inertia;
+use Symfony\Component\HttpFoundation\Response;
 
 class SandboxBootstrapController extends Controller
 {
-    public function __invoke(Request $request, string $token): RedirectResponse
+    public function show(Request $request, string $token): Response|RedirectResponse
+    {
+        abort_unless(config('demo_sandbox.enabled'), 404);
+        $tokenHash = hash('sha256', $token);
+        $bootstrap = SandboxBootstrapToken::query()->where('token_hash', $tokenHash)->firstOrFail();
+        $pair = SandboxPair::query()->findOrFail($bootstrap->sandbox_pair_id);
+
+        if ($bootstrap->used_at !== null && $this->hasActiveSession($request, $pair, $bootstrap)) {
+            return to_route('demo.personas.index');
+        }
+
+        $this->ensureAvailable($bootstrap, $pair);
+
+        $response = Inertia::render('demo/bootstrap', [
+            'token' => $token,
+            'expiresAt' => $bootstrap->expires_at->toIso8601String(),
+            'expiresAtLabel' => $bootstrap->expires_at->format('j M Y, H:i T'),
+        ])->toResponse($request);
+
+        foreach ($this->privateHeaders() as $name => $value) {
+            $response->headers->set($name, $value);
+        }
+
+        return $response;
+    }
+
+    public function store(Request $request, string $token): RedirectResponse
     {
         abort_unless(config('demo_sandbox.enabled'), 404);
         $tokenHash = hash('sha256', $token);
         $pairId = SandboxBootstrapToken::query()->where('token_hash', $tokenHash)->value('sandbox_pair_id');
         abort_unless(is_string($pairId), 404);
 
-        $bootstrap = DB::transaction(function () use ($pairId, $tokenHash): SandboxBootstrapToken {
+        $bootstrap = DB::transaction(function () use ($pairId, $request, $tokenHash): SandboxBootstrapToken {
             $pair = SandboxPair::query()->lockForUpdate()->findOrFail($pairId);
             $bootstrap = SandboxBootstrapToken::query()
                 ->where('sandbox_pair_id', $pair->id)
@@ -28,9 +56,11 @@ class SandboxBootstrapController extends Controller
                 ->lockForUpdate()
                 ->firstOrFail();
 
-            abort_if($bootstrap->used_at !== null || $bootstrap->revoked_at !== null, 410);
-            abort_if($bootstrap->expires_at->isPast() || $pair->expires_at->isPast(), 410);
-            abort_unless($bootstrap->generation === $pair->generation && $pair->status->isAccessible(), 410);
+            if ($bootstrap->used_at !== null && $this->hasActiveSession($request, $pair, $bootstrap)) {
+                return $bootstrap;
+            }
+
+            $this->ensureAvailable($bootstrap, $pair);
 
             $bootstrap->update(['used_at' => now()]);
 
@@ -49,9 +79,31 @@ class SandboxBootstrapController extends Controller
             'demo_sandbox_generation' => $bootstrap->generation,
         ]);
 
-        return to_route('demo.personas.index')->withHeaders([
+        return to_route('demo.personas.index')->withHeaders($this->privateHeaders());
+    }
+
+    private function ensureAvailable(SandboxBootstrapToken $bootstrap, SandboxPair $pair): void
+    {
+        abort_if($bootstrap->used_at !== null || $bootstrap->revoked_at !== null, 410);
+        abort_if($bootstrap->expires_at->isPast() || $pair->expires_at->isPast(), 410);
+        abort_unless($bootstrap->generation === $pair->generation && $pair->status->isAccessible(), 410);
+    }
+
+    private function hasActiveSession(Request $request, SandboxPair $pair, SandboxBootstrapToken $bootstrap): bool
+    {
+        return $request->session()->get('demo_sandbox_pair_id') === $pair->id
+            && $request->session()->get('demo_sandbox_generation') === $bootstrap->generation
+            && $bootstrap->generation === $pair->generation
+            && $pair->status->isAccessible()
+            && ! $pair->expires_at->isPast();
+    }
+
+    /** @return array<string, string> */
+    private function privateHeaders(): array
+    {
+        return [
             'Referrer-Policy' => 'no-referrer',
             'Cache-Control' => 'no-store',
-        ]);
+        ];
     }
 }

--- a/database/migrations/2026_08_31_051837_create_case_assignments_table.php
+++ b/database/migrations/2026_08_31_051837_create_case_assignments_table.php
@@ -70,6 +70,27 @@ return new class extends Migration
                 SQL);
         } elseif (DB::getDriverName() === 'sqlite') {
             DB::unprepared("CREATE TRIGGER case_assignments_append_only_delete BEFORE DELETE ON case_assignments BEGIN SELECT RAISE(ABORT, 'Case assignment history is append-only.'); END");
+            DB::unprepared(<<<'SQL'
+                CREATE TRIGGER case_assignments_history_guard
+                BEFORE UPDATE ON case_assignments
+                FOR EACH ROW
+                WHEN OLD.status <> 'active'
+                    OR NEW.status <> 'ended'
+                    OR NEW.active_primary_marker IS NOT NULL
+                    OR OLD.ended_at IS NOT NULL
+                    OR NEW.ended_at IS NULL
+                    OR NEW.id IS NOT OLD.id
+                    OR NEW.organisation_id IS NOT OLD.organisation_id
+                    OR NEW.service_case_id IS NOT OLD.service_case_id
+                    OR NEW.membership_id IS NOT OLD.membership_id
+                    OR NEW.role IS NOT OLD.role
+                    OR NEW.started_at IS NOT OLD.started_at
+                    OR NEW.assigned_reason IS NOT OLD.assigned_reason
+                    OR NEW.assigned_by_user_id IS NOT OLD.assigned_by_user_id
+                BEGIN
+                    SELECT RAISE(ABORT, 'Case assignment history may only be ended.');
+                END
+                SQL);
         }
     }
 

--- a/resources/js/pages/demo/bootstrap.tsx
+++ b/resources/js/pages/demo/bootstrap.tsx
@@ -1,0 +1,77 @@
+import { Form, Head } from '@inertiajs/react';
+import { FlaskConical, ShieldCheck } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+    Card,
+    CardContent,
+    CardDescription,
+    CardHeader,
+    CardTitle,
+} from '@/components/ui/card';
+import { store } from '@/routes/demo/bootstrap';
+
+type Props = {
+    token: string;
+    expiresAt: string;
+    expiresAtLabel: string;
+};
+
+export default function DemoBootstrap({
+    token,
+    expiresAt,
+    expiresAtLabel,
+}: Props) {
+    return (
+        <main className="bg-muted/30 flex min-h-screen items-center px-4 py-12">
+            <Head title="Enter the CommunityKind demo" />
+            <Card className="mx-auto w-full max-w-xl">
+                <CardHeader className="space-y-4 text-center">
+                    <FlaskConical
+                        className="mx-auto size-10 text-amber-600"
+                        aria-hidden="true"
+                    />
+                    <div className="space-y-2">
+                        <CardTitle className="text-2xl">
+                            Explore a synthetic CommunityKind workspace
+                        </CardTitle>
+                        <CardDescription className="text-base">
+                            Choose from several staff perspectives and explore
+                            realistic, fictional community-service data.
+                        </CardDescription>
+                    </div>
+                </CardHeader>
+                <CardContent className="space-y-6">
+                    <div className="bg-muted flex gap-3 rounded-lg p-4 text-sm">
+                        <ShieldCheck
+                            className="mt-0.5 size-5 shrink-0 text-emerald-700"
+                            aria-hidden="true"
+                        />
+                        <p>
+                            This isolated demo cannot reach real organisations,
+                            send messages, accept payments, or upload files. It
+                            expires{' '}
+                            <time dateTime={expiresAt}>{expiresAtLabel}</time>.
+                        </p>
+                    </div>
+                    <Form {...store.form({ token })}>
+                        {({ processing }) => (
+                            <Button
+                                className="w-full"
+                                size="lg"
+                                type="submit"
+                                disabled={processing}
+                            >
+                                {processing
+                                    ? 'Preparing perspectives…'
+                                    : 'Enter the demo'}
+                            </Button>
+                        )}
+                    </Form>
+                    <p className="text-muted-foreground text-center text-xs">
+                        Opening this page does not consume the access link.
+                    </p>
+                </CardContent>
+            </Card>
+        </main>
+    );
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -116,7 +116,8 @@ Route::domain('{public_organisation}.'.config('organisations.public_domain'))
 Route::inertia('/', 'welcome')->name('home');
 Route::model('current_organisation', Organisation::class);
 
-Route::get('/demo/bootstrap/{token}', SandboxBootstrapController::class)->middleware('throttle:30,1')->name('demo.bootstrap');
+Route::get('/demo/bootstrap/{token}', [SandboxBootstrapController::class, 'show'])->middleware('throttle:30,1')->name('demo.bootstrap');
+Route::post('/demo/bootstrap/{token}', [SandboxBootstrapController::class, 'store'])->middleware('throttle:10,1')->name('demo.bootstrap.store');
 Route::get('/demo/personas', [SandboxPersonaController::class, 'index'])->name('demo.personas.index');
 Route::post('/demo/personas', [SandboxPersonaController::class, 'store'])->middleware('throttle:30,1')->name('demo.personas.store');
 

--- a/tests/Feature/ConfigurableEngagementJourneyTest.php
+++ b/tests/Feature/ConfigurableEngagementJourneyTest.php
@@ -218,7 +218,7 @@ it('publishes only configured reconciled aggregates and serves tenant-safe publi
                 'pack_metric_ids' => ['engagement.event_attendance', 'data.missing_contact_rate'],
             ],
         ]);
-        $filters = ['period_start' => now()->startOfMonth()->toDateString(), 'period_end' => now()->addDay()->toDateString()];
+        $filters = ['period_start' => now()->subDays(2)->toDateString(), 'period_end' => now()->addDay()->toDateString()];
         $public = app(PublishImpactSnapshot::class)->handle($organisation, $executive, 'public', $filters);
         $board = app(PublishImpactSnapshot::class)->handle($organisation, $executive, 'board', $filters);
 

--- a/tests/Feature/DemoSandboxTest.php
+++ b/tests/Feature/DemoSandboxTest.php
@@ -38,6 +38,20 @@ it('provisions a confined pair through a single-use hashed bootstrap and audited
         ->and($bootstrap->getAttributes())->not->toContain($plainTextToken);
 
     $this->get(route('demo.bootstrap', ['token' => $plainTextToken]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('demo/bootstrap')
+            ->where('token', $plainTextToken))
+        ->assertHeader('Referrer-Policy', 'no-referrer')
+        ->assertHeader('Cache-Control', 'no-store, private');
+
+    expect($bootstrap->refresh()->used_at)->toBeNull()
+        ->and($pair->refresh()->status)->toBe(SandboxPairStatus::Ready);
+
+    $this->get(route('demo.bootstrap', ['token' => $plainTextToken]))->assertOk();
+    expect($bootstrap->refresh()->used_at)->toBeNull();
+
+    $this->post(route('demo.bootstrap.store', ['token' => $plainTextToken]))
         ->assertRedirect(route('demo.personas.index'))
         ->assertHeader('Referrer-Policy', 'no-referrer')
         ->assertHeader('Cache-Control', 'no-store, private');
@@ -52,7 +66,8 @@ it('provisions a confined pair through a single-use hashed bootstrap and audited
     expect($pair->bootstrapTokens()->count())->toBe(3)
         ->and($pair->bootstrapTokens()->whereNull('used_at')->whereNull('revoked_at')->count())->toBe(1);
 
-    $this->get(route('demo.bootstrap', ['token' => $plainTextToken]))->assertGone();
+    $this->get(route('demo.bootstrap', ['token' => $plainTextToken]))
+        ->assertRedirect(route('demo.personas.index'));
     $this->get(route('demo.personas.index'))
         ->assertOk()
         ->assertInertia(fn (Assert $page) => $page
@@ -79,14 +94,19 @@ it('provisions a confined pair through a single-use hashed bootstrap and audited
     $this->get(route('dashboard', ['current_organisation' => $unrelated]))->assertNotFound();
     $this->post(route('organisations.invitations.store', ['organisation' => $harbourKind]))->assertForbidden();
     $this->patch(route('profile.update'), ['name' => 'Evaluator', 'email' => 'evaluator@example.com'])->assertForbidden();
+    $bootstrapUrl = route('demo.bootstrap', ['token' => $plainTextToken]);
     $this->get("https://{$harbourKind->slug}.community-kind.test/")->assertOk();
     $this->get("https://{$unrelated->slug}.community-kind.test/")->assertNotFound();
+
+    $this->flushSession();
+    $this->get($bootstrapUrl)->assertGone();
 });
 
 it('resets only the selected Organisation and invalidates its generation', function () {
     $result = app(ProvisionSandboxPair::class)->handle();
     $pair = $result['pair'];
-    $this->get(route('demo.bootstrap', ['token' => $result['token']]))->assertRedirect();
+    $this->get(route('demo.bootstrap', ['token' => $result['token']]))->assertOk();
+    $this->post(route('demo.bootstrap.store', ['token' => $result['token']]))->assertRedirect();
     $harbourKind = $pair->organisations()->where('sandbox_template', 'harbourkind')->firstOrFail();
     $neighbourLink = $pair->organisations()->where('sandbox_template', 'neighbourlink')->firstOrFail();
     $administrator = Membership::query()->findOrFail((int) DB::table('role_assignments')

--- a/tests/Feature/ImpactReportExportTest.php
+++ b/tests/Feature/ImpactReportExportTest.php
@@ -68,7 +68,7 @@ it('exports the exact privacy-safe dashboard context and audits it separately', 
         $audits = TenantAuditEvent::query()->where('type', TenantAuditEventType::ImpactReportExported)->get();
         expect($audits)->toHaveCount(3)
             ->and($audits->every(fn (TenantAuditEvent $audit): bool => $audit->payload['metric_count'] === 4 && $audit->payload['registry_version'] === '2026.4'))->toBeTrue()
-            ->and($audits->pluck('payload.format')->all())->toBe(['csv', 'csv', 'svg']);
+            ->and($audits->pluck('payload.format')->sort()->values()->all())->toBe(['csv', 'csv', 'svg']);
     });
 });
 


### PR DESCRIPTION
## Summary
- make demo bootstrap GET requests non-destructive
- consume bootstrap tokens only through a CSRF-protected POST confirmation
- recover used links in their matching active sandbox session
- add a safe confirmation screen and regression coverage
- stabilize two existing order/date-sensitive reporting tests uncovered by the full review
- enforce the existing append-only case-assignment invariant on SQLite as well as PostgreSQL

## Verification
- `composer ci:check` — 356 tests, 2,290 assertions
- `npm test`
- `npm run build:ssr`