### PR TITLE
Start a resettable demo without credentials

### DIFF
--- a/app/Actions/Demo/BuildSandboxScenario.php
+++ b/app/Actions/Demo/BuildSandboxScenario.php
@@ -13,7 +13,7 @@ final class BuildSandboxScenario
      */
     public function handle(array $template, string $pairId, int $generation): array
     {
-        $shortPairId = substr(str_replace('-', '', $pairId), 0, 8);
+        $shortPairId = substr(hash('sha256', $pairId), 0, 16);
         $suffix = "{$shortPairId}-g{$generation}";
         $scenario = $template;
         $scenario['uuid'] = $this->uuid($pairId, $generation, $template['uuid']);

--- a/app/Http/Controllers/Demo/SandboxController.php
+++ b/app/Http/Controllers/Demo/SandboxController.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace App\Http\Controllers\Demo;
+
+use App\Actions\Demo\ExpireSandboxPair;
+use App\Actions\Demo\ProvisionSandboxPair;
+use App\Http\Controllers\Controller;
+use App\Models\SandboxBootstrapToken;
+use App\Models\SandboxPair;
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Crypt;
+use Inertia\Inertia;
+use Inertia\Response;
+use Throwable;
+
+class SandboxController extends Controller
+{
+    public function create(Request $request): Response|RedirectResponse
+    {
+        abort_unless(config('demo_sandbox.enabled'), 404);
+
+        if ($this->hasActiveSandbox($request)) {
+            return to_route('demo.personas.index');
+        }
+
+        if (is_string($token = $this->pendingToken($request))) {
+            return to_route('demo.bootstrap', ['token' => $token])->withHeaders($this->privateHeaders());
+        }
+
+        return Inertia::render('demo/start', [
+            'lifetimeHours' => (int) config('demo_sandbox.maximum_lifetime_hours'),
+        ]);
+    }
+
+    public function store(Request $request, ProvisionSandboxPair $provisionSandboxPair): RedirectResponse
+    {
+        abort_unless(config('demo_sandbox.enabled'), 404);
+
+        if ($this->hasActiveSandbox($request)) {
+            return to_route('demo.personas.index');
+        }
+
+        if (is_string($token = $this->pendingToken($request))) {
+            return to_route('demo.bootstrap', ['token' => $token])->withHeaders($this->privateHeaders());
+        }
+
+        return $this->provision($request, $provisionSandboxPair);
+    }
+
+    public function destroy(
+        Request $request,
+        ExpireSandboxPair $expireSandboxPair,
+        ProvisionSandboxPair $provisionSandboxPair,
+    ): RedirectResponse {
+        abort_unless(config('demo_sandbox.enabled'), 404);
+        $pairId = $request->session()->get('demo_sandbox_pair_id')
+            ?? $request->session()->get('demo_pending_pair_id');
+
+        if (is_string($pairId)) {
+            $pair = SandboxPair::query()->find($pairId);
+
+            if ($pair?->status->isAccessible()) {
+                $expireSandboxPair->handle($pair);
+            }
+        }
+
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return $this->provision($request, $provisionSandboxPair);
+    }
+
+    private function provision(Request $request, ProvisionSandboxPair $provisionSandboxPair): RedirectResponse
+    {
+        try {
+            $result = $provisionSandboxPair->handle();
+        } catch (Throwable $exception) {
+            report($exception);
+
+            return to_route('demo.create')->withErrors([
+                'demo' => 'The demo could not be prepared. Please try again.',
+            ]);
+        }
+
+        $request->session()->put([
+            'demo_pending_pair_id' => $result['pair']->id,
+            'demo_pending_token' => Crypt::encryptString($result['token']),
+        ]);
+
+        return to_route('demo.bootstrap', ['token' => $result['token']])->withHeaders($this->privateHeaders());
+    }
+
+    private function pendingToken(Request $request): ?string
+    {
+        $pairId = $request->session()->get('demo_pending_pair_id');
+        $encryptedToken = $request->session()->get('demo_pending_token');
+
+        if (! is_string($pairId) || ! is_string($encryptedToken)) {
+            return null;
+        }
+
+        try {
+            $token = Crypt::decryptString($encryptedToken);
+        } catch (DecryptException) {
+            $this->forgetPending($request);
+
+            return null;
+        }
+
+        $bootstrap = SandboxBootstrapToken::query()
+            ->where('sandbox_pair_id', $pairId)
+            ->where('token_hash', hash('sha256', $token))
+            ->whereNull('used_at')
+            ->whereNull('revoked_at')
+            ->first();
+        $pair = SandboxPair::query()->find($pairId);
+
+        if ($bootstrap === null || $pair === null || $bootstrap->expires_at->isPast()
+            || $pair->expires_at->isPast() || $bootstrap->generation !== $pair->generation
+            || ! $pair->status->isAccessible()) {
+            $this->forgetPending($request);
+
+            return null;
+        }
+
+        return $token;
+    }
+
+    private function hasActiveSandbox(Request $request): bool
+    {
+        $pairId = $request->session()->get('demo_sandbox_pair_id');
+        $generation = $request->session()->get('demo_sandbox_generation');
+
+        if (! is_string($pairId) || ! is_int($generation)) {
+            return false;
+        }
+
+        return SandboxPair::query()
+            ->whereKey($pairId)
+            ->where('generation', $generation)
+            ->whereIn('status', ['ready', 'active'])
+            ->where('expires_at', '>', now())
+            ->exists();
+    }
+
+    private function forgetPending(Request $request): void
+    {
+        $request->session()->forget(['demo_pending_pair_id', 'demo_pending_token']);
+    }
+
+    /** @return array<string, string> */
+    private function privateHeaders(): array
+    {
+        return [
+            'Referrer-Policy' => 'no-referrer',
+            'Cache-Control' => 'no-store',
+        ];
+    }
+}

--- a/resources/js/components/demo-sandbox-banner.test.tsx
+++ b/resources/js/components/demo-sandbox-banner.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DemoSandboxBanner } from './demo-sandbox-banner';
 
