### PR TITLE
Guide evaluation through staff perspectives

### DIFF
--- a/app/Data/Demo/PersonaGuide.php
+++ b/app/Data/Demo/PersonaGuide.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Data\Demo;
+
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+
+class PersonaGuide
+{
+    /**
+     * @return array{
+     *     responsibility: string,
+     *     boundary: string,
+     *     tasks: list<array{label: string, description: string, href: string}>
+     * }
+     */
+    public static function for(OrganisationRole $role, Organisation $organisation): array
+    {
+        return match ($role) {
+            OrganisationRole::OrganisationAdministrator => [
+                'responsibility' => 'Keep the organisation, programmes, and staff access safely configured.',
+                'boundary' => 'Can inspect organisation-wide setup and audit history. Demo confinement still blocks invitations, uploads, domains, payments, and outbound messages.',
+                'tasks' => [
+                    self::task('Review programme setup', 'See how service programmes are structured.', 'programs.index', $organisation),
+                    self::task('Inspect organisation configuration', 'Review the controls that shape day-to-day work.', 'organisation-configurations.index', $organisation),
+                    self::task('Trace the audit history', 'See how important actions remain accountable.', 'audit.index', $organisation),
+                ],
+            ],
+            OrganisationRole::ProgramManager => [
+                'responsibility' => 'Coordinate demand, assignments, and delivery across assigned programmes.',
+                'boundary' => 'Can inspect service records within programme scope, but cannot administer the organisation or see work outside that scope.',
+                'tasks' => [
+                    self::task('Review the intake queue', 'Follow requests from triage into service delivery.', 'intakes.index', $organisation),
+                    self::task('Explore participant profiles', 'See consent-aware context across programme work.', 'parties.index', $organisation),
+                    self::task('Check operational accountability', 'Review the audit trail for service decisions.', 'audit.index', $organisation),
+                ],
+            ],
+            OrganisationRole::CaseWorker => [
+                'responsibility' => 'Support people through assigned cases while protecting sensitive information.',
+                'boundary' => 'Can reach assigned programme and case records only; management, supporter, and organisation controls stay out of scope.',
+                'tasks' => [
+                    self::task('Open assigned service requests', 'See the hand-off from intake to active support.', 'intakes.index', $organisation),
+                    self::task('Review participant context', 'Inspect the profiles available to this worker.', 'parties.index', $organisation),
+                    self::task('Follow accountable actions', 'See the service activity recorded for review.', 'audit.index', $organisation),
+                ],
+            ],
+            OrganisationRole::EngagementOfficer => [
+                'responsibility' => 'Build community support through donors, volunteers, audiences, and journeys.',
+                'boundary' => 'Can work with supporter-safe information, but cannot open confidential service-delivery records.',
+                'tasks' => [
+                    self::task('Follow simulated donations', 'Review supporter gifts and stewardship context.', 'donations.index', $organisation),
+                    self::task('Explore volunteer opportunities', 'See recruitment and follow-up in one place.', 'volunteers.index', $organisation),
+                    self::task('Inspect welcome journeys', 'Review how audiences move through engagement.', 'supporter-journeys.index', $organisation),
+                ],
+            ],
+            OrganisationRole::ExecutiveViewer => [
+                'responsibility' => 'Understand performance, outcomes, and organisational impact without entering frontline records.',
+                'boundary' => 'Can inspect aggregate impact views; operational case, supporter, and configuration records remain unavailable.',
+                'tasks' => [
+                    self::task('Read the impact dashboard', 'Start with an organisation-wide view of progress.', 'dashboard', $organisation),
+                    self::task('Review published impact packs', 'See how evidence is prepared for leadership and partners.', 'impact-snapshots.index', $organisation),
+                ],
+            ],
+        };
+    }
+
+    /** @return array{label: string, description: string, href: string} */
+    private static function task(string $label, string $description, string $routeName, Organisation $organisation): array
+    {
+        return [
+            'label' => $label,
+            'description' => $description,
+            'href' => route($routeName, ['current_organisation' => $organisation]),
+        ];
+    }
+}

--- a/app/Http/Controllers/Demo/SandboxPersonaController.php
+++ b/app/Http/Controllers/Demo/SandboxPersonaController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Demo;
 
 use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Data\Demo\PersonaGuide;
 use App\Enums\OrganisationRole;
 use App\Enums\TenantAuditEventType;
 use App\Http\Controllers\Controller;
