### PR TITLE
Publish evaluation and operations documentation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Run frontend tests
         run: npm test
 
+      - name: Check documentation links and freshness
+        run: npm run docs:check
+
       - name: Build production assets
         run: npm run build
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,17 @@
 
 CommunityKind is an open-source, multi-tenant community impact platform for local nonprofits that deliver support services while mobilising donors and supporters.
 
-The project is in its specification-build stage. Its centrepiece is a privacy-preserving request-to-outcome workflow, with strict separation between service-client information, supporter activity, and nonprofit tenants.
+The project is an active reference implementation. Its centrepiece is a privacy-preserving request-to-outcome workflow, with strict separation between service-client information, supporter activity, and nonprofit tenants.
 
-Read the [product requirements document](PRD-community-impact-platform.md) for the proposed scope, architecture, delivery milestones, safeguards, and sustainability model.
+Start with the [documentation](docs/index.md), or read the [product requirements document](PRD-community-impact-platform.md) for scope, architecture, delivery milestones, safeguards, and sustainability.
 
 ## Project status
 
-**Foundation only.** The Laravel application and engineering baseline are runnable, but the product workflows are not yet implemented. The requirements use fictional organisations and synthetic data and have not been validated with a real nonprofit, practitioner, or jurisdiction-specific legal adviser. Do not use real data.
+**Active reference implementation.** The connected service, engagement, stewardship, impact, tenancy, billing-foundation, and resettable-demo workflows are runnable. They use fictional organisations and synthetic data and have not been validated as a production service with a real nonprofit, practitioner, or jurisdiction-specific legal adviser. Do not use real data.
+
+## Quick start
+
+For evaluation, open the application and choose **Explore the demo**. For development, follow the [non-Docker local setup guide](docs/how-to/local-setup.md); Docker remains an [optional separate setup](docs/how-to/docker-setup.md).
 
 ## Technology baseline
 
@@ -37,6 +41,7 @@ Create a PostgreSQL database and user for the application, then copy the
 environment file:
 
 ```bash
+cd /path/to/community-kind
 cp .env.example .env
 ```
 
