### PR TITLE
Model Program terminology and stages explicitly

### DIFF
--- a/app/Actions/Demo/BuildOrganisationScenario.php
+++ b/app/Actions/Demo/BuildOrganisationScenario.php
@@ -136,13 +136,31 @@ final class BuildOrganisationScenario
                 'organisation_id' => $organisation->id,
                 'slug' => $definition['slug'],
             ]);
+            $configuration = $definition['configuration'];
+            /** @var array{request: string, case: string} $labels */
+            $labels = $configuration['labels'];
+            /** @var list<array{key: string, label: string}> $stages */
+            $stages = $configuration['stages'];
+            unset($configuration['labels'], $configuration['stages']);
             $program->forceFill([
                 'organisation_id' => $organisation->id,
                 'name' => $definition['name'],
                 'slug' => $definition['slug'],
-                'configuration' => $definition['configuration'],
+                'request_label' => $labels['request'],
+                'case_label' => $labels['case'],
+                'configuration' => $configuration,
                 'deleted_at' => null,
             ])->save();
+
+            $activeStageKeys = collect($stages)->pluck('key');
+            $program->stages()->whereNotIn('key', $activeStageKeys)->update(['retired_at' => now()]);
+
+            foreach ($stages as $position => $stage) {
+                $program->stages()->updateOrCreate(
+                    ['key' => $stage['key']],
+                    ['label' => $stage['label'], 'position' => $position, 'retired_at' => null],
+                );
+            }
 
             return [$program->slug => $program];
         });

--- a/app/Actions/Programs/UpdateProgram.php
+++ b/app/Actions/Programs/UpdateProgram.php
@@ -7,18 +7,49 @@ use App\Enums\TenantAuditEventType;
 use App\Models\Program;
 use App\Models\User;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class UpdateProgram
 {
     public function __construct(private RecordTenantAuditEvent $recordTenantAuditEvent) {}
 
-    /** @param array{name: string, slug: string, configuration?: array<string, mixed>} $attributes */
+    /**
+     * @param array{
+     *     name: string,
+     *     slug: string,
+     *     request_label?: string,
+     *     case_label?: string,
+     *     stages?: list<array{id: int|null, label: string, retired: bool}>,
+     *     configuration?: array<string, mixed>
+     * } $attributes
+     */
     public function handle(Program $program, array $attributes, User $actor): Program
     {
         return DB::transaction(function () use ($program, $attributes, $actor): Program {
+            $program = Program::query()->whereKey($program->getKey())->lockForUpdate()->firstOrFail();
+            $stages = $attributes['stages'] ?? null;
+            unset($attributes['stages']);
             $program->fill($attributes);
             $changedFields = array_keys($program->getDirty());
             $program->save();
+
+            foreach ($stages ?? [] as $position => $stageAttributes) {
+                $stage = $stageAttributes['id'] === null
+                    ? $program->stages()->make(['key' => $this->uniqueStageKey($program, $stageAttributes['label'])])
+                    : $program->stages()->whereKey($stageAttributes['id'])->firstOrFail();
+                $stage->fill([
+                    'label' => $stageAttributes['label'],
+                    'position' => $position,
+                    'retired_at' => $stageAttributes['retired'] ? ($stage->retired_at ?? now()) : null,
+                ]);
+
+                if (! $stage->exists || $stage->isDirty()) {
+                    $stage->save();
+                    $changedFields[] = 'stages';
+                }
+            }
+
+            $changedFields = array_values(array_unique($changedFields));
 
             $this->recordTenantAuditEvent->handle(
                 $program->organisation,
@@ -32,7 +63,21 @@ class UpdateProgram
                 $actor,
             );
 
-            return $program;
+            return $program->refresh()->load('stages');
         });
+    }
+
+    private function uniqueStageKey(Program $program, string $label): string
+    {
+        $base = Str::of($label)->ascii()->snake()->limit(56, '')->toString() ?: 'stage';
+        $key = $base;
+        $suffix = 2;
+
+        while ($program->stages()->where('key', $key)->exists()) {
+            $key = Str::limit($base, 56, '').'_'.$suffix;
+            $suffix++;
+        }
+
+        return $key;
     }
 }

--- a/app/Http/Controllers/Organisations/ProgramController.php
+++ b/app/Http/Controllers/Organisations/ProgramController.php
@@ -11,6 +11,7 @@ use App\Http\Requests\Organisations\UpdateProgramRequest;
 use App\Models\Organisation;
 use App\Models\Program;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Storage;