@@ -45,6 +46,8 @@ class SandboxPersonaController extends Controller
                     'name' => $membership->user->name,
                     'organisation' => $membership->organisation->name,
                     'role' => $role->label(),
+                    'roleKey' => $role->value,
+                    ...PersonaGuide::for($role, $membership->organisation),
                 ];
             })
             ->filter()

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Data\Demo\PersonaGuide;
 use App\Models\AudienceSegment;
 use App\Models\Donation;
 use App\Models\IntakeRequest;
@@ -96,9 +97,21 @@ class HandleInertiaRequests extends Middleware
                     $pair = SandboxPair::query()->find($pairId);
 
                     if ($pair?->status->isAccessible()) {
+                        $organisation = $user?->currentOrganisation;
+                        $role = $organisation instanceof Organisation
+                            ? $user->organisationRole($organisation)
+                            : null;
+
                         return [
                             'pairId' => $pair->id,
                             'expiresAt' => $pair->expires_at->toISOString(),
+                            'persona' => $role === null
+                                ? null
+                                : [
+                                    'role' => $role->label(),
+                                    'organisation' => $organisation->name,
+                                    ...PersonaGuide::for($role, $organisation),
+                                ],
                         ];
                     }
                 }
@@ -108,7 +121,7 @@ class HandleInertiaRequests extends Middleware
                     ?? $user?->currentOrganisation;
 
                 return $visibleOrganisation instanceof Organisation && $visibleOrganisation->is_synthetic
-                    ? ['pairId' => null, 'expiresAt' => null]
+                    ? ['pairId' => null, 'expiresAt' => null, 'persona' => null]
                     : null;
             },
             'canViewParties' => fn (): bool => $routeOrganisation instanceof Organisation

--- a/resources/js/components/demo-sandbox-banner.test.tsx
+++ b/resources/js/components/demo-sandbox-banner.test.tsx
@@ -1,13 +1,24 @@
 import '@testing-library/jest-dom/vitest';
 import { render, screen } from '@testing-library/react';
-import type { ReactNode } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DemoSandboxBanner } from './demo-sandbox-banner';
 
 let demoSandbox: {
     pairId: string | null;
     expiresAt: string | null;
+    persona: {
+        role: string;
+        organisation: string;
+        responsibility: string;
+        boundary: string;
+        tasks: { label: string; description: string; href: string }[];
+    } | null;
 } | null;