@@ -130,6 +135,7 @@ Docker Desktop (or a compatible Docker Engine), Composer 2, and PHP 8.4 or
 newer for the initial dependency install.
 
 ```bash
+cd /path/to/community-kind
 cp .env.example .env
 composer install
 ./vendor/bin/sail up -d

--- a/docs/explanation/domain-and-tenancy.md
+++ b/docs/explanation/domain-and-tenancy.md
@@ -1,0 +1,23 @@
+<!-- reviewed: 2026-09-01 -->
+
+# Architecture, tenancy, organisations, and billing
+
+One CommunityKind Installation is an independent deployment and identity boundary. Within it, each Organisation is a separate nonprofit tenant and data boundary. Organisations do not contain one another or inherit access, even when they share Users or a Billing Account.
+
+## Identity and operational authority
+
+A User authenticates to one Installation. Organisation Membership records each separate tenure, while Role Assignments grant operational permissions at organisation or programme scope. Organisation ownership is a governance responsibility, not automatic access to case, supporter, or billing data.
+
+Parties are organisation-owned people, households, or external organisations. They are not Users or tenant Organisations and are never deduplicated across tenants.
+
+## Service delivery
+
+Programs organise service delivery. Cases belong to exactly one Program; assignment and role scope determine confidential access. Supporter-safe engagement remains distinct from service-client context even when aggregate signals contribute to impact reporting.
+
+## Billing is a separate authority plane
+
+A Billing Account represents the payer for the official hosted Installation. It may fund several Organisations through separate Subscriptions but owns none of their operational data. Billing Account Membership grants billing authority only. Service Invoices and Service Payments are platform charges and never become an Organisation's donations.
+
+Self-hosted Organisations have no hosted Subscription. Organisation Status, Subscription Status, incident Access Holds, and effective Hosted Access are deliberately separate state machines.
+
+The canonical vocabulary and invariants are in [CONTEXT.md](../../CONTEXT.md); implemented and planned scope is tracked in the [PRD](../../PRD-community-impact-platform.md).

--- a/docs/explanation/privacy-and-safety.md
+++ b/docs/explanation/privacy-and-safety.md
@@ -1,0 +1,19 @@
+<!-- reviewed: 2026-09-01 -->
+
+# Privacy, safety, and demo confinement
+
+CommunityKind treats privacy as an operating boundary, not a presentation setting. Tenant identity, programme scope, role assignment, case assignment, consent, safe-contact context, and restricted grants combine before confidential information is available.
+
+## Separation by purpose
+
+Service delivery can contain sensitive or highly restricted records. Engagement staff work with supporter-safe profiles, donations, audiences, volunteers, events, and journeys. Impact views use authorised operational signals and minimum-cohort suppression rather than opening frontline records to every viewer.
+
+Important changes are audited. Installation operators receive no routine tenant authority; elevated support access is intended to be narrow, time-limited, approved, and auditable.
+
+## Synthetic demo boundary
+
+Self-service demo sandboxes are enabled only in `local` or `demo` environments. Each pair is isolated, generation-bound, rate-limited, and expires within 24 hours. Bootstrap tokens are hashed, single-use, and consumed only by a CSRF-protected POST after a harmless confirmation GET.
+
+Demo mode blocks uploads, invitations, external messages, payments, and custom domains. Reset expires the current pair, invalidates its session, and provisions a fresh pair. Never enter real information: synthetic mode reduces risk but is not consent to process personal data.
+
+See [SECURITY.md](../../SECURITY.md) for responsible disclosure.

--- a/docs/how-to/contribute.md
+++ b/docs/how-to/contribute.md
@@ -1,0 +1,13 @@
+<!-- reviewed: 2026-09-01 -->
+
+# Contribute a change
+
+1. Follow the [non-Docker local setup](local-setup.md).
+2. Read [CONTEXT.md](../../CONTEXT.md), applicable project guidance, and the [contribution policy](../../CONTRIBUTING.md).
+3. Never use real service-user, supporter, credential, or incident data.
+4. Add proportionate tests and preserve keyboard, screen-reader, authorization, and tenant-isolation behaviour.
+5. Run `composer ci:check`, `npm test`, `npm run build:ssr`, `npm run docs:check`, and licence/security checks.
+6. Review the diff against its base branch and fix actionable findings.
+7. Sign every commit cryptographically and add DCO sign-off with `git commit -S -s`.
+
+Disclose material AI assistance in the pull request. Report vulnerabilities through [SECURITY.md](../../SECURITY.md), not a public issue.

--- a/docs/how-to/docker-setup.md
+++ b/docs/how-to/docker-setup.md
@@ -1,0 +1,27 @@
+<!-- reviewed: 2026-09-01 -->
+
+# Use the optional Docker development environment
+
+The repository retains Laravel Sail as an optional environment. It is not the primary local workflow.
+
+## Requirements
+
+- Docker Desktop or a compatible Docker Engine
+- Composer 2 and PHP 8.4+ for the initial dependency install
+
+## Start the environment
+
+```bash
+cd /path/to/community-kind
+cp .env.example .env
+composer install
+./vendor/bin/sail up -d
+./vendor/bin/sail artisan key:generate
+./vendor/bin/sail artisan migrate
+./vendor/bin/sail npm ci
+./vendor/bin/sail npm run dev
+```
+
+Open `http://localhost`. Mailpit is at `http://localhost:8025`; MinIO is at `http://localhost:8900`.
+
+Stop services with `./vendor/bin/sail down`. Classified-data keys and demo seeding still follow the [local setup guide](local-setup.md).

