### PR TITLE
Give the evaluator journey a humane visual identity

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -13,6 +13,14 @@
         'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
         'Noto Color Emoji';
 
+    --color-civic: #173b57;
+    --color-service: #1e7a70;
+    --color-service-bright: #71c6bc;
+    --color-leaf: #5e8f4e;
+    --color-saffron: #e5a23a;
+    --color-coral: #d86a56;
+    --color-cloud: #f4f7f5;
+
     --radius-lg: var(--radius);
     --radius-md: calc(var(--radius) - 2px);
     --radius-sm: calc(var(--radius) - 4px);
@@ -62,74 +70,74 @@
 }
 
 :root {
-    --background: oklch(1 0 0);
-    --foreground: oklch(0.145 0 0);
-    --card: oklch(1 0 0);
-    --card-foreground: oklch(0.145 0 0);
-    --popover: oklch(1 0 0);
-    --popover-foreground: oklch(0.145 0 0);
-    --primary: oklch(0.205 0 0);
-    --primary-foreground: oklch(0.985 0 0);
-    --secondary: oklch(0.97 0 0);
-    --secondary-foreground: oklch(0.205 0 0);
-    --muted: oklch(0.97 0 0);
-    --muted-foreground: oklch(0.556 0 0);
-    --accent: oklch(0.97 0 0);
-    --accent-foreground: oklch(0.205 0 0);
-    --destructive: oklch(0.577 0.245 27.325);
-    --destructive-foreground: oklch(0.577 0.245 27.325);
-    --border: oklch(0.922 0 0);
-    --input: oklch(0.922 0 0);
-    --ring: oklch(0.87 0 0);
-    --chart-1: oklch(0.646 0.222 41.116);
-    --chart-2: oklch(0.6 0.118 184.704);
-    --chart-3: oklch(0.398 0.07 227.392);
-    --chart-4: oklch(0.828 0.189 84.429);
-    --chart-5: oklch(0.769 0.188 70.08);
+    --background: #f4f7f5;
+    --foreground: #173b57;
+    --card: #ffffff;
+    --card-foreground: #173b57;
+    --popover: #ffffff;
+    --popover-foreground: #173b57;
+    --primary: #173b57;
+    --primary-foreground: #ffffff;
+    --secondary: #e4efec;
+    --secondary-foreground: #173b57;
+    --muted: #e9efed;
+    --muted-foreground: #526b78;
+    --accent: #dbeae6;
+    --accent-foreground: #173b57;
+    --destructive: #b84f3f;
+    --destructive-foreground: #ffffff;
+    --border: #cbd9d5;
+    --input: #b9ccc6;
+    --ring: #1e7a70;
+    --chart-1: #1e7a70;
+    --chart-2: #5e8f4e;
+    --chart-3: #e5a23a;
+    --chart-4: #d86a56;
+    --chart-5: #173b57;
     --radius: 0.625rem;
-    --sidebar: oklch(0.985 0 0);
-    --sidebar-foreground: oklch(0.145 0 0);
-    --sidebar-primary: oklch(0.205 0 0);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.97 0 0);
-    --sidebar-accent-foreground: oklch(0.205 0 0);
-    --sidebar-border: oklch(0.922 0 0);
-    --sidebar-ring: oklch(0.87 0 0);
+    --sidebar: #e9f0ee;
+    --sidebar-foreground: #173b57;
+    --sidebar-primary: #173b57;
+    --sidebar-primary-foreground: #ffffff;
+    --sidebar-accent: #d8e7e3;
+    --sidebar-accent-foreground: #173b57;
+    --sidebar-border: #c4d4cf;
+    --sidebar-ring: #1e7a70;
 }
 
 .dark {
-    --background: oklch(0.145 0 0);
-    --foreground: oklch(0.985 0 0);
-    --card: oklch(0.145 0 0);
-    --card-foreground: oklch(0.985 0 0);
-    --popover: oklch(0.145 0 0);
-    --popover-foreground: oklch(0.985 0 0);
-    --primary: oklch(0.985 0 0);
-    --primary-foreground: oklch(0.205 0 0);
-    --secondary: oklch(0.269 0 0);
-    --secondary-foreground: oklch(0.985 0 0);
-    --muted: oklch(0.269 0 0);
-    --muted-foreground: oklch(0.708 0 0);
-    --accent: oklch(0.269 0 0);
-    --accent-foreground: oklch(0.985 0 0);
-    --destructive: oklch(0.396 0.141 25.723);
-    --destructive-foreground: oklch(0.637 0.237 25.331);
-    --border: oklch(0.269 0 0);
-    --input: oklch(0.269 0 0);
-    --ring: oklch(0.439 0 0);
-    --chart-1: oklch(0.488 0.243 264.376);
-    --chart-2: oklch(0.696 0.17 162.48);
-    --chart-3: oklch(0.769 0.188 70.08);
-    --chart-4: oklch(0.627 0.265 303.9);
-    --chart-5: oklch(0.645 0.246 16.439);
-    --sidebar: oklch(0.205 0 0);
-    --sidebar-foreground: oklch(0.985 0 0);
-    --sidebar-primary: oklch(0.985 0 0);
-    --sidebar-primary-foreground: oklch(0.985 0 0);
-    --sidebar-accent: oklch(0.269 0 0);
-    --sidebar-accent-foreground: oklch(0.985 0 0);
-    --sidebar-border: oklch(0.269 0 0);
-    --sidebar-ring: oklch(0.439 0 0);
+    --background: #0d1d29;
+    --foreground: #f4f7f5;
+    --card: #132a3a;
+    --card-foreground: #f4f7f5;
+    --popover: #132a3a;
+    --popover-foreground: #f4f7f5;
+    --primary: #71c6bc;
+    --primary-foreground: #0d1d29;
+    --secondary: #1b3545;
+    --secondary-foreground: #f4f7f5;
+    --muted: #1a3040;
+    --muted-foreground: #afc1c8;
+    --accent: #214638;
+    --accent-foreground: #f4f7f5;
+    --destructive: #ed8370;
+    --destructive-foreground: #0d1d29;
+    --border: #2d4958;
+    --input: #3a5866;
+    --ring: #71c6bc;
+    --chart-1: #71c6bc;
+    --chart-2: #94bb7f;
+    --chart-3: #f0bc68;
+    --chart-4: #ed8e7c;
+    --chart-5: #a8c2d3;
+    --sidebar: #102331;
+    --sidebar-foreground: #f4f7f5;
+    --sidebar-primary: #71c6bc;
+    --sidebar-primary-foreground: #0d1d29;
+    --sidebar-accent: #1b3b43;
+    --sidebar-accent-foreground: #f4f7f5;
+    --sidebar-border: #294554;
+    --sidebar-ring: #71c6bc;
 }
 
 @layer base {
@@ -138,6 +146,6 @@
     }
 
     body {
-        @apply bg-background text-foreground;
+        @apply bg-background text-foreground antialiased;
     }
 }