@@ -9,6 +10,11 @@ let demoSandbox: {
 } | null;
 
 vi.mock('@inertiajs/react', () => ({
+    Form: ({
+        children,
+    }: {
+        children: (state: { processing: boolean }) => ReactNode;
+    }) => <form>{children({ processing: false })}</form>,
     usePage: () => ({ props: { demoSandbox } }),
 }));
 
@@ -31,6 +37,9 @@ describe('DemoSandboxBanner', () => {
         expect(screen.getByRole('status')).toHaveTextContent(
             'uploads, invitations, external messages, payments, and domains are disabled',
         );
+        expect(
+            screen.getByRole('button', { name: 'Reset demo' }),
+        ).toBeEnabled();
     });
 
     it('does not label ordinary sessions as demos', () => {

--- a/resources/js/components/demo-sandbox-banner.tsx
+++ b/resources/js/components/demo-sandbox-banner.tsx
@@ -1,5 +1,6 @@
-import { usePage } from '@inertiajs/react';
+import { Form, usePage } from '@inertiajs/react';
 import { FlaskConical } from 'lucide-react';
+import { destroy } from '@/routes/demo';
 
 export function DemoSandboxBanner() {
     const sandbox = usePage().props.demoSandbox;
@@ -14,13 +15,26 @@ export function DemoSandboxBanner() {
             role="status"
             data-test="demo-sandbox-banner"
         >
-            <div className="mx-auto flex max-w-7xl items-center justify-center gap-2 text-sm font-medium">
+            <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-center gap-x-3 gap-y-1 text-sm font-medium">
                 <FlaskConical className="size-4" aria-hidden="true" />
-                Synthetic demo data · uploads, invitations, external messages,
-                payments, and domains are disabled
-                {sandbox.expiresAt
-                    ? ` · expires ${new Date(sandbox.expiresAt).toLocaleString()}`
-                    : null}
+                <span>
+                    Synthetic demo data · uploads, invitations, external
+                    messages, payments, and domains are disabled
+                    {sandbox.expiresAt
+                        ? ` · expires ${new Date(sandbox.expiresAt).toLocaleString()}`
+                        : null}
+                </span>
+                <Form {...destroy.form()}>
+                    {({ processing }) => (
+                        <button
+                            type="submit"
+                            className="rounded-sm underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-900 disabled:opacity-60 dark:focus-visible:outline-amber-100"
+                            disabled={processing}
+                        >
+                            {processing ? 'Resetting…' : 'Reset demo'}
+                        </button>
+                    )}
+                </Form>
             </div>
         </div>
     );

--- a/resources/js/pages/demo/personas.tsx
+++ b/resources/js/pages/demo/personas.tsx
@@ -8,6 +8,7 @@ import {
     CardHeader,
     CardTitle,
 } from '@/components/ui/card';
+import { destroy } from '@/routes/demo';
 import { store } from '@/routes/demo/personas';
 
 type Persona = {
@@ -70,6 +71,21 @@ export default function DemoPersonas({ personas }: { personas: Persona[] }) {
                             </CardContent>
                         </Card>
                     ))}
+                </div>
+                <div className="flex justify-center border-t pt-6">
+                    <Form {...destroy.form()}>
+                        {({ processing }) => (
+                            <Button
+                                type="submit"
+                                variant="outline"
+                                disabled={processing}
+                            >
+                                {processing
+                                    ? 'Preparing a clean demo…'
+                                    : 'Reset with fresh demo data'}
+                            </Button>
+                        )}
+                    </Form>
                 </div>
             </div>
         </main>

--- a/resources/js/pages/demo/start.tsx
+++ b/resources/js/pages/demo/start.tsx
@@ -1,0 +1,150 @@
+import { Form, Head, Link } from '@inertiajs/react';
+import { ArrowRight, RotateCcw, ShieldCheck } from 'lucide-react';
+import InputError from '@/components/input-error';
+import { Button } from '@/components/ui/button';
+import { home } from '@/routes';
+import { store } from '@/routes/demo';
+
+export default function DemoStart({
+    lifetimeHours,
+}: {
+    lifetimeHours: number;
+}) {
+    return (
+        <main className="relative min-h-screen overflow-hidden bg-slate-50 text-slate-950 dark:bg-slate-950 dark:text-slate-50">
+            <Head title="Explore the CommunityKind demo" />
+            <div
+                className="absolute inset-x-0 top-0 h-1 bg-teal-700"
+                aria-hidden="true"
+            />
+            <div className="mx-auto grid min-h-screen w-full max-w-6xl items-center gap-12 px-6 py-16 lg:grid-cols-[1.1fr_0.9fr] lg:px-10">
+                <section aria-labelledby="demo-heading" className="space-y-8">
+                    <Link
+                        href={home()}
+                        className="inline-flex items-center gap-2 text-sm font-semibold text-slate-700 underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-teal-700 dark:text-slate-200"
+                    >
+                        <span className="size-2 rounded-full bg-teal-700" />
+                        CommunityKind
+                    </Link>
+                    <div className="max-w-2xl space-y-5">
+                        <p className="text-sm font-semibold tracking-[0.16em] text-teal-800 uppercase dark:text-teal-300">
+                            A safe, synthetic workspace
+                        </p>
+                        <h1
+                            id="demo-heading"
+                            className="text-4xl font-semibold tracking-tight text-balance sm:text-6xl"
+                        >
+                            Follow the work from first contact to community
+                            impact.
+                        </h1>
+                        <p className="max-w-xl text-lg leading-8 text-slate-600 dark:text-slate-300">
+                            Step into several staff perspectives across two
+                            fictional human-services organisations. No account,
+                            setup, or real personal information is required.
+                        </p>
+                    </div>
+                    <div
+                        className="flex max-w-xl items-center gap-3 text-sm text-slate-600 dark:text-slate-300"
+                        aria-label="Demo journey"
+                    >
+                        {[
+                            'Choose a role',
+                            'Explore real workflows',
+                            'Reset anytime',
+                        ].map((step, index) => (
+                            <div
+                                key={step}
+                                className="flex min-w-0 flex-1 items-center gap-3"
+                            >
+                                <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-teal-800 text-xs font-semibold text-white">
+                                    {index + 1}
+                                </span>
+                                <span className="leading-tight">{step}</span>
+                                {index < 2 && (
+                                    <span
+                                        className="hidden h-px flex-1 bg-teal-700/30 sm:block"
+                                        aria-hidden="true"
+                                    />
+                                )}
+                            </div>
+                        ))}
+                    </div>
+                </section>
+
+                <section
+                    aria-label="Prepare demo"
+                    className="rounded-2xl border border-slate-900/10 bg-white/80 p-8 shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/80"
+                >
+                    <div className="space-y-7">
+                        <div className="space-y-3">
+                            <div className="flex size-11 items-center justify-center rounded-xl bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-200">
+                                <ShieldCheck
+                                    className="size-6"
+                                    aria-hidden="true"
+                                />
+                            </div>
+                            <h2 className="text-2xl font-semibold tracking-tight">
+                                Your isolated evaluation space
+                            </h2>
+                            <p className="leading-7 text-slate-600 dark:text-slate-300">
+                                The workspace lasts up to {lifetimeHours} hours.
+                                Uploads, invitations, outbound messages,
+                                payments, and custom domains stay disabled.
+                            </p>
+                        </div>
+
+                        <ul className="space-y-3 text-sm text-slate-700 dark:text-slate-200">
+                            <li className="flex gap-3">
+                                <span className="mt-2 size-1.5 shrink-0 rounded-full bg-teal-700" />
+                                Fictional people, cases, donations, volunteers,
+                                and outcomes
+                            </li>
+                            <li className="flex gap-3">
+                                <span className="mt-2 size-1.5 shrink-0 rounded-full bg-teal-700" />
+                                Role-specific permissions and realistic safety
+                                boundaries
+                            </li>
+                            <li className="flex gap-3">
+                                <span className="mt-2 size-1.5 shrink-0 rounded-full bg-teal-700" />
+                                A clean reset whenever you want to start again
+                            </li>
+                        </ul>
+
+                        <Form {...store.form()} className="space-y-3">
+                            {({ processing, errors }) => (
+                                <>
+                                    <Button
+                                        type="submit"
+                                        size="lg"
+                                        className="w-full bg-teal-800 text-white hover:bg-teal-700 focus-visible:ring-teal-700"
+                                        disabled={processing}
+                                    >
+                                        {processing
+                                            ? 'Preparing your workspace…'
+                                            : 'Prepare my demo'}
+                                        {!processing && (
+                                            <ArrowRight
+                                                className="size-4"
+                                                aria-hidden="true"
+                                            />
+                                        )}
+                                    </Button>
+                                    <InputError message={errors.demo} />
+                                </>
+                            )}
+                        </Form>
+
+                        <p className="flex items-center justify-center gap-2 text-center text-xs text-slate-500 dark:text-slate-400">
+                            <RotateCcw
+                                className="size-3.5"
+                                aria-hidden="true"
+                            />
+                            Repeat submissions resume the same pending
+                            workspace.
+                        </p>
+                    </div>
+                </section>
+            </div>
+        </main>
+    );
+}

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -1,6 +1,7 @@
 import { Head, Link, usePage } from '@inertiajs/react';
 import { dashboard, login } from '@/routes';
 import SourceAndLicenceLink from '@/components/source-and-licence-link';
+import { create as createDemo } from '@/routes/demo';
 
 export default function Welcome() {
     const { auth, currentOrganisation } = usePage().props;
@@ -59,6 +60,20 @@ export default function Welcome() {
                             synthetic data. It is not ready for real client or
                             supporter information.
                         </p>
+                        <div className="mt-8 flex flex-wrap gap-3">
+                            <Link
+                                href={createDemo()}
+                                className="rounded-md bg-neutral-900 px-5 py-3 text-sm font-medium text-white dark:bg-white dark:text-neutral-900"
+                            >
+                                Explore the demo
+                            </Link>
+                            <Link
+                                href={login()}
+                                className="rounded-md border px-5 py-3 text-sm font-medium"
+                            >
+                                Staff log in
+                            </Link>
+                        </div>
                     </div>
                 </main>
 

--- a/resources/js/tests/pages/demo-start.test.tsx
+++ b/resources/js/tests/pages/demo-start.test.tsx
@@ -1,0 +1,73 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import type { ComponentProps, ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import DemoStart from '@/pages/demo/start';
+
+type InertiaLinkProps = Omit<ComponentProps<'a'>, 'href'> & {
+    href: string | { url: string };
+};
+
+let formState: {
+    processing: boolean;
+    errors: Record<string, string>;
+};
+
+vi.mock('@inertiajs/react', () => ({
+    Form: ({
+        children,
+    }: {
+        children: (state: typeof formState) => ReactNode;
+    }) => <form>{children(formState)}</form>,
+    Head: () => null,
+    Link: ({ children, href, ...props }: InertiaLinkProps) => (
+        <a {...props} href={typeof href === 'string' ? href : href.url}>
+            {children}
+        </a>
+    ),
+}));
+
+describe('Demo start', () => {
+    beforeEach(() => {
+        formState = { processing: false, errors: {} };
+    });
+
+    it('explains the safe evaluation journey and offers one primary action', () => {
+        render(<DemoStart lifetimeHours={24} />);
+
+        expect(
+            screen.getByRole('heading', {
+                name: 'Follow the work from first contact to community impact.',
+            }),
+        ).toBeVisible();
+        expect(screen.getByLabelText('Demo journey')).toHaveTextContent(
+            'Choose a role',
+        );
+        expect(
+            screen.getByRole('button', { name: 'Prepare my demo' }),
+        ).toBeEnabled();
+        expect(screen.getByText(/lasts up to 24 hours/i)).toBeVisible();
+    });
+
+    it('shows progress and a useful provisioning failure', () => {
+        formState = {
+            processing: true,
+            errors: {
+                demo: 'The demo could not be prepared. Please try again.',
+            },
+        };
+
+        render(<DemoStart lifetimeHours={24} />);
+
+        expect(
+            screen.getByRole('button', {
+                name: 'Preparing your workspace…',
+            }),
+        ).toBeDisabled();
+        expect(
+            screen.getByText(
+                'The demo could not be prepared. Please try again.',
+            ),
+        ).toBeVisible();
+    });
+});

--- a/resources/js/tests/pages/welcome.test.tsx
+++ b/resources/js/tests/pages/welcome.test.tsx
@@ -1,0 +1,35 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import Welcome from '@/pages/welcome';
+
+type InertiaLinkProps = Omit<ComponentProps<'a'>, 'href'> & {
+    href: string | { url: string };
+};
+
+vi.mock('@inertiajs/react', () => ({
+    Head: () => null,
+    Link: ({ children, href, ...props }: InertiaLinkProps) => (
+        <a {...props} href={typeof href === 'string' ? href : href.url}>
+            {children}
+        </a>
+    ),
+    usePage: () => ({
+        props: { auth: { user: null }, currentOrganisation: null },
+    }),
+}));
+
+vi.mock('@/components/source-and-licence-link', () => ({
+    default: () => <a href="/source-and-licence">Source and licence</a>,
+}));
+
+describe('Welcome', () => {
+    it('offers public evaluators a direct path to the demo', () => {
+        render(<Welcome />);
+
+        expect(
+            screen.getByRole('link', { name: 'Explore the demo' }),
+        ).toHaveAttribute('href', '/demo');
+    });
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\Demo\SandboxBootstrapController;
+use App\Http\Controllers\Demo\SandboxController;
 use App\Http\Controllers\Demo\SandboxOrganisationController;
 use App\Http\Controllers\Demo\SandboxPersonaController;
 use App\Http\Controllers\Organisations\AudienceSegmentController;
@@ -116,6 +117,9 @@ Route::domain('{public_organisation}.'.config('organisations.public_domain'))
 Route::inertia('/', 'welcome')->name('home');
 Route::model('current_organisation', Organisation::class);
 
+Route::get('/demo', [SandboxController::class, 'create'])->name('demo.create');
+Route::post('/demo', [SandboxController::class, 'store'])->middleware('throttle:3,60')->name('demo.store');
+Route::delete('/demo', [SandboxController::class, 'destroy'])->middleware('throttle:3,60')->name('demo.destroy');
 Route::get('/demo/bootstrap/{token}', [SandboxBootstrapController::class, 'show'])->middleware('throttle:30,1')->name('demo.bootstrap');
 Route::post('/demo/bootstrap/{token}', [SandboxBootstrapController::class, 'store'])->middleware('throttle:10,1')->name('demo.bootstrap.store');
 Route::get('/demo/personas', [SandboxPersonaController::class, 'index'])->name('demo.personas.index');

--- a/tests/Feature/DemoSandboxEntryTest.php
+++ b/tests/Feature/DemoSandboxEntryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use App\Actions\Demo\ProvisionSandboxPair;
+use App\Enums\SandboxPairStatus;
+use App\Models\SandboxPair;
+use Inertia\Testing\AssertableInertia as Assert;
+
+beforeEach(function () {
+    config(['demo_sandbox.enabled' => true]);
+});
+
+it('presents a public self-service demo entry', function () {
+    $this->get('/demo')
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('demo/start')
+            ->where('lifetimeHours', 24));
+});
+
+it('provisions one pending sandbox for repeated submissions from the same session', function () {
+    $this->withServerVariables(['REMOTE_ADDR' => '203.0.113.70']);
+    $first = $this->post('/demo');
+    $pair = SandboxPair::query()->sole();
+    $location = $first->headers->get('Location');
+
+    $first->assertRedirectContains('/demo/bootstrap/')
+        ->assertSessionHas('demo_pending_pair_id', $pair->id);
+    expect($pair->status)->toBe(SandboxPairStatus::Ready)
+        ->and($location)->toBeString();
+
+    $this->post('/demo')->assertRedirect($location);
+    $this->post('/demo')->assertRedirect($location);
+    $this->post('/demo')->assertTooManyRequests();
+    expect(SandboxPair::query()->count())->toBe(1);
+});
+
+it('reports provisioning failures without exposing a partial sandbox', function () {
+    config(['classified_data.encryption.keys' => []]);
+
+    $this->from('/demo')->post('/demo')
+        ->assertRedirect('/demo')
+        ->assertSessionHasErrors([
+            'demo' => 'The demo could not be prepared. Please try again.',
+        ]);
+
+    expect(SandboxPair::query()->sole()->status)->toBe(SandboxPairStatus::Failed);
+});
+
+it('expires the current sandbox and prepares a clean replacement', function () {
+    $result = app(ProvisionSandboxPair::class)->handle();
+    $pair = $result['pair'];
+    $oldSlugs = $pair->organisations()->pluck('slug');
+    $this->post(route('demo.bootstrap.store', ['token' => $result['token']]))->assertRedirect();
+    $this->get('/demo')->assertRedirect(route('demo.personas.index'));
+
+    $this->delete('/demo')
+        ->assertRedirectContains('/demo/bootstrap/')
+        ->assertSessionHas('demo_pending_pair_id');
+
+    expect($pair->refresh()->status)->toBe(SandboxPairStatus::Expired)
+        ->and(SandboxPair::query()->count())->toBe(2);
+    $replacementSlugs = SandboxPair::query()->whereKeyNot($pair->id)->sole()->organisations()->pluck('slug');
+    expect($replacementSlugs->intersect($oldSlugs))->toBeEmpty();
+    $this->assertGuest();
+});
+
+it('does not expose self-service provisioning when demo sandboxes are disabled', function () {
+    config(['demo_sandbox.enabled' => false]);
+
+    $this->get('/demo')->assertNotFound();
+    $this->post('/demo')->assertNotFound();
+    $this->delete('/demo')->assertNotFound();
+});


### PR DESCRIPTION
Closes #70

## Summary
- add a public one-action demo entry with visible provisioning and recovery states
- make pending provisioning idempotent and rate-limited, with reset available before and during evaluation
- prevent rapid reset slug collisions and cover the complete flow with backend and frontend tests

## Verification
- `composer ci:check`
- `npm test`
- `npm run build:ssr`
- live desktop and mobile walkthrough through the preview-safe bootstrap to the persona chooser