--- a/docs/how-to/local-setup.md
+++ b/docs/how-to/local-setup.md
@@ -1,0 +1,51 @@
+<!-- reviewed: 2026-09-01 -->
+
+# Set up local development without Docker
+
+This is the primary development setup. Docker is optional and not required.
+
+## Requirements
+
+- PHP 8.4+ with `mbstring`, `pdo_pgsql`, and `redis`
+- Composer 2, Laravel Valet 4, Node.js 24, and npm 11+
+- PostgreSQL 18 and Redis 7
+
+## Configure the application
+
+```bash
+cd /path/to/community-kind
+cp .env.example .env
+composer install
+npm ci
+php artisan key:generate
+```
+
+Create a PostgreSQL database and least-privileged application user. Set `APP_URL=https://community-kind.test`, `ORGANISATION_PUBLIC_DOMAIN=community-kind.test`, the `DB_*` values, `REDIS_HOST=127.0.0.1`, and `MAIL_MAILER=log`.
+
+Generate separate 32-byte classified-data and contact-index keys:
+
+```bash
+php -r 'echo "base64:".base64_encode(random_bytes(32)).PHP_EOL;'
+```
+
+Set `CLASSIFIED_DATA_KEY_CURRENT`, `CLASSIFIED_DATA_KEYS`, `CONTACT_INDEX_KEY_CURRENT`, and `CONTACT_INDEX_KEYS` as shown in [.env.example](../../.env.example).
+
+## Prepare services and data
+
+```bash
+php artisan migrate
+php artisan config:clear
+php artisan db:seed
+valet link community-kind --secure
+```
+
+Valet routes wildcard tenant subdomains to the linked application. Start the frontend and queue worker in separate terminals:
+
+```bash
+npm run dev
+php artisan horizon
+```
+
+Open `https://community-kind.test`. Seeded synthetic users use password `password`; begin with `admin@harbourkind.example.test`, `admin@neighbourlink.example.test`, or `switcher@community-kind.example.test`.
+
+Run `composer ci:check`, `npm test`, and `npm run build:ssr` before proposing a change.