@@ -26,10 +27,10 @@ class ProgramController extends Controller
 
         return Inertia::render('programs/index', [
             'programs' => Program::query()
+                ->with('stages')
                 ->orderBy('name')
-                ->get(['id', 'organisation_id', 'name', 'slug', 'configuration'])
-                ->map(fn (Program $program): array => [
-                    ...$program->only(['id', 'name', 'slug', 'configuration']),
+                ->get(['id', 'organisation_id', 'name', 'slug', 'request_label', 'case_label', 'configuration'])
+                ->map(fn (Program $program): array => $this->serializeProgram($program) + [
                     'canUpdate' => Gate::allows('update', $program),
                 ]),
         ]);
@@ -40,16 +41,20 @@ class ProgramController extends Controller
         $program = $this->findProgram($program);
         Gate::authorize('view', $program);
 
-        return response()->json($program->only(['id', 'organisation_id', 'name', 'slug', 'configuration']));
+        return response()->json($this->serializeProgram($program->load('stages')));
     }
 
-    public function update(UpdateProgramRequest $request, Organisation $organisation, string $program, UpdateProgram $updateProgram): JsonResponse
+    public function update(UpdateProgramRequest $request, Organisation $organisation, string $program, UpdateProgram $updateProgram): JsonResponse|RedirectResponse
     {
         $program = $this->findProgram($program);
         Gate::authorize('update', $program);
         $program = $updateProgram->handle($program, $this->updateAttributes($request), $request->user());
 
-        return response()->json($program->only(['id', 'organisation_id', 'name', 'slug', 'configuration']));
+        if ($request->header('X-Inertia') !== null) {
+            return back();
+        }
+
+        return response()->json($this->serializeProgram($program));
     }
 
     public function search(Request $request, Organisation $organisation, SearchPrograms $searchPrograms): JsonResponse
@@ -81,20 +86,61 @@ class ProgramController extends Controller
             : Program::query()->where('slug', $identifier)->firstOrFail();
     }
 
-    /** @return array{name: string, slug: string, configuration?: array<string, mixed>} */
+    /**
+     * @return array{
+     *     name: string,
+     *     slug: string,
+     *     request_label?: string,
+     *     case_label?: string,
+     *     stages?: list<array{id: int|null, label: string, retired: bool}>,
+     *     configuration?: array<string, mixed>
+     * }
+     */
     private function updateAttributes(UpdateProgramRequest $request): array
     {
         $configuration = $request->validated('configuration');
+        $attributes = [
+            'name' => $request->string('name')->toString(),
+            'slug' => $request->string('slug')->toString(),
+        ];
 
-        return $request->has('configuration') && is_array($configuration)
-            ? [
-                'name' => $request->string('name')->toString(),
-                'slug' => $request->string('slug')->toString(),
-                'configuration' => $configuration,
-            ]
-            : [
-                'name' => $request->string('name')->toString(),
-                'slug' => $request->string('slug')->toString(),
-            ];
+        if ($request->has('request_label')) {
+            $attributes['request_label'] = $request->string('request_label')->toString();
+        }
+
+        if ($request->has('case_label')) {
+            $attributes['case_label'] = $request->string('case_label')->toString();
+        }
+
+        if ($request->has('stages')) {
+            /** @var list<array{id?: int|null, label: string, retired: bool}> $stages */
+            $stages = $request->validated('stages');
+            $attributes['stages'] = array_map(fn (array $stage): array => [
+                'id' => isset($stage['id']) ? (int) $stage['id'] : null,
+                'label' => (string) $stage['label'],
+                'retired' => (bool) $stage['retired'],
+            ], $stages);
+        }
+
+        if ($request->has('configuration') && is_array($configuration)) {
+            /** @var array<string, mixed> $configuration */
+            $attributes['configuration'] = $configuration;
+        }
+
+        return $attributes;
+    }
+
+    /** @return array<string, mixed> */
+    private function serializeProgram(Program $program): array
+    {
+        return [
+            ...$program->only(['id', 'organisation_id', 'name', 'slug', 'request_label', 'case_label', 'configuration']),
+            'stages' => $program->stages->map(fn ($stage): array => [
+                'id' => $stage->id,
+                'key' => $stage->key,
+                'label' => $stage->label,
+                'retired' => $stage->retired_at !== null,
+            ])->values(),
+        ];
     }
 }

--- a/app/Http/Requests/Organisations/UpdateProgramRequest.php
+++ b/app/Http/Requests/Organisations/UpdateProgramRequest.php
@@ -7,6 +7,7 @@ use App\Models\Program;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class UpdateProgramRequest extends FormRequest
 {
@@ -42,14 +43,24 @@ class UpdateProgramRequest extends FormRequest
                     ->where('organisation_id', $organisation instanceof Organisation ? $organisation->id : 0)
                     ->ignore($program?->id),
             ],
-            'configuration' => ['sometimes', 'array:labels,stages,outcome_measures,taxonomies,intake_fields,eligibility_fields,risk_flags'],
-            'configuration.labels' => ['required_with:configuration', 'array:request,case'],
-            'configuration.labels.request' => ['required_with:configuration', 'string', 'max:100'],
-            'configuration.labels.case' => ['required_with:configuration', 'string', 'max:100'],
-            'configuration.stages' => ['required_with:configuration', 'array', 'max:20'],
-            'configuration.stages.*' => ['array:key,label'],
-            'configuration.stages.*.key' => ['required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/', 'distinct'],
-            'configuration.stages.*.label' => ['required', 'string', 'max:100'],
+            'request_label' => ['sometimes', 'required', 'string', 'max:100'],
+            'case_label' => ['sometimes', 'required', 'string', 'max:100'],
+            'stages' => ['sometimes', 'required', 'array', 'min:1', 'max:20'],
+            'stages.*' => ['array:id,key,label,retired'],
+            'stages.*.id' => [
+                'nullable',
+                'integer',
+                'distinct',
+                Rule::exists('program_stages', 'id')->where(
+                    fn ($query) => $query
+                        ->where('organisation_id', $organisation instanceof Organisation ? $organisation->id : 0)
+                        ->where('program_id', $program instanceof Program ? $program->id : 0),
+                ),
+            ],
+            'stages.*.key' => ['nullable', 'string', 'max:64'],
+            'stages.*.label' => ['required', 'string', 'max:100'],
+            'stages.*.retired' => ['required', 'boolean'],
+            'configuration' => ['sometimes', 'array:outcome_measures,taxonomies,intake_fields,eligibility_fields,risk_flags'],
             'configuration.outcome_measures' => ['required_with:configuration', 'array', 'max:20'],
             'configuration.outcome_measures.*' => ['array:key,label,unit'],
             'configuration.outcome_measures.*.key' => ['required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/', 'distinct'],