+
+type InertiaLinkProps = Omit<ComponentProps<'a'>, 'href'> & {
+    href: string | { url: string };
+};
 
 vi.mock('@inertiajs/react', () => ({
     Form: ({
@@ -15,6 +26,11 @@ vi.mock('@inertiajs/react', () => ({
     }: {
         children: (state: { processing: boolean }) => ReactNode;
     }) => <form>{children({ processing: false })}</form>,
+    Link: ({ children, href, ...props }: InertiaLinkProps) => (
+        <a {...props} href={typeof href === 'string' ? href : href.url}>
+            {children}
+        </a>
+    ),
     usePage: () => ({ props: { demoSandbox } }),
 }));
 
@@ -27,6 +43,19 @@ describe('DemoSandboxBanner', () => {
         demoSandbox = {
             pairId: 'sandbox-pair',
             expiresAt: '2026-08-31T20:00:00Z',
+            persona: {
+                role: 'Case worker',
+                organisation: 'HarbourKind',
+                responsibility: 'Support people through assigned cases.',
+                boundary: 'Assigned case records only.',
+                tasks: [
+                    {
+                        label: 'Open assigned service requests',
+                        description: 'Follow requests into service delivery.',
+                        href: '/harbourkind/intakes',
+                    },
+                ],
+            },
         };
 
         render(<DemoSandboxBanner />);
@@ -35,11 +64,22 @@ describe('DemoSandboxBanner', () => {
             'Synthetic demo data',
         );
         expect(screen.getByRole('status')).toHaveTextContent(
-            'uploads, invitations, external messages, payments, and domains are disabled',
+            'Viewing as Case worker at HarbourKind',
+        );
+        expect(screen.getByRole('status')).toHaveTextContent(
+            'uploads, invitations, external messages, payments, and domains disabled',
         );
         expect(
             screen.getByRole('button', { name: 'Reset demo' }),
         ).toBeEnabled();
+        expect(
+            screen.getByRole('link', { name: 'Change perspective' }),
+        ).toHaveAttribute('href', '/demo/personas');
+        expect(
+            screen.getByRole('link', {
+                name: /Open assigned service requests/,
+            }),
+        ).toHaveAttribute('href', '/harbourkind/intakes');
     });
 
     it('does not label ordinary sessions as demos', () => {

--- a/resources/js/components/demo-sandbox-banner.tsx
+++ b/resources/js/components/demo-sandbox-banner.tsx
@@ -1,6 +1,7 @@
-import { Form, usePage } from '@inertiajs/react';
-import { FlaskConical } from 'lucide-react';
+import { Form, Link, usePage } from '@inertiajs/react';
+import { ArrowRight, FlaskConical } from 'lucide-react';
 import { destroy } from '@/routes/demo';
+import { index as choosePersona } from '@/routes/demo/personas';
 
 export function DemoSandboxBanner() {
     const sandbox = usePage().props.demoSandbox;
@@ -15,26 +16,56 @@ export function DemoSandboxBanner() {
             role="status"
             data-test="demo-sandbox-banner"
         >
-            <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-center gap-x-3 gap-y-1 text-sm font-medium">
-                <FlaskConical className="size-4" aria-hidden="true" />
-                <span>
-                    Synthetic demo data · uploads, invitations, external
-                    messages, payments, and domains are disabled
-                    {sandbox.expiresAt
-                        ? ` · expires ${new Date(sandbox.expiresAt).toLocaleString()}`
-                        : null}
-                </span>
-                <Form {...destroy.form()}>
-                    {({ processing }) => (
-                        <button
-                            type="submit"
-                            className="rounded-sm underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-900 disabled:opacity-60 dark:focus-visible:outline-amber-100"
-                            disabled={processing}
-                        >
-                            {processing ? 'Resetting…' : 'Reset demo'}
-                        </button>
-                    )}
-                </Form>
+            <div className="mx-auto max-w-7xl space-y-2 text-sm">
+                <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1 font-medium">
+                    <FlaskConical className="size-4" aria-hidden="true" />
+                    <span>
+                        Synthetic demo data · uploads, invitations, external
+                        messages, payments, and domains disabled
+                        {sandbox.persona
+                            ? ` · Viewing as ${sandbox.persona.role} at ${sandbox.persona.organisation}`
+                            : null}
+                        {sandbox.expiresAt
+                            ? ` · expires ${new Date(sandbox.expiresAt).toLocaleString()}`
+                            : null}
+                    </span>
+                    <Link
+                        href={choosePersona()}
+                        className="rounded-sm underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-900 dark:focus-visible:outline-amber-100"
+                    >
+                        Change perspective
+                    </Link>
+                    <Form {...destroy.form()}>
+                        {({ processing }) => (
+                            <button
+                                type="submit"
+                                className="rounded-sm underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-900 disabled:opacity-60 dark:focus-visible:outline-amber-100"
+                                disabled={processing}
+                            >
+                                {processing ? 'Resetting…' : 'Reset demo'}
+                            </button>
+                        )}
+                    </Form>
+                </div>
+                {sandbox.persona && (
+                    <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-xs">
+                        <span className="font-semibold">Try next:</span>
+                        {sandbox.persona.tasks.map((task) => (
+                            <Link
+                                key={task.href}
+                                href={task.href}
+                                className="inline-flex items-center gap-1 rounded-sm underline-offset-4 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-900 dark:focus-visible:outline-amber-100"
+                                title={task.description}
+                            >
+                                {task.label}
+                                <ArrowRight
+                                    className="size-3"
+                                    aria-hidden="true"
+                                />
+                            </Link>
+                        ))}
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/resources/js/pages/demo/personas.tsx
+++ b/resources/js/pages/demo/personas.tsx
@@ -1,5 +1,5 @@
 import { Form, Head } from '@inertiajs/react';
-import { FlaskConical } from 'lucide-react';
+import { ArrowRight, FlaskConical, ShieldCheck } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import {
     Card,
@@ -16,13 +16,17 @@ type Persona = {
     name: string;
     organisation: string;
     role: string;
+    roleKey: string;
+    responsibility: string;
+    boundary: string;
+    tasks: { label: string; description: string; href: string }[];
 };
 
 export default function DemoPersonas({ personas }: { personas: Persona[] }) {
     return (
         <main className="bg-muted/30 min-h-screen px-4 py-12">
             <Head title="Choose a demo persona" />
-            <div className="mx-auto max-w-5xl space-y-8">
+            <div className="mx-auto max-w-6xl space-y-8">
                 <div className="space-y-3 text-center">
                     <FlaskConical
                         className="mx-auto size-10 text-amber-600"
@@ -37,9 +41,12 @@ export default function DemoPersonas({ personas }: { personas: Persona[] }) {
                         external messaging, payments, or domains.
                     </p>
                 </div>
-                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                <div className="grid gap-5 lg:grid-cols-2">
                     {personas.map((persona) => (
-                        <Card key={persona.membershipId}>
+                        <Card
+                            key={persona.membershipId}
+                            className="border-slate-900/10 bg-white/80 shadow-sm dark:border-white/10 dark:bg-slate-900/80"
+                        >
                             <CardHeader>
                                 <CardTitle className="text-lg">
                                     {persona.role}
@@ -47,9 +54,50 @@ export default function DemoPersonas({ personas }: { personas: Persona[] }) {
                                 <CardDescription>
                                     {persona.organisation}
                                 </CardDescription>
+                                <p className="pt-2 text-sm leading-6">
+                                    {persona.responsibility}
+                                </p>
                             </CardHeader>
-                            <CardContent className="space-y-4">
-                                <p className="text-sm">{persona.name}</p>
+                            <CardContent className="space-y-5">
+                                <div className="rounded-lg bg-amber-50 p-3 text-sm leading-6 text-amber-950 dark:bg-amber-950 dark:text-amber-100">
+                                    <div className="mb-1 flex items-center gap-2 font-semibold">
+                                        <ShieldCheck
+                                            className="size-4"
+                                            aria-hidden="true"
+                                        />
+                                        Permission boundary
+                                    </div>
+                                    {persona.boundary}
+                                </div>
+                                <div>
+                                    <p className="mb-2 text-xs font-semibold tracking-wide text-slate-500 uppercase dark:text-slate-400">
+                                        Suggested evaluation
+                                    </p>
+                                    <ul className="space-y-2 text-sm">
+                                        {persona.tasks.map((task) => (
+                                            <li
+                                                key={task.label}
+                                                className="flex gap-2"
+                                            >
+                                                <ArrowRight
+                                                    className="mt-0.5 size-4 shrink-0 text-teal-700"
+                                                    aria-hidden="true"
+                                                />
+                                                <span>
+                                                    <span className="font-medium">
+                                                        {task.label}
+                                                    </span>{' '}
+                                                    <span className="text-muted-foreground">
+                                                        — {task.description}
+                                                    </span>
+                                                </span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                </div>
+                                <p className="text-muted-foreground text-xs">
+                                    Synthetic account: {persona.name}
+                                </p>
                                 <Form {...store.form()}>
                                     {({ processing }) => (
                                         <>
@@ -63,7 +111,7 @@ export default function DemoPersonas({ personas }: { personas: Persona[] }) {
                                                 type="submit"
                                                 disabled={processing}
                                             >
-                                                Continue as this persona
+                                                Continue as {persona.role}
                                             </Button>
                                         </>
                                     )}

--- a/resources/js/types/global.d.ts
+++ b/resources/js/types/global.d.ts
@@ -29,6 +29,17 @@ declare module '@inertiajs/core' {
             demoSandbox: {
                 pairId: string | null;
                 expiresAt: string | null;
+                persona: {
+                    role: string;
+                    organisation: string;
+                    responsibility: string;
+                    boundary: string;
+                    tasks: {
+                        label: string;
+                        description: string;
+                        href: string;
+                    }[];
+                } | null;
             } | null;
             [key: string]: unknown;
         };

--- a/tests/Feature/DemoPersonaGuideTest.php
+++ b/tests/Feature/DemoPersonaGuideTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Actions\Demo\ProvisionSandboxPair;
+use App\Enums\OrganisationRole;
+use App\Models\Membership;
+use App\Models\Organisation;
+use Illuminate\Support\Facades\DB;
+use Inertia\Testing\AssertableInertia as Assert;
+
+beforeEach(function () {
+    config(['demo_sandbox.enabled' => true]);
+    $result = app(ProvisionSandboxPair::class)->handle();
+    $this->pair = $result['pair'];
+    $this->post(route('demo.bootstrap.store', ['token' => $result['token']]))->assertRedirect();
+    $this->organisation = $this->pair->organisations()->where('sandbox_template', 'harbourkind')->firstOrFail();
+});
+
+it('explains each perspective and links to meaningful permitted work', function () {
+    $this->get(route('demo.personas.index'))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('demo/personas')
+            ->has('personas', 5)
+            ->where('personas.0.roleKey', OrganisationRole::OrganisationAdministrator->value)
+            ->where('personas.0.responsibility', fn (string $value): bool => str_contains($value, 'organisation'))
+            ->where('personas.0.boundary', fn (string $value): bool => str_contains($value, 'Demo confinement'))
+            ->has('personas.0.tasks', 3)
+            ->where('personas.4.roleKey', OrganisationRole::ExecutiveViewer->value)
+            ->has('personas.4.tasks', 2));
+
+    $destinations = [
+        OrganisationRole::OrganisationAdministrator->value => [
+            'programs.index',
+            'organisation-configurations.index',
+            'audit.index',
+        ],
+        OrganisationRole::ProgramManager->value => [
+            'intakes.index',
+            'parties.index',
+            'audit.index',
+        ],
+        OrganisationRole::CaseWorker->value => [
+            'intakes.index',
+            'parties.index',
+            'audit.index',
+        ],
+        OrganisationRole::EngagementOfficer->value => [
+            'donations.index',
+            'volunteers.index',
+            'supporter-journeys.index',
+        ],
+        OrganisationRole::ExecutiveViewer->value => [
+            'dashboard',
+            'impact-snapshots.index',
+        ],
+    ];
+
+    foreach ($destinations as $role => $routeNames) {
+        $membership = personaMembership($this->organisation, OrganisationRole::from($role));
+
+        $this->post(route('demo.personas.store'), ['membership_id' => $membership->id])->assertRedirect();
+
+        foreach ($routeNames as $routeName) {
+            $this->get(route($routeName, ['current_organisation' => $this->organisation]))->assertOk();
+        }
+    }
+});
+
+it('shares the active perspective, supports switching, and preserves inaccessible boundaries', function () {
+    $caseWorker = personaMembership($this->organisation, OrganisationRole::CaseWorker);
+    $executive = personaMembership($this->organisation, OrganisationRole::ExecutiveViewer);
+
+    $this->post(route('demo.personas.store'), ['membership_id' => $caseWorker->id])->assertRedirect();
+    $this->get(route('dashboard', ['current_organisation' => $this->organisation]))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('demoSandbox.persona.role', 'Case worker')
+            ->where('demoSandbox.persona.organisation', $this->organisation->name)
+            ->has('demoSandbox.persona.tasks', 3));
+
+    $this->post(route('demo.personas.store'), ['membership_id' => $executive->id])->assertRedirect();
+    $this->assertAuthenticatedAs($executive->user);
+    $this->get(route('impact-snapshots.index', ['current_organisation' => $this->organisation]))->assertOk();
+    $this->get(route('parties.index', ['current_organisation' => $this->organisation]))->assertForbidden();
+});
+
+function personaMembership(Organisation $organisation, OrganisationRole $role): Membership
+{
+    return Membership::query()->findOrFail((int) DB::table('role_assignments')
+        ->where('organisation_id', $organisation->id)
+        ->whereNull('program_id')
+        ->whereNull('ended_at')
+        ->where('role', $role->value)
+        ->value('membership_id'));
+}


### PR DESCRIPTION
Closes #71

## Stack
- depends on #75
- review this PR against `codex/issue-70-self-service-demo`

## Summary
- explain each persona’s responsibility, permission boundary, and meaningful evaluation tasks
- persist the chosen perspective, safe task links, role switching, and reset controls across the authenticated app shell
- verify every advertised destination under its role and confirm inaccessible records remain forbidden

## Verification
- `composer ci:check` (363 tests, 2,383 assertions)
- `npm test`
- `npm run build:ssr`
- live chooser and authenticated Case worker walkthrough