--- a/docs/how-to/operate-an-installation.md
+++ b/docs/how-to/operate-an-installation.md
@@ -1,0 +1,29 @@
+<!-- reviewed: 2026-09-01 -->
+
+# Deploy, back up, and upgrade an installation
+
+CommunityKind does not yet ship a production deployment recipe. Treat this as the minimum operator checklist and validate it for the chosen platform and jurisdiction.
+
+## Deploy
+
+1. Provide PHP 8.4, Node.js 24 build tooling, PostgreSQL 18, Redis 7, TLS, durable object storage, and a supervised Horizon process.
+2. Set `APP_ENV=production`, `APP_DEBUG=false`, `DEMO_SANDBOX_ENABLED=false`, `APP_RELEASE` to the deployed commit, and `APP_SOURCE_REPOSITORY` to durable corresponding source.
+3. Use distinct migration and least-privileged application database roles.
+4. Run `composer install --no-dev --optimize-autoloader`, build assets, run migrations, cache configuration/routes/views, and restart Horizon with `php artisan horizon:terminate`.
+5. Run health, authentication, tenant-isolation, queue, mail, storage, and restore smoke tests.
+
+## Back up and restore
+
+Back up PostgreSQL, object storage, encryption-key material, and deployment configuration on separate retention schedules. Encrypt backups and restrict restore authority. A database backup without the matching classified-data and contact-index keys is incomplete.
+
+Test restores into an isolated environment. Verify row counts, encrypted-field readability, tenant isolation, stored objects, and a representative queued job before declaring the restore usable.
+
+## Upgrade
+
+1. Read the release diff, migrations, dependency advisories, and [decision records](../reference/decisions.md).
+2. Take and verify a restorable backup.
+3. Run `composer ci:check`, `npm test`, and `npm run build:ssr` against production-like services.
+4. Deploy code and assets, run migrations once, clear/rebuild caches, and terminate Horizon gracefully.
+5. Verify `APP_RELEASE`, source/licence links, scheduled tasks, queues, logs, and tenant/public hosts.
+
+Rollback must account for irreversible migrations. Prefer forward-compatible expand/migrate/contract changes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,28 @@
+<!-- reviewed: 2026-09-01 -->
+
+# CommunityKind documentation
+
+CommunityKind is an open-source community operations platform for human-services organisations. These docs describe the implemented reference application and its safe synthetic demo.
+
+## Learn by evaluating
+
+- [Evaluate CommunityKind through five staff perspectives](tutorials/evaluate-communitykind.md)
+
+## Complete a task
+
+- [Set up local development without Docker](how-to/local-setup.md)
+- [Use the optional Docker development environment](how-to/docker-setup.md)
+- [Deploy, back up, and upgrade an installation](how-to/operate-an-installation.md)
+- [Contribute a change](how-to/contribute.md)
+
+## Understand the model
+
+- [Architecture, tenancy, organisations, and billing](explanation/domain-and-tenancy.md)
+- [Privacy, safety, and demo confinement](explanation/privacy-and-safety.md)
+
+## Look up facts
+
+- [Configuration reference](reference/configuration.md)
+- [Decision and project-record reference](reference/decisions.md)
+
+CommunityKind is not yet a production service for real client or supporter information. Use fictional data only.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,17 @@
+<!-- reviewed: 2026-09-01 -->
+
+# Configuration reference
+
+| Area            | Variables                                                               | Current requirement                                               |
+| --------------- | ----------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Runtime         | `APP_ENV`, `APP_DEBUG`, `APP_URL`                                       | Production uses `APP_DEBUG=false` and HTTPS                       |
+| Release/source  | `APP_RELEASE`, `APP_SOURCE_REPOSITORY`                                  | Production release must identify an exact commit or release       |
+| Tenancy         | `ORGANISATION_PUBLIC_DOMAIN`, `ORGANISATION_SELF_SERVICE_PROVISIONING`  | Hosted provisioning should remain controlled                      |
+| Database        | `DB_CONNECTION`, `DB_HOST`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD` | PostgreSQL 18; application role is least-privileged               |
+| Queue/cache     | `REDIS_HOST`, `HORIZON_*`                                               | Redis 7 and a supervised Horizon worker                           |
+| Classified data | `CLASSIFIED_DATA_KEY_CURRENT`, `CLASSIFIED_DATA_KEYS`                   | Versioned 32-byte keys; retain keys needed by stored ciphertext   |
+| Contact indexes | `CONTACT_INDEX_KEY_CURRENT`, `CONTACT_INDEX_KEYS`                       | Separate versioned keys from classified-data encryption           |
+| Demo            | `DEMO_SANDBOX_ENABLED`                                                  | Effective only in `local` or `demo`; maximum lifetime is 24 hours |
+| Mail/storage    | `MAIL_*`, `FILESYSTEM_DISK`, object-store variables                     | Production providers require TLS, access controls, and monitoring |
+
+Authoritative defaults live in [.env.example](../../.env.example) and `config/`. PHP targets 8.4, Node.js 24, PostgreSQL 18, and Redis 7.

--- a/docs/reference/decisions.md
+++ b/docs/reference/decisions.md
@@ -1,0 +1,17 @@
+<!-- reviewed: 2026-09-01 -->
+
+# Decision and project-record reference
+
+CommunityKind currently records durable decisions in these versioned sources:
+
+| Record                                                         | Purpose                                                                       |
+| -------------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| [CONTEXT.md](../../CONTEXT.md)                                 | Canonical domain language, invariants, and terms to avoid                     |
+| [Product requirements](../../PRD-community-impact-platform.md) | Product scope, architecture, safeguards, milestones, and sustainability model |
+| [README](../../README.md)                                      | Current project status, setup summary, verification, and licensing            |
+| [CONTRIBUTING](../../CONTRIBUTING.md)                          | Contribution, DCO, testing, and AI-assistance policy                          |
+| [SECURITY](../../SECURITY.md)                                  | Vulnerability reporting and security expectations                             |
+| [GOVERNANCE](../../GOVERNANCE.md)                              | Project governance                                                            |
+| [Dependency policy](../licensing/dependency-policy.md)         | Licence acceptance and dependency review                                      |
+
+There is no `docs/adr/` series yet. Do not infer undocumented decisions from an empty ADR catalogue; consult the records above and git history. When a new architectural decision needs a durable rationale and alternatives, add an ADR and link it here.

--- a/docs/tutorials/evaluate-communitykind.md
+++ b/docs/tutorials/evaluate-communitykind.md
@@ -1,0 +1,42 @@
+<!-- reviewed: 2026-09-01 -->
+
+# Evaluate CommunityKind through staff perspectives
+
+In this tutorial, we will start an isolated demo, inspect connected work as several staff roles, change perspective, and reset the workspace.
+
+## Before you begin
+
+- Open the CommunityKind homepage in a modern browser.
+- Do not enter real personal, client, donor, volunteer, or organisation data.
+
+## 1. Start a safe workspace
+
+Choose **Explore the demo**, then **Prepare my demo**. The confirmation page describes the synthetic boundary and expiry. Choose **Enter the demo** to reach the persona guide.
+
+Repeated preparation requests in the same browser resume the pending workspace. Each workspace expires within 24 hours.
+
+## 2. Choose a perspective
+
+Start as **Case worker**. Read the responsibility and permission boundary before continuing. Use the persistent **Try next** links to inspect service requests, participant context, and accountable actions.
+
+Notice that the shell always identifies the synthetic state and selected perspective.
+
+## 3. Compare roles
+
+Choose **Change perspective** in the synthetic-demo banner, then try:
+
+| Perspective                | Meaningful tasks                                           | Deliberate boundary                               |
+| -------------------------- | ---------------------------------------------------------- | ------------------------------------------------- |
+| Organisation administrator | Programme setup, organisation configuration, audit history | Outbound and hosted capabilities remain disabled  |
+| Program manager            | Intake queue, participant profiles, operational audit      | Work is limited to authorised programme scope     |
+| Case worker                | Assigned requests and participant context                  | Confidential work requires assignment and scope   |
+| Engagement officer         | Simulated donations, volunteers, welcome journeys          | Confidential service records are unavailable      |
+| Executive viewer           | Impact dashboard and published impact packs                | Operational and supporter records are unavailable |
+
+## 4. Reset safely
+
+Choose **Reset demo** from any authenticated demo page. The current pair is expired, the session is cleared, and a fresh synthetic workspace is prepared through the same confirmation flow.
+
+## What you evaluated
+
+You followed one connected operating model while seeing how permissions change the available data and tasks. For the underlying boundaries, read [Privacy, safety, and demo confinement](../explanation/privacy-and-safety.md).

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "build": "vp build",
         "build:ssr": "vp build && vp build --ssr",
         "dev": "vp dev",
+        "docs:check": "node scripts/check-docs.mjs",
         "check": "vp check",
         "check:fix": "vp check --fix",
         "licenses:check": "node scripts/check-licenses.mjs",

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -12,7 +12,7 @@ import { dashboard, login } from '@/routes';
 import { create as createDemo } from '@/routes/demo';
 
 const documentationUrl =
-    'https://github.com/datashaman/community-kind/tree/main/docs';
+    'https://github.com/datashaman/community-kind/blob/main/docs/index.md';
 
 const operatingModel = [
     [

--- a/resources/js/tests/pages/welcome.test.tsx
+++ b/resources/js/tests/pages/welcome.test.tsx
@@ -49,7 +49,7 @@ describe('Welcome', () => {
             screen.getAllByRole('link', { name: 'Read the documentation' })[0],
         ).toHaveAttribute(
             'href',
-            'https://github.com/datashaman/community-kind/tree/main/docs',
+            'https://github.com/datashaman/community-kind/blob/main/docs/index.md',
         );
         expect(
             screen.getAllByRole('link', { name: 'Staff log in' })[0],

--- a/scripts/check-docs.mjs
+++ b/scripts/check-docs.mjs
@@ -1,0 +1,84 @@
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative, resolve } from 'node:path';
+
+const root = process.cwd();
+const docsRoot = join(root, 'docs');
+const quadrants = ['tutorials', 'how-to', 'explanation', 'reference'];
+const requiredPages = [
+    'docs/index.md',
+    'docs/tutorials/evaluate-communitykind.md',
+    'docs/how-to/local-setup.md',
+    'docs/how-to/docker-setup.md',
+    'docs/how-to/operate-an-installation.md',
+    'docs/how-to/contribute.md',
+    'docs/explanation/domain-and-tenancy.md',
+    'docs/explanation/privacy-and-safety.md',
+    'docs/reference/configuration.md',
+    'docs/reference/decisions.md',
+];
+const errors = [];
+
+for (const page of requiredPages) {
+    if (!existsSync(join(root, page))) {
+        errors.push(`Missing required documentation page: ${page}`);
+    }
+}
+
+const publishedPages = [join(docsRoot, 'index.md')];
+for (const quadrant of quadrants) {
+    const directory = join(docsRoot, quadrant);
+    const pages = existsSync(directory)
+        ? readdirSync(directory).filter((file) => file.endsWith('.md'))
+        : [];
+
+    if (pages.length === 0) {
+        errors.push(`Documentation quadrant is empty: docs/${quadrant}`);
+    }
+
+    publishedPages.push(...pages.map((page) => join(directory, page)));
+}
+
+for (const page of publishedPages.filter(existsSync)) {
+    const contents = readFileSync(page, 'utf8');
+    const displayPath = relative(root, page);
+    const reviewed = contents.match(/<!-- reviewed: (\d{4}-\d{2}-\d{2}) -->/);
+
+    if (!reviewed) {
+        errors.push(`${displayPath}: missing reviewed date`);
+    } else {
+        const reviewedAt = new Date(`${reviewed[1]}T00:00:00Z`);
+        const ageDays = (Date.now() - reviewedAt.getTime()) / 86_400_000;
+
+        if (Number.isNaN(reviewedAt.getTime()) || ageDays < -1) {
+            errors.push(
+                `${displayPath}: invalid or future reviewed date ${reviewed[1]}`,
+            );
+        } else if (ageDays > 183) {
+            errors.push(
+                `${displayPath}: stale review date ${reviewed[1]} (over 183 days)`,
+            );
+        }
+    }
+
+    for (const match of contents.matchAll(/!?\[[^\]]*\]\(([^)]+)\)/g)) {
+        const target = match[1].trim();
+
+        if (/^(?:https?:|mailto:|#)/.test(target)) {
+            continue;
+        }
+
+        const path = decodeURIComponent(target.split('#')[0].split('?')[0]);
+        if (!existsSync(resolve(dirname(page), path))) {
+            errors.push(`${displayPath}: broken link ${target}`);
+        }
+    }
+}
+
+if (errors.length > 0) {
+    console.error(errors.join('\n'));
+    process.exit(1);
+}
+
+console.log(
+    `Documentation check passed for ${publishedPages.length} published pages.`,
+);


### PR DESCRIPTION
Closes #74

## Stack
- depends on #78 → #77 → #76 → #75
- review this PR against `codex/issue-73-humane-visual-identity`

## Summary
- publish a navigable Diátaxis set for evaluators, adopters, operators, and contributors
- document non-Docker local setup separately from optional Docker, plus domain/tenancy/billing, privacy/demo confinement, deployment, backups, upgrades, configuration, and decision records
- add CI-enforced required-page, internal-link, and 183-day freshness checks; point the public site at the docs landing page

## Verification
- `composer ci:check` (364 tests, 2,405 assertions)
- `npm test`
- `npm run build:ssr`
- `npm run docs:check` (10 published pages)
- independent docs audit: 75/100, all four Diátaxis categories, 0 broken links, 0 stale pages, 0 category gaps/miscategorisations, 0 copy-paste findings