@@ -76,5 +87,39 @@ class UpdateProgramRequest extends FormRequest
             'configuration.risk_flags.*.key' => ['required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/', 'distinct'],
             'configuration.risk_flags.*.label' => ['required', 'string', 'max:100'],
         ];
+    }
+
+    /** @return array<int, callable(Validator): void> */
+    public function after(): array
+    {
+        return [function (Validator $validator): void {
+            if (! $this->has('stages') || $validator->errors()->hasAny(['stages', 'stages.*'])) {
+                return;
+            }
+
+            $stageInput = $this->input('stages', []);
+            /** @var list<array{id?: mixed, retired?: mixed}> $stages */
+            $stages = is_array($stageInput) ? $stageInput : [];
+
+            if (collect($stages)->every(fn (array $stage): bool => (bool) ($stage['retired'] ?? false))) {
+                $validator->errors()->add('stages', 'A Program must have at least one active stage.');
+            }
+
+            $identifier = (string) $this->route('program');
+            $program = ctype_digit($identifier)
+                ? Program::query()->find((int) $identifier)
+                : Program::query()->where('slug', $identifier)->first();
+            $submittedIds = collect($stages)
+                ->pluck('id')
+                ->filter()
+                ->map(fn (mixed $id): int => (int) $id)
+                ->sort()
+                ->values();
+            $existingIds = $program instanceof Program ? $program->stages()->pluck('id')->sort()->values() : null;
+
+            if ($existingIds !== null && $submittedIds->all() !== $existingIds->all()) {
+                $validator->errors()->add('stages', 'Keep every existing stage in the pathway and retire stages that are no longer used.');
+            }
+        }];
     }
 }

--- a/app/Models/Program.php
+++ b/app/Models/Program.php
@@ -6,10 +6,12 @@ use App\Concerns\BelongsToOrganisation;
 use App\OrganisationContext;
 use Database\Factories\ProgramFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Laravel\Scout\Searchable;
 
@@ -18,10 +20,13 @@ use Laravel\Scout\Searchable;
  * @property int $organisation_id
  * @property string $name
  * @property string $slug
+ * @property string $request_label
+ * @property string $case_label
  * @property array<string, mixed> $configuration
  * @property-read Organisation $organisation
+ * @property-read Collection<int, ProgramStage> $stages
  */
-#[Fillable(['organisation_id', 'name', 'slug', 'configuration'])]
+#[Fillable(['organisation_id', 'name', 'slug', 'request_label', 'case_label', 'configuration'])]
 class Program extends Model
 {
     /** @use HasFactory<ProgramFactory> */
@@ -54,6 +59,12 @@ class Program extends Model
         return $this->belongsToMany(Party::class, 'party_program')
             ->withPivotValue('organisation_id', app(OrganisationContext::class)->id())
             ->withTimestamps();
+    }
+
+    /** @return HasMany<ProgramStage, $this> */
+    public function stages(): HasMany
+    {
+        return $this->hasMany(ProgramStage::class)->orderBy('position')->orderBy('id');
     }
 
     /** @return array<string, int|string> */