--- a/resources/js/components/demo-sandbox-banner.tsx
+++ b/resources/js/components/demo-sandbox-banner.tsx
@@ -12,7 +12,7 @@ export function DemoSandboxBanner() {
 
     return (
         <div
-            className="border-amber-300 bg-amber-50 px-4 py-2 text-amber-950 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100"
+            className="border-saffron/40 bg-saffron/12 text-foreground border-b px-4 py-2"
             role="status"
             data-test="demo-sandbox-banner"
         >
@@ -31,7 +31,7 @@ export function DemoSandboxBanner() {
                     </span>
                     <Link
                         href={choosePersona()}
-                        className="rounded-sm underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-900 dark:focus-visible:outline-amber-100"
+                        className="focus-visible:outline-ring rounded-sm font-semibold underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2"
                     >
                         Change perspective
                     </Link>
@@ -39,7 +39,7 @@ export function DemoSandboxBanner() {
                         {({ processing }) => (
                             <button
                                 type="submit"
-                                className="rounded-sm underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-900 disabled:opacity-60 dark:focus-visible:outline-amber-100"
+                                className="focus-visible:outline-ring rounded-sm font-semibold underline underline-offset-4 focus-visible:outline-2 focus-visible:outline-offset-2 disabled:opacity-60"
                                 disabled={processing}
                             >
                                 {processing ? 'Resetting…' : 'Reset demo'}
@@ -54,7 +54,7 @@ export function DemoSandboxBanner() {
                             <Link
                                 key={task.href}
                                 href={task.href}
-                                className="inline-flex items-center gap-1 rounded-sm underline-offset-4 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-900 dark:focus-visible:outline-amber-100"
+                                className="focus-visible:outline-ring inline-flex items-center gap-1 rounded-sm underline-offset-4 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2"
                                 title={task.description}
                             >
                                 {task.label}

--- a/resources/js/components/nav-main.tsx
+++ b/resources/js/components/nav-main.tsx
@@ -14,7 +14,7 @@ export function NavMain({ items }: { items: NavItem[] }) {
 
     return (
         <SidebarGroup className="px-2 py-0">
-            <SidebarGroupLabel>Platform</SidebarGroupLabel>
+            <SidebarGroupLabel>Workspace</SidebarGroupLabel>
             <SidebarMenu>
                 {items.map((item) => (
                     <SidebarMenuItem key={item.title}>
@@ -22,6 +22,7 @@ export function NavMain({ items }: { items: NavItem[] }) {
                             asChild
                             isActive={isCurrentUrl(item.href)}
                             tooltip={{ children: item.title }}
+                            className="data-[active=true]:border-service data-[active=true]:border-l-4 data-[active=true]:pl-1.5"
                         >
                             <Link href={item.href} prefetch>
                                 {item.icon && <item.icon />}

--- a/resources/js/components/ui/button.tsx
+++ b/resources/js/components/ui/button.tsx
@@ -5,16 +5,16 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-semibold transition-[color,box-shadow] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   {
     variants: {
       variant: {
         default:
           "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
         destructive:
-          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
+          "bg-destructive text-destructive-foreground shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
         outline:
-          "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-card shadow-xs hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",

--- a/resources/js/components/ui/card.tsx
+++ b/resources/js/components/ui/card.tsx
@@ -7,7 +7,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        "bg-card/95 text-card-foreground flex flex-col gap-6 rounded-xl border border-border/80 py-6 shadow-[0_10px_30px_rgba(23,59,87,0.06)] dark:shadow-black/10",
         className
       )}
       {...props}

--- a/resources/js/dashboard.test.tsx
+++ b/resources/js/dashboard.test.tsx
@@ -56,6 +56,7 @@ describe('Service operations dashboard', () => {
         expect(
             screen.getByRole('region', { name: 'Work queue counts' }),
         ).toBeVisible();
+        expect(screen.getAllByText('Queue clear')).toHaveLength(4);
 
         const interactiveElements = [
             ...screen.getAllByRole('button'),

--- a/resources/js/layouts/app/app-sidebar-layout.tsx
+++ b/resources/js/layouts/app/app-sidebar-layout.tsx
@@ -12,7 +12,10 @@ export default function AppSidebarLayout({
     return (
         <AppShell variant="sidebar">
             <AppSidebar />
-            <AppContent variant="sidebar" className="min-w-0 overflow-x-clip">
+            <AppContent
+                variant="sidebar"
+                className="bg-background min-w-0 overflow-x-clip"
+            >
                 <AppSidebarHeader breadcrumbs={breadcrumbs} />
                 <DemoSandboxBanner />
                 {children}

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -74,11 +74,11 @@ type ServiceOperations = {
 };
 
 const queueDefinitions = [
-    { key: 'caseload', label: 'Active caseload' },
-    { key: 'waitlist', label: 'Waitlist' },
-    { key: 'overdue', label: 'Overdue actions' },
-    { key: 'risks', label: 'Unresolved risks' },
-    { key: 'referrals', label: 'External referrals' },
+    { key: 'caseload', label: 'Active caseload', accent: 'border-t-service' },
+    { key: 'waitlist', label: 'Waitlist', accent: 'border-t-saffron' },
+    { key: 'overdue', label: 'Overdue actions', accent: 'border-t-coral' },
+    { key: 'risks', label: 'Unresolved risks', accent: 'border-t-coral' },
+    { key: 'referrals', label: 'External referrals', accent: 'border-t-leaf' },
 ] as const;
 
 type QueueKey = (typeof queueDefinitions)[number]['key'];
@@ -101,22 +101,22 @@ export default function Dashboard({
                 open={pendingInvitations.length > 0 && showInvitations}
                 onOpenChange={setShowInvitations}
             />
-            <main className="flex h-full flex-1 flex-col gap-6 overflow-x-auto rounded-xl p-4">
+            <main className="flex h-full flex-1 flex-col gap-6 overflow-x-auto rounded-xl p-4 sm:p-6">
                 {impact ? <ImpactMetrics impact={impact} /> : null}
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
                     <div>
-                        <h1 className="text-2xl font-semibold">
+                        <h1 className="text-3xl font-semibold tracking-tight">
                             Service operations
                         </h1>
                         <p className="text-muted-foreground mt-1 text-sm">
                             Work requiring attention within your current scope.
                         </p>
                     </div>
-                    <div className="flex flex-wrap gap-2">
+                    <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:flex-wrap">
                         <Form
                             action={dashboard.url(organisation.slug)}
                             method="get"
-                            className="flex gap-2"
+                            className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row"
                         >
                             <label className="sr-only" htmlFor="program-filter">
                                 Filter by program
@@ -127,7 +127,7 @@ export default function Dashboard({
                                 defaultValue={
                                     serviceOperations.selectedProgramId ?? ''
                                 }
-                                className="h-9 rounded-md border bg-transparent px-3"
+                                className="bg-card h-9 w-full rounded-md border px-3 sm:w-auto"
                             >
                                 <option value="">
                                     All authorised programs
@@ -164,8 +164,8 @@ export default function Dashboard({
                     aria-label="Work queue counts"
                     className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5"
                 >
-                    {queueDefinitions.map(({ key, label }) => (
-                        <Card key={key}>
+                    {queueDefinitions.map(({ key, label, accent }) => (
+                        <Card key={key} className={`border-t-4 ${accent}`}>
                             <CardHeader className="pb-2">
                                 <CardTitle className="text-sm font-medium">
                                     {label}
@@ -194,9 +194,15 @@ export default function Dashboard({
                                 </CardHeader>
                                 <CardContent>
                                     {rows.length === 0 ? (
-                                        <p className="text-muted-foreground text-sm">
-                                            No accessible work in this queue.
-                                        </p>
+                                        <div className="bg-muted/40 rounded-lg border border-dashed p-4">
+                                            <p className="font-medium">
+                                                Queue clear
+                                            </p>
+                                            <p className="text-muted-foreground mt-1 text-sm">
+                                                No accessible work in this
+                                                queue.
+                                            </p>
+                                        </div>
                                     ) : (
                                         <ul
                                             className="divide-y"

--- a/resources/js/pages/demo/personas.tsx
+++ b/resources/js/pages/demo/personas.tsx
@@ -24,7 +24,7 @@ type Persona = {
 
 export default function DemoPersonas({ personas }: { personas: Persona[] }) {
     return (
-        <main className="bg-muted/30 min-h-screen px-4 py-12">
+        <main className="bg-background min-h-screen px-4 py-12">
             <Head title="Choose a demo persona" />
             <div className="mx-auto max-w-6xl space-y-8">
                 <div className="space-y-3 text-center">
@@ -45,7 +45,7 @@ export default function DemoPersonas({ personas }: { personas: Persona[] }) {
                     {personas.map((persona) => (
                         <Card
                             key={persona.membershipId}
-                            className="border-slate-900/10 bg-white/80 shadow-sm dark:border-white/10 dark:bg-slate-900/80"
+                            className="border-border/80 bg-card/95"
                         >
                             <CardHeader>
                                 <CardTitle className="text-lg">
@@ -59,7 +59,7 @@ export default function DemoPersonas({ personas }: { personas: Persona[] }) {
                                 </p>
                             </CardHeader>
                             <CardContent className="space-y-5">
-                                <div className="rounded-lg bg-amber-50 p-3 text-sm leading-6 text-amber-950 dark:bg-amber-950 dark:text-amber-100">
+                                <div className="border-saffron bg-saffron/10 rounded-lg border-l-4 p-3 text-sm leading-6">
                                     <div className="mb-1 flex items-center gap-2 font-semibold">
                                         <ShieldCheck
                                             className="size-4"
@@ -80,7 +80,7 @@ export default function DemoPersonas({ personas }: { personas: Persona[] }) {
                                                 className="flex gap-2"
                                             >
                                                 <ArrowRight
-                                                    className="mt-0.5 size-4 shrink-0 text-teal-700"
+                                                    className="text-service dark:text-service-bright mt-0.5 size-4 shrink-0"
                                                     aria-hidden="true"
                                                 />
                                                 <span>

--- a/resources/js/pages/demo/start.tsx
+++ b/resources/js/pages/demo/start.tsx
@@ -11,23 +11,23 @@ export default function DemoStart({
     lifetimeHours: number;
 }) {
     return (
-        <main className="relative min-h-screen overflow-hidden bg-slate-50 text-slate-950 dark:bg-slate-950 dark:text-slate-50">
+        <main className="bg-background text-foreground relative min-h-screen overflow-hidden">
             <Head title="Explore the CommunityKind demo" />
             <div
-                className="absolute inset-x-0 top-0 h-1 bg-teal-700"
+                className="bg-service absolute inset-x-0 top-0 h-1"
                 aria-hidden="true"
             />
             <div className="mx-auto grid min-h-screen w-full max-w-6xl items-center gap-12 px-6 py-16 lg:grid-cols-[1.1fr_0.9fr] lg:px-10">
                 <section aria-labelledby="demo-heading" className="space-y-8">
                     <Link
                         href={home()}
-                        className="inline-flex items-center gap-2 text-sm font-semibold text-slate-700 underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-teal-700 dark:text-slate-200"
+                        className="text-foreground/80 focus-visible:outline-service inline-flex items-center gap-2 text-sm font-semibold underline-offset-4 hover:underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4"
                     >
-                        <span className="size-2 rounded-full bg-teal-700" />
+                        <span className="bg-service size-2 rounded-full" />
                         CommunityKind
                     </Link>
                     <div className="max-w-2xl space-y-5">
-                        <p className="text-sm font-semibold tracking-[0.16em] text-teal-800 uppercase dark:text-teal-300">
+                        <p className="text-service dark:text-service-bright text-sm font-semibold tracking-[0.16em] uppercase">
                             A safe, synthetic workspace
                         </p>
                         <h1
@@ -37,14 +37,14 @@ export default function DemoStart({
                             Follow the work from first contact to community
                             impact.
                         </h1>
-                        <p className="max-w-xl text-lg leading-8 text-slate-600 dark:text-slate-300">
+                        <p className="text-muted-foreground max-w-xl text-lg leading-8">
                             Step into several staff perspectives across two
                             fictional human-services organisations. No account,
                             setup, or real personal information is required.
                         </p>
                     </div>
                     <div
-                        className="flex max-w-xl items-center gap-3 text-sm text-slate-600 dark:text-slate-300"
+                        className="text-muted-foreground flex max-w-xl items-center gap-3 text-sm"
                         aria-label="Demo journey"
                     >
                         {[
@@ -56,13 +56,13 @@ export default function DemoStart({
                                 key={step}
                                 className="flex min-w-0 flex-1 items-center gap-3"
                             >
-                                <span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-teal-800 text-xs font-semibold text-white">
+                                <span className="bg-service flex size-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold text-white">
                                     {index + 1}
                                 </span>
                                 <span className="leading-tight">{step}</span>
                                 {index < 2 && (
                                     <span
-                                        className="hidden h-px flex-1 bg-teal-700/30 sm:block"
+                                        className="bg-service/30 hidden h-px flex-1 sm:block"
                                         aria-hidden="true"
                                     />
                                 )}
@@ -73,11 +73,11 @@ export default function DemoStart({
 
                 <section
                     aria-label="Prepare demo"
-                    className="rounded-2xl border border-slate-900/10 bg-white/80 p-8 shadow-sm backdrop-blur dark:border-white/10 dark:bg-slate-900/80"
+                    className="border-border/80 bg-card/90 rounded-2xl border p-8 shadow-[0_18px_50px_rgba(23,59,87,0.10)] backdrop-blur"
                 >
                     <div className="space-y-7">
                         <div className="space-y-3">
-                            <div className="flex size-11 items-center justify-center rounded-xl bg-amber-100 text-amber-800 dark:bg-amber-950 dark:text-amber-200">
+                            <div className="bg-saffron/20 text-civic dark:text-saffron flex size-11 items-center justify-center rounded-xl">
                                 <ShieldCheck
                                     className="size-6"
                                     aria-hidden="true"
@@ -86,26 +86,26 @@ export default function DemoStart({
                             <h2 className="text-2xl font-semibold tracking-tight">
                                 Your isolated evaluation space
                             </h2>
-                            <p className="leading-7 text-slate-600 dark:text-slate-300">
+                            <p className="text-muted-foreground leading-7">
                                 The workspace lasts up to {lifetimeHours} hours.
                                 Uploads, invitations, outbound messages,
                                 payments, and custom domains stay disabled.
                             </p>
                         </div>
 
-                        <ul className="space-y-3 text-sm text-slate-700 dark:text-slate-200">
+                        <ul className="text-foreground/85 space-y-3 text-sm">
                             <li className="flex gap-3">
-                                <span className="mt-2 size-1.5 shrink-0 rounded-full bg-teal-700" />
+                                <span className="bg-service mt-2 size-1.5 shrink-0 rounded-full" />
                                 Fictional people, cases, donations, volunteers,
                                 and outcomes
                             </li>
                             <li className="flex gap-3">
-                                <span className="mt-2 size-1.5 shrink-0 rounded-full bg-teal-700" />
+                                <span className="bg-leaf mt-2 size-1.5 shrink-0 rounded-full" />
                                 Role-specific permissions and realistic safety
                                 boundaries
                             </li>
                             <li className="flex gap-3">
-                                <span className="mt-2 size-1.5 shrink-0 rounded-full bg-teal-700" />
+                                <span className="bg-coral mt-2 size-1.5 shrink-0 rounded-full" />
                                 A clean reset whenever you want to start again
                             </li>
                         </ul>
@@ -116,7 +116,7 @@ export default function DemoStart({
                                     <Button
                                         type="submit"
                                         size="lg"
-                                        className="w-full bg-teal-800 text-white hover:bg-teal-700 focus-visible:ring-teal-700"
+                                        className="bg-service hover:bg-civic focus-visible:ring-service w-full text-white"
                                         disabled={processing}
                                     >
                                         {processing
@@ -134,7 +134,7 @@ export default function DemoStart({
                             )}
                         </Form>
 
-                        <p className="flex items-center justify-center gap-2 text-center text-xs text-slate-500 dark:text-slate-400">
+                        <p className="text-muted-foreground flex items-center justify-center gap-2 text-center text-xs">
                             <RotateCcw
                                 className="size-3.5"
                                 aria-hidden="true"

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -19,25 +19,25 @@ const operatingModel = [
         'Service delivery',
         'Respond with the right context',
         'Move from intake to assigned support with consent, safety, and programme scope carried through the work.',
-        'bg-[#1E7A70]',
+        'bg-service',
     ],
     [
         'Community engagement',
         'Turn participation into relationships',
         'Coordinate events, volunteers, and partner activity without losing the people and purpose behind them.',
-        'bg-[#5E8F4E]',
+        'bg-leaf',
     ],
     [
         'Supporter stewardship',
         'Make every welcome feel joined up',
         'Understand donations, audiences, and journeys while keeping supporter-safe work apart from confidential services.',
-        'bg-[#E5A23A]',
+        'bg-saffron',
     ],
     [
         'Impact evidence',
         'Show what changed—and why',
         'Bring operational signals into accountable impact packs for leaders, funders, partners, and communities.',
-        'bg-[#D86A56]',
+        'bg-coral',
     ],
 ] as const;
 
@@ -50,21 +50,21 @@ export default function Welcome() {
     return (
         <>
             <Head title="Community operations, connected" />
-            <div className="min-h-screen bg-[#F4F7F5] text-[#173B57] dark:bg-[#0D1D29] dark:text-[#F4F7F5]">
-                <header className="border-b border-[#173B57]/10 dark:border-white/10">
+            <div className="bg-cloud text-civic dark:text-cloud min-h-screen dark:bg-[#0D1D29]">
+                <header className="border-civic/10 border-b dark:border-white/10">
                     <div className="mx-auto flex w-full max-w-7xl items-center justify-between gap-6 px-5 py-5 sm:px-8 lg:px-12">
                         <Link
                             href="/"
-                            className="inline-flex items-center gap-3 rounded-sm text-lg font-semibold tracking-tight focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#1E7A70]"
+                            className="focus-visible:outline-service inline-flex items-center gap-3 rounded-sm text-lg font-semibold tracking-tight focus-visible:outline-2 focus-visible:outline-offset-4"
                         >
                             <span
-                                className="grid size-8 grid-cols-2 gap-0.5 rounded-full bg-[#173B57] p-2 dark:bg-[#F4F7F5]"
+                                className="bg-civic dark:bg-cloud grid size-8 grid-cols-2 gap-0.5 rounded-full p-2"
                                 aria-hidden="true"
                             >
-                                <span className="rounded-full bg-[#1E7A70]" />
-                                <span className="rounded-full bg-[#E5A23A]" />
-                                <span className="rounded-full bg-[#D86A56]" />
-                                <span className="rounded-full bg-[#5E8F4E]" />
+                                <span className="bg-service rounded-full" />
+                                <span className="bg-saffron rounded-full" />
+                                <span className="bg-coral rounded-full" />
+                                <span className="bg-leaf rounded-full" />
                             </span>
                             CommunityKind
                         </Link>
@@ -74,21 +74,21 @@ export default function Welcome() {
                         >
                             <a
                                 href="#operating-model"
-                                className="hidden rounded-sm text-sm font-medium hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#1E7A70] sm:inline"
+                                className="focus-visible:outline-service hidden rounded-sm text-sm font-medium hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 sm:inline"
                             >
                                 How it connects
                             </a>
                             {auth.user ? (
                                 <Link
                                     href={dashboardUrl}
-                                    className="rounded-full bg-[#173B57] px-4 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-[#1E7A70] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#1E7A70] dark:bg-[#F4F7F5] dark:text-[#173B57]"
+                                    className="bg-civic hover:bg-service focus-visible:outline-service dark:bg-cloud dark:text-civic rounded-full px-4 py-2.5 text-sm font-semibold text-white transition-colors focus-visible:outline-2 focus-visible:outline-offset-4"
                                 >
                                     Open dashboard
                                 </Link>
                             ) : (
                                 <Link
                                     href={login()}
-                                    className="rounded-full border border-[#173B57]/25 px-4 py-2.5 text-sm font-semibold transition-colors hover:border-[#1E7A70] hover:text-[#1E7A70] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#1E7A70] dark:border-white/25"
+                                    className="border-civic/25 hover:border-service hover:text-service focus-visible:outline-service rounded-full border px-4 py-2.5 text-sm font-semibold transition-colors focus-visible:outline-2 focus-visible:outline-offset-4 dark:border-white/25"
                                 >
                                     Staff log in
                                 </Link>
@@ -98,10 +98,10 @@ export default function Welcome() {
                 </header>
 
                 <main>
-                    <section className="overflow-hidden border-b border-[#173B57]/10 dark:border-white/10">
+                    <section className="border-civic/10 overflow-hidden border-b dark:border-white/10">
                         <div className="mx-auto grid max-w-7xl items-center gap-14 px-5 py-16 sm:px-8 sm:py-20 lg:grid-cols-[1.05fr_0.95fr] lg:px-12">
                             <div className="relative z-10 max-w-3xl">
-                                <p className="mb-6 flex items-center gap-2 text-sm font-semibold tracking-[0.14em] text-[#1E7A70] uppercase dark:text-[#71C6BC]">
+                                <p className="text-service mb-6 flex items-center gap-2 text-sm font-semibold tracking-[0.14em] uppercase dark:text-[#71C6BC]">
                                     <CircleDot
                                         className="size-4"
                                         aria-hidden="true"
@@ -110,11 +110,11 @@ export default function Welcome() {
                                 </p>
                                 <h1 className="text-5xl leading-[0.98] font-semibold tracking-[-0.055em] text-balance sm:text-7xl lg:text-[4.6rem]">
                                     One shared thread from first contact to{' '}
-                                    <span className="font-serif font-normal text-[#1E7A70] italic dark:text-[#71C6BC]">
+                                    <span className="text-service font-serif font-normal italic dark:text-[#71C6BC]">
                                         visible impact.
                                     </span>
                                 </h1>
-                                <p className="mt-8 max-w-2xl text-lg leading-8 text-[#173B57]/75 sm:text-xl dark:text-[#F4F7F5]/75">
+                                <p className="text-civic/75 dark:text-cloud/75 mt-8 max-w-2xl text-lg leading-8 sm:text-xl">
                                     CommunityKind helps local organisations
                                     coordinate services, supporters, volunteers,
                                     and evidence—without flattening the privacy
@@ -123,7 +123,7 @@ export default function Welcome() {
                                 <div className="mt-10 flex flex-wrap items-center gap-3">
                                     <Link
                                         href={createDemo()}
-                                        className="inline-flex items-center gap-2 rounded-full bg-[#173B57] px-6 py-3.5 text-sm font-semibold text-white transition-colors hover:bg-[#1E7A70] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#1E7A70] dark:bg-[#F4F7F5] dark:text-[#173B57]"
+                                        className="bg-civic hover:bg-service focus-visible:outline-service dark:bg-cloud dark:text-civic inline-flex items-center gap-2 rounded-full px-6 py-3.5 text-sm font-semibold text-white transition-colors focus-visible:outline-2 focus-visible:outline-offset-4"
                                     >
                                         Explore the demo{' '}
                                         <ArrowRight
@@ -133,7 +133,7 @@ export default function Welcome() {
                                     </Link>
                                     <a
                                         href={documentationUrl}
-                                        className="inline-flex items-center gap-2 rounded-full px-5 py-3.5 text-sm font-semibold hover:text-[#1E7A70] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#1E7A70]"
+                                        className="hover:text-service focus-visible:outline-service inline-flex items-center gap-2 rounded-full px-5 py-3.5 text-sm font-semibold focus-visible:outline-2 focus-visible:outline-offset-4"
                                     >
                                         Read the documentation{' '}
                                         <BookOpen
@@ -159,7 +159,7 @@ export default function Welcome() {
                                         fill="none"
                                         stroke="currentColor"
                                         strokeWidth="3"
-                                        className="text-[#173B57]/18 dark:text-white/18"
+                                        className="text-civic/18 dark:text-white/18"
                                     />
                                     <path
                                         d="M76 76 C330 65 148 218 376 228"
@@ -187,27 +187,27 @@ export default function Welcome() {
                                     [
                                         'A person asks for support',
                                         'left-[3%] top-[5%]',
-                                        'bg-[#1E7A70]',
+                                        'bg-service',
                                     ],
                                     [
                                         'A community responds',
                                         'right-[0%] top-[32%]',
-                                        'bg-[#5E8F4E]',
+                                        'bg-leaf',
                                     ],
                                     [
                                         'Relationships grow',
                                         'left-[18%] top-[58%]',
-                                        'bg-[#E5A23A]',
+                                        'bg-saffron',
                                     ],
                                     [
                                         'Change becomes visible',
                                         'right-[0%] bottom-[4%]',
-                                        'bg-[#D86A56]',
+                                        'bg-coral',
                                     ],
                                 ].map(([label, position, color]) => (
                                     <div
                                         key={label}
-                                        className={`absolute ${position} flex max-w-48 items-center gap-3 rounded-xl border border-[#173B57]/10 bg-white/90 p-3 shadow-[0_18px_45px_rgba(23,59,87,0.12)] backdrop-blur dark:border-white/10 dark:bg-[#173B57]/90`}
+                                        className={`absolute ${position} border-civic/10 dark:bg-civic/90 flex max-w-48 items-center gap-3 rounded-xl border bg-white/90 p-3 shadow-[0_18px_45px_rgba(23,59,87,0.12)] backdrop-blur dark:border-white/10`}
                                     >
                                         <span
                                             className={`size-3 shrink-0 rounded-full ${color}`}
@@ -229,7 +229,7 @@ export default function Welcome() {
                     >
                         <div className="grid gap-10 lg:grid-cols-[0.7fr_1.3fr] lg:gap-16">
                             <div>
-                                <p className="text-sm font-semibold tracking-[0.14em] text-[#1E7A70] uppercase dark:text-[#71C6BC]">
+                                <p className="text-service text-sm font-semibold tracking-[0.14em] uppercase dark:text-[#71C6BC]">
                                     One connected operating model
                                 </p>
                                 <h2
@@ -239,26 +239,26 @@ export default function Welcome() {
                                     The work makes more sense when the thread
                                     stays intact.
                                 </h2>
-                                <p className="mt-6 text-base leading-7 text-[#173B57]/70 dark:text-[#F4F7F5]/70">
+                                <p className="text-civic/70 dark:text-cloud/70 mt-6 text-base leading-7">
                                     Each team keeps the view and safeguards it
                                     needs. Shared signals travel forward, so
                                     impact is grounded in real work instead of
                                     assembled at reporting time.
                                 </p>
                             </div>
-                            <ol className="relative border-l-2 border-[#173B57]/10 dark:border-white/10">
+                            <ol className="border-civic/10 relative border-l-2 dark:border-white/10">
                                 {operatingModel.map(
                                     ([label, title, body, color], index) => (
                                         <li
                                             key={label}
-                                            className="relative grid gap-3 border-b border-[#173B57]/10 py-7 pl-8 last:border-b-0 sm:grid-cols-[10rem_1fr] sm:gap-8 dark:border-white/10"
+                                            className="border-civic/10 relative grid gap-3 border-b py-7 pl-8 last:border-b-0 sm:grid-cols-[10rem_1fr] sm:gap-8 dark:border-white/10"
                                         >
                                             <span
-                                                className={`absolute top-9 -left-[7px] size-3 rounded-full ring-4 ring-[#F4F7F5] dark:ring-[#0D1D29] ${color}`}
+                                                className={`ring-cloud absolute top-9 -left-[7px] size-3 rounded-full ring-4 dark:ring-[#0D1D29] ${color}`}
                                                 aria-hidden="true"
                                             />
                                             <div>
-                                                <span className="text-xs font-semibold tracking-[0.12em] text-[#173B57]/55 uppercase dark:text-[#F4F7F5]/55">
+                                                <span className="text-civic/55 dark:text-cloud/55 text-xs font-semibold tracking-[0.12em] uppercase">
                                                     {String(index + 1).padStart(
                                                         2,
                                                         '0',
@@ -272,7 +272,7 @@ export default function Welcome() {
                                                 <h3 className="text-xl font-semibold tracking-tight">
                                                     {title}
                                                 </h3>
-                                                <p className="mt-2 leading-7 text-[#173B57]/70 dark:text-[#F4F7F5]/70">
+                                                <p className="text-civic/70 dark:text-cloud/70 mt-2 leading-7">
                                                     {body}
                                                 </p>
                                             </div>
@@ -283,7 +283,7 @@ export default function Welcome() {
                         </div>
                     </section>
 
-                    <section className="bg-[#173B57] text-[#F4F7F5]">
+                    <section className="bg-civic text-cloud">
                         <div className="mx-auto grid max-w-7xl gap-14 px-5 py-20 sm:px-8 sm:py-28 lg:grid-cols-2 lg:px-12">
                             <div>
                                 <LockKeyhole
@@ -293,7 +293,7 @@ export default function Welcome() {
                                 <h2 className="mt-6 text-4xl leading-tight font-semibold tracking-[-0.035em] sm:text-5xl">
                                     Privacy is part of the operating model.
                                 </h2>
-                                <p className="mt-6 max-w-xl text-lg leading-8 text-[#F4F7F5]/70">
+                                <p className="text-cloud/70 mt-6 max-w-xl text-lg leading-8">
                                     CommunityKind separates confidential service
                                     delivery from supporter-safe engagement,
                                     then applies role and programme boundaries
@@ -309,7 +309,7 @@ export default function Welcome() {
                                 ].map((item) => (
                                     <li
                                         key={item}
-                                        className="flex gap-3 border-t border-white/15 pt-4 leading-7 text-[#F4F7F5]/85"
+                                        className="text-cloud/85 flex gap-3 border-t border-white/15 pt-4 leading-7"
                                     >
                                         <Check
                                             className="mt-1 size-5 shrink-0 text-[#71C6BC]"
@@ -323,15 +323,15 @@ export default function Welcome() {
                     </section>
 
                     <section className="mx-auto max-w-7xl px-5 py-20 sm:px-8 sm:py-28 lg:px-12">
-                        <div className="grid gap-12 border-b border-[#173B57]/15 pb-20 lg:grid-cols-[1fr_0.8fr] dark:border-white/15">
+                        <div className="border-civic/15 grid gap-12 border-b pb-20 lg:grid-cols-[1fr_0.8fr] dark:border-white/15">
                             <div>
-                                <p className="text-sm font-semibold tracking-[0.14em] text-[#1E7A70] uppercase dark:text-[#71C6BC]">
+                                <p className="text-service text-sm font-semibold tracking-[0.14em] uppercase dark:text-[#71C6BC]">
                                     Open by design
                                 </p>
                                 <h2 className="mt-4 max-w-3xl text-4xl leading-tight font-semibold tracking-[-0.035em] sm:text-5xl">
                                     Inspect the decisions, not just the demo.
                                 </h2>
-                                <p className="mt-6 max-w-2xl text-lg leading-8 text-[#173B57]/70 dark:text-[#F4F7F5]/70">
+                                <p className="text-civic/70 dark:text-cloud/70 mt-6 max-w-2xl text-lg leading-8">
                                     The source, licence, domain decisions, and
                                     technical documentation are public. That
                                     makes the platform easier to evaluate,
@@ -341,7 +341,7 @@ export default function Welcome() {
                             <div className="flex flex-col justify-end gap-3">
                                 <a
                                     href={documentationUrl}
-                                    className="inline-flex items-center justify-between gap-4 border-t border-[#173B57]/15 py-4 font-semibold hover:text-[#1E7A70] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#1E7A70] dark:border-white/15"
+                                    className="border-civic/15 hover:text-service focus-visible:outline-service inline-flex items-center justify-between gap-4 border-t py-4 font-semibold focus-visible:outline-2 focus-visible:outline-offset-4 dark:border-white/15"
                                 >
                                     Read the documentation{' '}
                                     <BookOpen
@@ -351,7 +351,7 @@ export default function Welcome() {
                                 </a>
                                 <a
                                     href="https://github.com/datashaman/community-kind"
-                                    className="inline-flex items-center justify-between gap-4 border-t border-[#173B57]/15 py-4 font-semibold hover:text-[#1E7A70] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#1E7A70] dark:border-white/15"
+                                    className="border-civic/15 hover:text-service focus-visible:outline-service inline-flex items-center justify-between gap-4 border-t py-4 font-semibold focus-visible:outline-2 focus-visible:outline-offset-4 dark:border-white/15"
                                 >
                                     Inspect the repository{' '}
                                     <GitFork
@@ -359,18 +359,18 @@ export default function Welcome() {
                                         aria-hidden="true"
                                     />
                                 </a>
-                                <SourceAndLicenceLink className="inline-flex items-center justify-between gap-4 border-y border-[#173B57]/15 py-4 font-semibold hover:text-[#1E7A70] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#1E7A70] dark:border-white/15" />
+                                <SourceAndLicenceLink className="border-civic/15 hover:text-service focus-visible:outline-service inline-flex items-center justify-between gap-4 border-y py-4 font-semibold focus-visible:outline-2 focus-visible:outline-offset-4 dark:border-white/15" />
                             </div>
                         </div>
                         <div className="grid items-end gap-10 pt-20 lg:grid-cols-[1fr_auto]">
                             <div>
-                                <p className="text-sm font-semibold tracking-[0.14em] text-[#D86A56] uppercase dark:text-[#F29A88]">
+                                <p className="text-coral text-sm font-semibold tracking-[0.14em] uppercase dark:text-[#F29A88]">
                                     Honest about readiness
                                 </p>
                                 <h2 className="mt-4 max-w-3xl text-4xl leading-tight font-semibold tracking-[-0.035em] sm:text-5xl">
                                     Evaluate the shape of the work—safely.
                                 </h2>
-                                <p className="mt-6 max-w-3xl leading-7 text-[#173B57]/70 dark:text-[#F4F7F5]/70">
+                                <p className="text-civic/70 dark:text-cloud/70 mt-6 max-w-3xl leading-7">
                                     CommunityKind is an active reference
                                     implementation, not yet a production service
                                     for real client or supporter information.
@@ -382,7 +382,7 @@ export default function Welcome() {
                             </div>
                             <Link
                                 href={createDemo()}
-                                className="inline-flex items-center justify-center gap-2 rounded-full bg-[#D86A56] px-6 py-3.5 text-sm font-semibold text-white transition-colors hover:bg-[#173B57] focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#D86A56] dark:hover:bg-[#F4F7F5] dark:hover:text-[#173B57]"
+                                className="bg-coral hover:bg-civic focus-visible:outline-coral dark:hover:bg-cloud dark:hover:text-civic inline-flex items-center justify-center gap-2 rounded-full px-6 py-3.5 text-sm font-semibold text-white transition-colors focus-visible:outline-2 focus-visible:outline-offset-4"
                             >
                                 Start a safe demo{' '}
                                 <ArrowRight
@@ -394,23 +394,23 @@ export default function Welcome() {
                     </section>
                 </main>
 
-                <footer className="border-t border-[#173B57]/10 dark:border-white/10">
+                <footer className="border-civic/10 border-t dark:border-white/10">
                     <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-5 px-5 py-8 text-sm sm:px-8 lg:px-12">
                         <p>Built in the open for stronger community work.</p>
                         <div className="flex flex-wrap gap-5">
                             <a
                                 href={documentationUrl}
-                                className="hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#1E7A70]"
+                                className="focus-visible:outline-service hover:underline focus-visible:outline-2 focus-visible:outline-offset-4"
                             >
                                 Documentation
                             </a>
                             <Link
                                 href={login()}
-                                className="hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#1E7A70]"
+                                className="focus-visible:outline-service hover:underline focus-visible:outline-2 focus-visible:outline-offset-4"
                             >
                                 Staff log in
                             </Link>
-                            <SourceAndLicenceLink className="hover:underline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#1E7A70]" />
+                            <SourceAndLicenceLink className="focus-visible:outline-service hover:underline focus-visible:outline-2 focus-visible:outline-offset-4" />
                         </div>
                     </div>
                 </footer>

--- a/resources/js/tests/pages/welcome.test.tsx
+++ b/resources/js/tests/pages/welcome.test.tsx
@@ -55,5 +55,11 @@ describe('Welcome', () => {
             screen.getAllByRole('link', { name: 'Staff log in' })[0],
         ).toHaveAttribute('href', '/login');
         expect(screen.getByText(/not yet a production service/i)).toBeVisible();
+
+        for (const link of screen.getAllByRole('link')) {
+            expect(link.tabIndex).toBe(0);
+            link.focus();
+            expect(link).toHaveFocus();
+        }
     });
 });

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -3,6 +3,8 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="theme-color" content="#f4f7f5" media="(prefers-color-scheme: light)">
+        <meta name="theme-color" content="#0d1d29" media="(prefers-color-scheme: dark)">
 
         {{-- Inline script to detect system dark mode preference and apply it immediately --}}
         <script>
@@ -22,11 +24,11 @@
         {{-- Inline style to set the HTML background color based on our theme in app.css --}}
         <style>
             html {
-                background-color: oklch(1 0 0);
+                background-color: #f4f7f5;
             }
 
             html.dark {
-                background-color: oklch(0.145 0 0);
+                background-color: #0d1d29;
             }
         </style>
 

--- a/tests/Feature/PublicHomepageTest.php
+++ b/tests/Feature/PublicHomepageTest.php
@@ -3,8 +3,13 @@
 use Inertia\Testing\AssertableInertia as Assert;
 
 it('renders the public product introduction', function () {
-    $this->get(route('home'))
+    $response = $this->get(route('home'));
+
+    $response
         ->assertOk()
+        ->assertSee('name="theme-color"', false)
+        ->assertSee('#f4f7f5', false)
+        ->assertSee('#0d1d29', false)
         ->assertInertia(fn (Assert $page) => $page
             ->component('welcome')
             ->where('auth.user', null));


### PR DESCRIPTION
Closes #73

## Stack
- depends on #77 → #76 → #75
- review this PR against `codex/issue-72-public-product-story`

## Summary
- establish shared civic, service, leaf, saffron, coral, and cloud semantic tokens in accessible light and dark palettes
- carry the identity through UI primitives, app shell, active navigation, demo entry, persona guide, synthetic banner, and service dashboard
- distinguish queue states with labels, structure, and accents; fix narrow-screen dashboard controls and the pre-CSS theme flash

## Verification
- `composer ci:check` (364 tests, 2,405 assertions)
- `npm test`
- `npm run build:ssr`
- focused design/WCAG static audit plus live desktop and 390px dark-mode checks
- no live contrast, colour-only signalling, clickable-div, keyboard, or viewport-overflow failures after fixes