--- a/app/Models/ProgramStage.php
+++ b/app/Models/ProgramStage.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use Database\Factories\ProgramStageFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property int $id
+ * @property int $organisation_id
+ * @property int $program_id
+ * @property string $key
+ * @property string $label
+ * @property int $position
+ * @property Carbon|null $retired_at
+ * @property-read Program $program
+ */
+#[Fillable(['organisation_id', 'program_id', 'key', 'label', 'position', 'retired_at'])]
+class ProgramStage extends Model
+{
+    /** @use HasFactory<ProgramStageFactory> */
+    use BelongsToOrganisation, HasFactory;
+
+    protected static function booted(): void
+    {
+        static::updating(function (ProgramStage $stage): void {
+            if ($stage->isDirty(['program_id', 'key'])) {
+                throw new LogicException('A Program Stage stable identity is immutable.');
+            }
+        });
+    }
+
+    /** @return BelongsTo<Program, $this> */
+    public function program(): BelongsTo
+    {
+        return $this->belongsTo(Program::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['retired_at' => 'immutable_datetime'];
+    }
+}

--- a/database/factories/ProgramStageFactory.php
+++ b/database/factories/ProgramStageFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Program;
+use App\Models\ProgramStage;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<ProgramStage>
+ */
+class ProgramStageFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $label = fake()->unique()->sentence(2);
+
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'program_id' => Program::factory()->for(app(OrganisationContext::class)->organisation()),
+            'key' => Str::snake($label),
+            'label' => Str::title($label),
+            'position' => fake()->numberBetween(0, 10),
+            'retired_at' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_09_01_063154_create_program_stages_and_add_terminology_to_programs.php
+++ b/database/migrations/2026_09_01_063154_create_program_stages_and_add_terminology_to_programs.php
@@ -1,0 +1,103 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('programs', function (Blueprint $table) {
+            $table->string('request_label', 100)->default('Request')->after('slug');
+            $table->string('case_label', 100)->default('Case')->after('request_label');
+        });
+
+        Schema::create('program_stages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('program_id');
+            $table->string('key', 64);
+            $table->string('label', 100);
+            $table->unsignedSmallInteger('position');
+            $table->timestamp('retired_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign(['organisation_id', 'program_id'])
+                ->references(['organisation_id', 'id'])->on('programs')->cascadeOnDelete();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'program_id', 'key']);
+            $table->index(['organisation_id', 'program_id', 'retired_at', 'position']);
+        });
+
+        DB::table('programs')->orderBy('id')->each(function (object $program): void {
+            $configuration = is_string($program->configuration)
+                ? json_decode($program->configuration, true, flags: JSON_THROW_ON_ERROR)
+                : (array) $program->configuration;
+            $labels = is_array($configuration['labels'] ?? null) ? $configuration['labels'] : [];
+            $stages = is_array($configuration['stages'] ?? null) ? $configuration['stages'] : [];
+
+            DB::table('programs')->where('id', $program->id)->update([
+                'request_label' => $labels['request'] ?? 'Request',
+                'case_label' => $labels['case'] ?? 'Case',
+            ]);
+
+            foreach (array_values($stages) as $position => $stage) {
+                if (! is_array($stage) || ! isset($stage['key'], $stage['label'])) {
+                    continue;
+                }
+
+                DB::table('program_stages')->insert([
+                    'organisation_id' => $program->organisation_id,
+                    'program_id' => $program->id,
+                    'key' => $stage['key'],
+                    'label' => $stage['label'],
+                    'position' => $position,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+
+            unset($configuration['labels'], $configuration['stages']);
+            DB::table('programs')->where('id', $program->id)->update([
+                'configuration' => json_encode($configuration, JSON_THROW_ON_ERROR),
+            ]);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::table('programs')->orderBy('id')->each(function (object $program): void {
+            $configuration = is_string($program->configuration)
+                ? json_decode($program->configuration, true, flags: JSON_THROW_ON_ERROR)
+                : (array) $program->configuration;
+            $configuration['labels'] = [
+                'request' => $program->request_label,
+                'case' => $program->case_label,
+            ];
+            $configuration['stages'] = DB::table('program_stages')
+                ->where('program_id', $program->id)
+                ->orderBy('position')
+                ->get(['key', 'label'])
+                ->map(fn (object $stage): array => ['key' => $stage->key, 'label' => $stage->label])
+                ->all();
+
+            DB::table('programs')->where('id', $program->id)->update([
+                'configuration' => json_encode($configuration, JSON_THROW_ON_ERROR),
+            ]);
+        });
+
+        Schema::dropIfExists('program_stages');
+
+        Schema::table('programs', function (Blueprint $table) {
+            $table->dropColumn(['request_label', 'case_label']);
+        });
+    }
+};

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -130,7 +130,7 @@ export function AppSidebar() {
         ...(page.props.canViewPrograms && page.props.currentOrganisation
             ? [
                   {
-                      title: 'Program configuration',
+                      title: 'Program pathways',
                       href: programsIndex(page.props.currentOrganisation.slug),
                       icon: Settings2,
                   },

--- a/resources/js/pages/programs/index.tsx
+++ b/resources/js/pages/programs/index.tsx
@@ -1,19 +1,37 @@
-import { Head, router, usePage } from '@inertiajs/react';
-import { useState } from 'react';
+import { Head, useForm, usePage } from '@inertiajs/react';
+import {
+    Archive,
+    ArrowDown,
+    ArrowUp,
+    Check,
+    Plus,
+    RotateCcw,
+} from 'lucide-react';
+import type { FormEvent } from 'react';
 import Heading from '@/components/heading';
+import InputError from '@/components/input-error';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import { index } from '@/routes/programs';
 import { update } from '@/routes/organisations/programs';
+
+type ProgramStage = {
+    id: number | null;
+    key: string | null;
+    label: string;
+    retired: boolean;
+};
 
 type Program = {
     id: number;
     name: string;
     slug: string;
-    configuration: Record<string, unknown>;
+    request_label: string;
+    case_label: string;
+    stages: ProgramStage[];
     canUpdate: boolean;
 };
 
@@ -24,69 +42,311 @@ function ProgramEditor({
     program: Program;
     organisation: string;
 }) {
-    const [name, setName] = useState(program.name);
-    const [slug, setSlug] = useState(program.slug);
-    const [configuration, setConfiguration] = useState(
-        JSON.stringify(program.configuration ?? {}, null, 2),
-    );
-    const [error, setError] = useState('');
-    const save = () => {
-        try {
-            const parsed = JSON.parse(configuration);
-            setError('');
-            router.patch(update.url([organisation, program.slug]), {
-                name,
-                slug,
-                configuration: parsed,
-            });
-        } catch {
-            setError('Configuration must be valid JSON.');
-        }
+    const form = useForm({
+        name: program.name,
+        slug: program.slug,
+        request_label: program.request_label,
+        case_label: program.case_label,
+        stages: program.stages,
+    });
+    const errors = form.errors as Record<string, string>;
+
+    const updateStage = (
+        stageIndex: number,
+        attributes: Partial<ProgramStage>,
+    ) => {
+        form.setData(
+            'stages',
+            form.data.stages.map((stage, index) =>
+                index === stageIndex ? { ...stage, ...attributes } : stage,
+            ),
+        );
     };
+
+    const moveStage = (stageIndex: number, direction: -1 | 1) => {
+        const targetIndex = stageIndex + direction;
+
+        if (targetIndex < 0 || targetIndex >= form.data.stages.length) return;
+
+        const stages = [...form.data.stages];
+        [stages[stageIndex], stages[targetIndex]] = [
+            stages[targetIndex],
+            stages[stageIndex],
+        ];
+        form.setData('stages', stages);
+    };
+
+    const addStage = () => {
+        form.setData('stages', [
+            ...form.data.stages,
+            { id: null, key: null, label: '', retired: false },
+        ]);
+    };
+
+    const save = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        form.patch(update.url([organisation, program.slug]), {
+            preserveScroll: true,
+        });
+    };
+
+    const activeStageCount = form.data.stages.filter(
+        (stage) => !stage.retired,
+    ).length;
+
     return (
         <Card>
-            <CardHeader>
+            <CardHeader className="gap-1">
                 <CardTitle>{program.name}</CardTitle>
+                <p className="text-muted-foreground text-sm">
+                    Shape the language and pathway staff use when supporting
+                    people through this Program.
+                </p>
             </CardHeader>
-            <CardContent className="space-y-4">
-                <div>
-                    <Label>Name</Label>
-                    <Input
-                        value={name}
-                        onChange={(event) => setName(event.target.value)}
-                        disabled={!program.canUpdate}
-                    />
-                </div>
-                <div>
-                    <Label>Slug</Label>
-                    <Input
-                        value={slug}
-                        onChange={(event) => setSlug(event.target.value)}
-                        disabled={!program.canUpdate}
-                    />
-                </div>
-                <div>
-                    <Label>
-                        Labels, stages, outcome measures and taxonomies
-                    </Label>
-                    <Textarea
-                        className="min-h-72 font-mono text-xs"
-                        value={configuration}
-                        onChange={(event) =>
-                            setConfiguration(event.target.value)
-                        }
-                        disabled={!program.canUpdate}
-                    />
-                    <p className="text-muted-foreground mt-1 text-xs">
-                        Structured JSON is validated before it is saved.
-                    </p>
-                    {error ? (
-                        <p className="text-destructive text-sm">{error}</p>
+            <CardContent>
+                <form className="space-y-8" onSubmit={save}>
+                    <section className="grid gap-4 md:grid-cols-2">
+                        <div className="grid gap-2">
+                            <Label htmlFor={`program-${program.id}-name`}>
+                                Program name
+                            </Label>
+                            <Input
+                                id={`program-${program.id}-name`}
+                                value={form.data.name}
+                                onChange={(event) =>
+                                    form.setData('name', event.target.value)
+                                }
+                                disabled={!program.canUpdate}
+                            />
+                            <InputError message={errors.name} />
+                        </div>
+                        <div className="grid gap-2">
+                            <Label htmlFor={`program-${program.id}-slug`}>
+                                Web address
+                            </Label>
+                            <Input
+                                id={`program-${program.id}-slug`}
+                                value={form.data.slug}
+                                onChange={(event) =>
+                                    form.setData('slug', event.target.value)
+                                }
+                                disabled={!program.canUpdate}
+                            />
+                            <InputError message={errors.slug} />
+                        </div>
+                    </section>
+
+                    <section className="space-y-4">
+                        <div>
+                            <h3 className="font-semibold">Language</h3>
+                            <p className="text-muted-foreground text-sm">
+                                Choose the words people in this Program already
+                                use. These labels appear throughout staff
+                                workflows.
+                            </p>
+                        </div>
+                        <div className="grid gap-4 md:grid-cols-2">
+                            <div className="grid gap-2">
+                                <Label
+                                    htmlFor={`program-${program.id}-request-label`}
+                                >
+                                    A new request is called
+                                </Label>
+                                <Input
+                                    id={`program-${program.id}-request-label`}
+                                    value={form.data.request_label}
+                                    onChange={(event) =>
+                                        form.setData(
+                                            'request_label',
+                                            event.target.value,
+                                        )
+                                    }
+                                    placeholder="Support request"
+                                    disabled={!program.canUpdate}
+                                />
+                                <InputError message={errors.request_label} />
+                            </div>
+                            <div className="grid gap-2">
+                                <Label
+                                    htmlFor={`program-${program.id}-case-label`}
+                                >
+                                    Ongoing work is called
+                                </Label>
+                                <Input
+                                    id={`program-${program.id}-case-label`}
+                                    value={form.data.case_label}
+                                    onChange={(event) =>
+                                        form.setData(
+                                            'case_label',
+                                            event.target.value,
+                                        )
+                                    }
+                                    placeholder="Support journey"
+                                    disabled={!program.canUpdate}
+                                />
+                                <InputError message={errors.case_label} />
+                            </div>
+                        </div>
+                    </section>
+
+                    <section className="space-y-4">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div>
+                                <div className="flex items-center gap-2">
+                                    <h3 className="font-semibold">
+                                        Service pathway
+                                    </h3>
+                                    <Badge variant="secondary">
+                                        {activeStageCount} active
+                                    </Badge>
+                                </div>
+                                <p className="text-muted-foreground text-sm">
+                                    Arrange stages in the order staff expect
+                                    work to progress. Retired stages remain in
+                                    history.
+                                </p>
+                            </div>
+                            {program.canUpdate ? (
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={addStage}
+                                >
+                                    <Plus /> Add stage
+                                </Button>
+                            ) : null}
+                        </div>
+
+                        <div className="space-y-2">
+                            {form.data.stages.map((stage, stageIndex) => (
+                                <div
+                                    key={stage.id ?? `new-${stageIndex}`}
+                                    className={`grid gap-3 rounded-xl border p-3 md:grid-cols-[2.25rem_1fr_auto] md:items-center ${
+                                        stage.retired
+                                            ? 'bg-muted/35 border-border/50'
+                                            : 'bg-card'
+                                    }`}
+                                >
+                                    <div
+                                        className="bg-primary/10 text-primary flex size-9 items-center justify-center rounded-full text-sm font-semibold"
+                                        aria-hidden="true"
+                                    >
+                                        {stageIndex + 1}
+                                    </div>
+                                    <div className="grid gap-1">
+                                        <Input
+                                            aria-label={`Stage ${stageIndex + 1} label`}
+                                            value={stage.label}
+                                            onChange={(event) =>
+                                                updateStage(stageIndex, {
+                                                    label: event.target.value,
+                                                })
+                                            }
+                                            placeholder="Stage name"
+                                            disabled={
+                                                !program.canUpdate ||
+                                                stage.retired
+                                            }
+                                        />
+                                        <div className="flex flex-wrap items-center gap-2">
+                                            {stage.key ? (
+                                                <span className="text-muted-foreground font-mono text-xs">
+                                                    {stage.key}
+                                                </span>
+                                            ) : (
+                                                <span className="text-muted-foreground text-xs">
+                                                    A stable reference will be
+                                                    created when saved.
+                                                </span>
+                                            )}
+                                            {stage.retired ? (
+                                                <Badge variant="outline">
+                                                    Retired
+                                                </Badge>
+                                            ) : null}
+                                        </div>
+                                        <InputError
+                                            message={
+                                                errors[
+                                                    `stages.${stageIndex}.label`
+                                                ]
+                                            }
+                                        />
+                                    </div>
+                                    {program.canUpdate ? (
+                                        <div className="flex items-center gap-1">
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="icon"
+                                                aria-label={`Move ${stage.label || 'stage'} up`}
+                                                disabled={stageIndex === 0}
+                                                onClick={() =>
+                                                    moveStage(stageIndex, -1)
+                                                }
+                                            >
+                                                <ArrowUp />
+                                            </Button>
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="icon"
+                                                aria-label={`Move ${stage.label || 'stage'} down`}
+                                                disabled={
+                                                    stageIndex ===
+                                                    form.data.stages.length - 1
+                                                }
+                                                onClick={() =>
+                                                    moveStage(stageIndex, 1)
+                                                }
+                                            >
+                                                <ArrowDown />
+                                            </Button>
+                                            <Button
+                                                type="button"
+                                                variant="ghost"
+                                                size="icon"
+                                                aria-label={
+                                                    stage.retired
+                                                        ? `Restore ${stage.label}`
+                                                        : `Retire ${stage.label || 'stage'}`
+                                                }
+                                                onClick={() =>
+                                                    updateStage(stageIndex, {
+                                                        retired: !stage.retired,
+                                                    })
+                                                }
+                                            >
+                                                {stage.retired ? (
+                                                    <RotateCcw />
+                                                ) : (
+                                                    <Archive />
+                                                )}
+                                            </Button>
+                                        </div>
+                                    ) : null}
+                                </div>
+                            ))}
+                        </div>
+                        <InputError message={errors.stages} />
+                    </section>
+
+                    {program.canUpdate ? (
+                        <div className="flex items-center gap-3">
+                            <Button disabled={form.processing}>
+                                {form.processing
+                                    ? 'Saving pathway…'
+                                    : 'Save Program'}
+                            </Button>
+                            {form.recentlySuccessful ? (
+                                <span className="text-muted-foreground flex items-center gap-1 text-sm">
+                                    <Check className="size-4" /> Saved
+                                </span>
+                            ) : null}
+                        </div>
                     ) : null}
-                </div>
-                {program.canUpdate ? (
-                    <Button onClick={save}>Save configuration</Button>
-                ) : null}
+                </form>
             </CardContent>
         </Card>
     );
@@ -94,15 +354,16 @@ function ProgramEditor({
 
 export default function ProgramsIndex({ programs }: { programs: Program[] }) {
     const organisation = usePage().props.currentOrganisation!;
+
     return (
         <>
-            <Head title="Program configuration" />
+            <Head title="Program pathways" />
             <div className="space-y-6 p-4">
                 <Heading
-                    title="Program configuration"
-                    description="Change operational language, stages, measures, and taxonomies without a deployment."
+                    title="Program pathways"
+                    description="Use familiar language and a clear service pathway so staff can recognise how work progresses."
                 />
-                <div className="grid gap-6 xl:grid-cols-2">
+                <div className="grid gap-6">
                     {programs.map((program) => (
                         <ProgramEditor
                             key={program.id}
@@ -115,10 +376,11 @@ export default function ProgramsIndex({ programs }: { programs: Program[] }) {
         </>
     );
 }
+
 ProgramsIndex.layout = (props: { currentOrganisation: { slug: string } }) => ({
     breadcrumbs: [
         {
-            title: 'Program configuration',
+            title: 'Program pathways',
             href: index(props.currentOrganisation.slug),
         },
     ],

--- a/tests/Feature/ProgramConfigurationTest.php
+++ b/tests/Feature/ProgramConfigurationTest.php
@@ -3,59 +3,191 @@
 use App\Enums\OrganisationRole;
 use App\Models\Organisation;
 use App\Models\Program;
+use App\Models\ProgramStage;
 use App\Models\User;
 use App\OrganisationContext;
 use Inertia\Testing\AssertableInertia as Assert;
 
-it('lets an administrator change validated Program terminology and measurement configuration without code', function () {
+/** @return array{administrator: User, organisation: Organisation, program: Program, received: ProgramStage, active: ProgramStage} */
+function createProgramConfigurationFixture(): array
+{
     $administrator = User::factory()->create();
     $organisation = Organisation::factory()->active()->create();
-    $organisation->memberships()->create(['user_id' => $administrator->id, 'role' => OrganisationRole::OrganisationAdministrator]);
-    $program = app(OrganisationContext::class)->run($organisation, fn (): Program => Program::factory()->for($organisation)->create());
-    $configuration = [
-        'labels' => ['request' => 'Support request', 'case' => 'Support journey'],
-        'stages' => [['key' => 'received', 'label' => 'Received'], ['key' => 'active', 'label' => 'Active']],
-        'outcome_measures' => [['key' => 'housing_stability', 'label' => 'Housing stability', 'unit' => 'score']],
-        'taxonomies' => [['key' => 'need', 'label' => 'Presenting need', 'values' => ['Housing', 'Food']]],
-    ];
+    $organisation->memberships()->create([
+        'user_id' => $administrator->id,
+        'role' => OrganisationRole::OrganisationAdministrator,
+    ]);
+
+    return app(OrganisationContext::class)->run($organisation, function () use ($administrator, $organisation): array {
+        $program = Program::factory()->for($organisation)->create([
+            'request_label' => 'Request',
+            'case_label' => 'Case',
+            'configuration' => [
+                'outcome_measures' => [['key' => 'progress', 'label' => 'Progress', 'unit' => 'score']],
+                'taxonomies' => [],
+            ],
+        ]);
+        $received = $program->stages()->create(['key' => 'received', 'label' => 'Received', 'position' => 0]);
+        $active = $program->stages()->create(['key' => 'active', 'label' => 'Active', 'position' => 1]);
+
+        return compact('administrator', 'organisation', 'program', 'received', 'active');
+    });
+}
+
+it('lets an administrator manage Program terminology and an ordered service pathway without JSON', function () {
+    extract(createProgramConfigurationFixture());
 
     $this->actingAs($administrator)
         ->patchJson(route('organisations.programs.update', [$organisation, $program]), [
             'name' => $program->name,
             'slug' => $program->slug,
-            'configuration' => $configuration,
+            'request_label' => 'Support request',
+            'case_label' => 'Support journey',
+            'stages' => [
+                ['id' => $active->id, 'key' => $active->key, 'label' => 'Working together', 'retired' => false],
+                ['id' => $received->id, 'key' => $received->key, 'label' => 'Received', 'retired' => true],
+                ['id' => null, 'key' => null, 'label' => 'Review progress', 'retired' => false],
+            ],
         ])
         ->assertOk()
-        ->assertJsonPath('configuration.labels.case', 'Support journey');
+        ->assertJsonPath('request_label', 'Support request')
+        ->assertJsonPath('case_label', 'Support journey')
+        ->assertJsonPath('stages.0.key', 'active')
+        ->assertJsonPath('stages.0.label', 'Working together')
+        ->assertJsonPath('stages.1.retired', true)
+        ->assertJsonPath('stages.2.key', 'review_progress');
 
-    app(OrganisationContext::class)->run($organisation, fn () => expect($program->refresh()->configuration)->toBe($configuration));
+    app(OrganisationContext::class)->run($organisation, function () use ($program, $received): void {
+        $program->refresh();
+
+        expect($program->request_label)->toBe('Support request')
+            ->and($program->case_label)->toBe('Support journey')
+            ->and($program->configuration)->toBe([
+                'outcome_measures' => [['key' => 'progress', 'label' => 'Progress', 'unit' => 'score']],
+                'taxonomies' => [],
+            ])
+            ->and($program->stages()->pluck('key')->all())->toBe(['active', 'received', 'review_progress'])
+            ->and($received->refresh()->retired_at)->not->toBeNull();
+    });
 
     $this->actingAs($administrator)
         ->get(route('programs.index', $organisation))
         ->assertOk()
         ->assertInertia(fn (Assert $page) => $page
             ->component('programs/index')
-            ->where('programs.0.configuration.labels.case', 'Support journey')
+            ->where('programs.0.request_label', 'Support request')
+            ->where('programs.0.case_label', 'Support journey')
+            ->where('programs.0.stages.0.key', 'active')
             ->where('programs.0.canUpdate', true));
 });
 
-it('rejects malformed Program configuration', function () {
-    $administrator = User::factory()->create();
-    $organisation = Organisation::factory()->active()->create();
-    $organisation->memberships()->create(['user_id' => $administrator->id, 'role' => OrganisationRole::OrganisationAdministrator]);
-    $program = app(OrganisationContext::class)->run($organisation, fn (): Program => Program::factory()->for($organisation)->create());
+it('requires at least one active Program stage', function () {
+    extract(createProgramConfigurationFixture());
 
     $this->actingAs($administrator)
         ->patchJson(route('organisations.programs.update', [$organisation, $program]), [
             'name' => $program->name,
             'slug' => $program->slug,
-            'configuration' => [
-                'labels' => ['request' => 'Request', 'case' => 'Case'],
-                'stages' => [['key' => 'Not valid', 'label' => 'Invalid']],
-                'outcome_measures' => [],
-                'taxonomies' => [],
+            'request_label' => 'Request',
+            'case_label' => 'Case',
+            'stages' => [
+                ['id' => $received->id, 'key' => $received->key, 'label' => 'Received', 'retired' => true],
+                ['id' => $active->id, 'key' => $active->key, 'label' => 'Active', 'retired' => true],
             ],
         ])
         ->assertUnprocessable()
-        ->assertJsonValidationErrors('configuration.stages.0.key');
+        ->assertJsonValidationErrors('stages');
+});
+
+it('requires existing stages to be retired rather than silently omitted', function () {
+    extract(createProgramConfigurationFixture());
+
+    $this->actingAs($administrator)
+        ->patchJson(route('organisations.programs.update', [$organisation, $program]), [
+            'name' => $program->name,
+            'slug' => $program->slug,
+            'request_label' => 'Request',
+            'case_label' => 'Case',
+            'stages' => [
+                ['id' => $active->id, 'key' => $active->key, 'label' => 'Active', 'retired' => false],
+            ],
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('stages');
+});
+
+it('keeps a Program stage stable identity immutable while allowing retirement', function () {
+    extract(createProgramConfigurationFixture());
+
+    app(OrganisationContext::class)->run($organisation, function () use ($received): void {
+        $received->update(['retired_at' => now()]);
+
+        expect($received->refresh()->retired_at)->not->toBeNull()
+            ->and(fn () => $received->update(['key' => 'renamed']))
+            ->toThrow(LogicException::class, 'stable identity');
+    });
+});
+
+it('returns an Inertia form submission to the Program pathway editor', function () {
+    extract(createProgramConfigurationFixture());
+    $editorUrl = route('programs.index', $organisation);
+
+    $this->actingAs($administrator)
+        ->from($editorUrl)
+        ->withHeader('X-Inertia', 'true')
+        ->patch(route('organisations.programs.update', [$organisation, $program]), [
+            'name' => $program->name,
+            'slug' => $program->slug,
+            'request_label' => 'Support request',
+            'case_label' => 'Support journey',
+            'stages' => [
+                ['id' => $received->id, 'key' => $received->key, 'label' => 'Received', 'retired' => false],
+                ['id' => $active->id, 'key' => $active->key, 'label' => 'Active', 'retired' => false],
+            ],
+        ])
+        ->assertRedirect($editorUrl);
+});
+
+it('rejects a stage owned by another Organisation', function () {
+    extract(createProgramConfigurationFixture());
+    $otherOrganisation = Organisation::factory()->active()->create();
+    $otherStage = app(OrganisationContext::class)->run($otherOrganisation, function () use ($otherOrganisation): ProgramStage {
+        $otherProgram = Program::factory()->for($otherOrganisation)->create();
+
+        return $otherProgram->stages()->create(['key' => 'secret', 'label' => 'Secret', 'position' => 0]);
+    });
+
+    $this->actingAs($administrator)
+        ->patchJson(route('organisations.programs.update', [$organisation, $program]), [
+            'name' => $program->name,
+            'slug' => $program->slug,
+            'request_label' => 'Request',
+            'case_label' => 'Case',
+            'stages' => [
+                ['id' => $otherStage->id, 'key' => $otherStage->key, 'label' => 'Leaked', 'retired' => false],
+            ],
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('stages.0.id');
+});
+
+it('rejects terminology and stages hidden inside Program configuration JSON', function () {
+    extract(createProgramConfigurationFixture());
+
+    $this->actingAs($administrator)
+        ->patchJson(route('organisations.programs.update', [$organisation, $program]), [
+            'name' => $program->name,
+            'slug' => $program->slug,
+            'request_label' => 'Request',
+            'case_label' => 'Case',
+            'stages' => [
+                ['id' => $received->id, 'key' => $received->key, 'label' => 'Received', 'retired' => false],
+            ],
+            'configuration' => [
+                'labels' => ['request' => 'Hidden request', 'case' => 'Hidden case'],
+                'stages' => [['key' => 'hidden', 'label' => 'Hidden']],
+            ],
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors('configuration');
 });


### PR DESCRIPTION
Closes #81

## Summary

- move Program request/case terminology into explicit fields
- backfill ordered, tenant-scoped Program Stage records with stable identities and reversible retirement
- replace the Program JSON editor with a structured, human-centred pathway editor
- keep demo scenarios, auditing, authorization, and Inertia form behaviour compatible

## Verification

- `php artisan test --compact` (369 tests, 2,432 assertions)
- `npm run check`
- `npm run types:check`
- `npm test` (9 tests)
- local migration rollback/reapply and seeded-data backfill inspection
- reviewed against `origin/main` and fixed findings