### PR TITLE
Model Program outcomes and taxonomies explicitly

### DIFF
--- a/app/Actions/CaseDelivery/TransitionServiceCase.php
+++ b/app/Actions/CaseDelivery/TransitionServiceCase.php
@@ -100,12 +100,11 @@ class TransitionServiceCase
             throw new LogicException('Case closure requires a reason and structured outcome.');
         }
 
-        $requiredMeasures = [];
-        foreach ($case->program->configuration['outcome_measures'] ?? [] as $measure) {
-            if (is_array($measure) && is_string($measure['key'] ?? null)) {
-                $requiredMeasures[] = $measure['key'];
-            }
-        }
+        $requiredMeasures = $case->program
+            ->outcomeMeasures()
+            ->whereNull('retired_at')
+            ->pluck('key')
+            ->all();
         $providedMeasures = array_keys($closure['measures']);
         sort($requiredMeasures);
         sort($providedMeasures);

--- a/app/Actions/Demo/BuildOrganisationScenario.php
+++ b/app/Actions/Demo/BuildOrganisationScenario.php
@@ -26,10 +26,9 @@ use LogicException;
 use Ramsey\Uuid\Uuid;
 
 /**
- * @phpstan-type ProgramDefinition array{name: string, slug: string, configuration: array<string, mixed>}
- * @phpstan-type MemberDefinition array{party_uuid: string, name: string, email: string, telephone: string, owner: bool, role: OrganisationRole|null, program_slugs: list<string>}
- * @phpstan-type PartyDefinition array{uuid: string, kind: PartyKind, name: string, email?: string, telephone?: string, program_slugs?: list<string>, roles?: list<PartyBusinessRole>, interests?: list<string>}
- * @phpstan-type ScenarioDefinition array{uuid: string, name: string, slug: string, timezone: string, currency: string, reporting_at: string, synthetic: true, template_slug?: string, sandbox_pair_id?: string, demo_generation?: int, party_population: array<string, int>, programs: list<ProgramDefinition>, members: list<MemberDefinition>, parties: list<PartyDefinition>}
+ * @phpstan-import-type ProgramDefinition from ScenarioCatalog
+ * @phpstan-import-type PartyDefinition from ScenarioCatalog
+ * @phpstan-import-type ScenarioDefinition from ScenarioCatalog
  */
 final class BuildOrganisationScenario
 {
@@ -137,11 +136,11 @@ final class BuildOrganisationScenario
                 'slug' => $definition['slug'],
             ]);
             $configuration = $definition['configuration'];
-            /** @var array{request: string, case: string} $labels */
             $labels = $configuration['labels'];
-            /** @var list<array{key: string, label: string}> $stages */
             $stages = $configuration['stages'];
-            unset($configuration['labels'], $configuration['stages']);
+            $outcomeMeasures = $configuration['outcome_measures'];
+            $taxonomies = $configuration['taxonomies'];
+            unset($configuration['labels'], $configuration['stages'], $configuration['outcome_measures'], $configuration['taxonomies']);
             $program->forceFill([
                 'organisation_id' => $organisation->id,
                 'name' => $definition['name'],
@@ -160,6 +159,38 @@ final class BuildOrganisationScenario
                     ['key' => $stage['key']],
                     ['label' => $stage['label'], 'position' => $position, 'retired_at' => null],
                 );
+            }
+
+            $activeMeasureKeys = collect($outcomeMeasures)->pluck('key');
+            $program->outcomeMeasures()->whereNotIn('key', $activeMeasureKeys)->update(['retired_at' => now()]);
+
+            foreach ($outcomeMeasures as $position => $measure) {
+                $program->outcomeMeasures()->updateOrCreate(
+                    ['key' => $measure['key']],
+                    ['label' => $measure['label'], 'unit' => $measure['unit'] ?? null, 'position' => $position, 'retired_at' => null],
+                );
+            }
+
+            $activeTaxonomyKeys = collect($taxonomies)->pluck('key');
+            $program->taxonomies()->whereNotIn('key', $activeTaxonomyKeys)->update(['retired_at' => now()]);
+
+            foreach ($taxonomies as $position => $taxonomyDefinition) {
+                $taxonomy = $program->taxonomies()->updateOrCreate(
+                    ['key' => $taxonomyDefinition['key']],
+                    ['label' => $taxonomyDefinition['label'], 'position' => $position, 'retired_at' => null],
+                );
+                $valueDefinitions = collect($taxonomyDefinition['values'])->map(fn (string $label): array => [
+                    'key' => Str::of($label)->ascii()->snake()->limit(56, '')->toString() ?: 'value',
+                    'label' => $label,
+                ]);
+                $taxonomy->values()->whereNotIn('key', $valueDefinitions->pluck('key'))->update(['retired_at' => now()]);
+
+                foreach ($valueDefinitions as $valuePosition => $valueDefinition) {
+                    $taxonomy->values()->updateOrCreate(
+                        ['key' => $valueDefinition['key']],
+                        ['label' => $valueDefinition['label'], 'position' => $valuePosition, 'retired_at' => null],
+                    );
+                }
             }
 
             return [$program->slug => $program];

--- a/app/Actions/Demo/BuildSandboxScenario.php
+++ b/app/Actions/Demo/BuildSandboxScenario.php
@@ -2,9 +2,10 @@
 
 namespace App\Actions\Demo;
 
+use App\Data\Demo\ScenarioCatalog;
 use Ramsey\Uuid\Uuid;
 
-/** @phpstan-import-type ScenarioDefinition from BuildOrganisationScenario */
+/** @phpstan-import-type ScenarioDefinition from ScenarioCatalog */
 final class BuildSandboxScenario
 {
     /**

--- a/app/Actions/Demo/ProvisionSandboxPair.php
+++ b/app/Actions/Demo/ProvisionSandboxPair.php
@@ -9,7 +9,7 @@ use App\Models\SandboxPair;
 use Illuminate\Support\Facades\DB;
 use Throwable;
 
-/** @phpstan-import-type ScenarioDefinition from BuildOrganisationScenario */
+/** @phpstan-import-type ScenarioDefinition from ScenarioCatalog */
 final class ProvisionSandboxPair
 {
     public function __construct(

--- a/app/Actions/Demo/ResetSandboxOrganisation.php
+++ b/app/Actions/Demo/ResetSandboxOrganisation.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use LogicException;
 
-/** @phpstan-import-type ScenarioDefinition from BuildOrganisationScenario */
+/** @phpstan-import-type ScenarioDefinition from ScenarioCatalog */
 final class ResetSandboxOrganisation
 {
     public function __construct(

--- a/app/Actions/Programs/UpdateProgram.php
+++ b/app/Actions/Programs/UpdateProgram.php
@@ -6,6 +6,7 @@ use App\Actions\Auditing\RecordTenantAuditEvent;
 use App\Enums\TenantAuditEventType;
 use App\Models\Program;
 use App\Models\User;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -20,6 +21,8 @@ class UpdateProgram
      *     request_label?: string,
      *     case_label?: string,
      *     stages?: list<array{id: int|null, label: string, retired: bool}>,
+     *     outcome_measures?: list<array{id: int|null, label: string, unit: string|null, retired: bool}>,
+     *     taxonomies?: list<array{id: int|null, label: string, retired: bool, values: list<array{id: int|null, label: string, retired: bool}>}>,
      *     configuration?: array<string, mixed>
      * } $attributes
      */
@@ -28,14 +31,16 @@ class UpdateProgram
         return DB::transaction(function () use ($program, $attributes, $actor): Program {
             $program = Program::query()->whereKey($program->getKey())->lockForUpdate()->firstOrFail();
             $stages = $attributes['stages'] ?? null;
-            unset($attributes['stages']);
+            $outcomeMeasures = $attributes['outcome_measures'] ?? null;
+            $taxonomies = $attributes['taxonomies'] ?? null;
+            unset($attributes['stages'], $attributes['outcome_measures'], $attributes['taxonomies']);
             $program->fill($attributes);
             $changedFields = array_keys($program->getDirty());
             $program->save();
 
             foreach ($stages ?? [] as $position => $stageAttributes) {
                 $stage = $stageAttributes['id'] === null
-                    ? $program->stages()->make(['key' => $this->uniqueStageKey($program, $stageAttributes['label'])])
+                    ? $program->stages()->make(['key' => $this->uniqueKey($program->stages(), $stageAttributes['label'], 'stage')])
                     : $program->stages()->whereKey($stageAttributes['id'])->firstOrFail();
                 $stage->fill([
                     'label' => $stageAttributes['label'],
@@ -46,6 +51,55 @@ class UpdateProgram
                 if (! $stage->exists || $stage->isDirty()) {
                     $stage->save();
                     $changedFields[] = 'stages';
+                }
+            }
+
+            foreach ($outcomeMeasures ?? [] as $position => $measureAttributes) {
+                $measure = $measureAttributes['id'] === null
+                    ? $program->outcomeMeasures()->make(['key' => $this->uniqueKey($program->outcomeMeasures(), $measureAttributes['label'], 'measure')])
+                    : $program->outcomeMeasures()->whereKey($measureAttributes['id'])->firstOrFail();
+                $measure->fill([
+                    'label' => $measureAttributes['label'],
+                    'unit' => $measureAttributes['unit'],
+                    'position' => $position,
+                    'retired_at' => $measureAttributes['retired'] ? ($measure->retired_at ?? now()) : null,
+                ]);
+
+                if (! $measure->exists || $measure->isDirty()) {
+                    $measure->save();
+                    $changedFields[] = 'outcome_measures';
+                }
+            }
+
+            foreach ($taxonomies ?? [] as $position => $taxonomyAttributes) {
+                $taxonomy = $taxonomyAttributes['id'] === null
+                    ? $program->taxonomies()->make(['key' => $this->uniqueKey($program->taxonomies(), $taxonomyAttributes['label'], 'taxonomy')])
+                    : $program->taxonomies()->whereKey($taxonomyAttributes['id'])->firstOrFail();
+                $taxonomy->fill([
+                    'label' => $taxonomyAttributes['label'],
+                    'position' => $position,
+                    'retired_at' => $taxonomyAttributes['retired'] ? ($taxonomy->retired_at ?? now()) : null,
+                ]);
+
+                if (! $taxonomy->exists || $taxonomy->isDirty()) {
+                    $taxonomy->save();
+                    $changedFields[] = 'taxonomies';
+                }
+
+                foreach ($taxonomyAttributes['values'] as $valuePosition => $valueAttributes) {
+                    $value = $valueAttributes['id'] === null
+                        ? $taxonomy->values()->make(['key' => $this->uniqueKey($taxonomy->values(), $valueAttributes['label'], 'value')])
+                        : $taxonomy->values()->whereKey($valueAttributes['id'])->firstOrFail();
+                    $value->fill([
+                        'label' => $valueAttributes['label'],
+                        'position' => $valuePosition,
+                        'retired_at' => $valueAttributes['retired'] ? ($value->retired_at ?? now()) : null,
+                    ]);
+
+                    if (! $value->exists || $value->isDirty()) {
+                        $value->save();
+                        $changedFields[] = 'taxonomies';
+                    }
                 }
             }
 
@@ -63,17 +117,23 @@ class UpdateProgram
                 $actor,
             );
 
-            return $program->refresh()->load('stages');
+            return $program->refresh()->load(['stages', 'outcomeMeasures', 'taxonomies.values']);
         });
     }
 
-    private function uniqueStageKey(Program $program, string $label): string
+    /**
+     * @template TRelatedModel of \Illuminate\Database\Eloquent\Model
+     * @template TDeclaringModel of \Illuminate\Database\Eloquent\Model
+     *
+     * @param  HasMany<TRelatedModel, TDeclaringModel>  $relationship
+     */
+    private function uniqueKey(HasMany $relationship, string $label, string $fallback): string
     {
-        $base = Str::of($label)->ascii()->snake()->limit(56, '')->toString() ?: 'stage';
+        $base = Str::of($label)->ascii()->snake()->limit(56, '')->toString() ?: $fallback;
         $key = $base;
         $suffix = 2;
 
-        while ($program->stages()->where('key', $key)->exists()) {
+        while ($relationship->where('key', $key)->exists()) {
             $key = Str::limit($base, 56, '').'_'.$suffix;
             $suffix++;
         }

--- a/app/Data/Demo/ScenarioCatalog.php
+++ b/app/Data/Demo/ScenarioCatalog.php
@@ -7,6 +7,12 @@ use App\Enums\PartyBusinessRole;
 use App\Enums\PartyKind;
 use InvalidArgumentException;
 
+/**
+ * @phpstan-type ProgramDefinition array{name: string, slug: string, configuration: array{labels: array{request: string, case: string}, stages: list<array{key: string, label: string}>, outcome_measures: list<array{key: string, label: string, unit?: string|null}>, taxonomies: list<array{key: string, label: string, values: list<string>}>, intake_fields: list<array<string, mixed>>, eligibility_fields: list<array<string, mixed>>, risk_flags: list<array<string, mixed>>}}
+ * @phpstan-type MemberDefinition array{party_uuid: string, name: string, email: string, telephone: string, owner: bool, role: OrganisationRole|null, program_slugs: list<string>}
+ * @phpstan-type PartyDefinition array{uuid: string, kind: PartyKind, name: string, email?: string, telephone?: string, program_slugs?: list<string>, roles?: list<PartyBusinessRole>, interests?: list<string>}
+ * @phpstan-type ScenarioDefinition array{uuid: string, name: string, slug: string, timezone: string, currency: string, reporting_at: string, synthetic: true, template_slug?: string, sandbox_pair_id?: string, demo_generation?: int, party_population: array<string, int>, programs: list<ProgramDefinition>, members: list<MemberDefinition>, parties: list<PartyDefinition>}
+ */
 final class ScenarioCatalog
 {
     public const VERSION = '2026.4';
@@ -26,15 +32,7 @@ final class ScenarioCatalog
         ];
     }
 
-    /**
-     * @return list<array{
-     *     uuid: string, name: string, slug: string, timezone: string, currency: string, reporting_at: string, synthetic: true,
-     *     party_population: array<string, int>,
-     *     programs: list<array{name: string, slug: string, configuration: array<string, mixed>}>,
-     *     members: list<array{party_uuid: string, name: string, email: string, telephone: string, owner: bool, role: OrganisationRole|null, program_slugs: list<string>}>,
-     *     parties: list<array{uuid: string, kind: PartyKind, name: string, email?: string, telephone?: string, program_slugs?: list<string>, roles?: list<PartyBusinessRole>, interests?: list<string>}>
-     * }>
-     */
+    /** @return list<ScenarioDefinition> */
     public static function organisations(): array
     {
         $organisations = [

--- a/app/Http/Controllers/Organisations/ProgramController.php
+++ b/app/Http/Controllers/Organisations/ProgramController.php
@@ -27,7 +27,7 @@ class ProgramController extends Controller
 
         return Inertia::render('programs/index', [
             'programs' => Program::query()
-                ->with('stages')
+                ->with(['stages', 'outcomeMeasures', 'taxonomies.values'])
                 ->orderBy('name')
                 ->get(['id', 'organisation_id', 'name', 'slug', 'request_label', 'case_label', 'configuration'])
                 ->map(fn (Program $program): array => $this->serializeProgram($program) + [
@@ -41,7 +41,7 @@ class ProgramController extends Controller
         $program = $this->findProgram($program);
         Gate::authorize('view', $program);
 
-        return response()->json($this->serializeProgram($program->load('stages')));
+        return response()->json($this->serializeProgram($program->load(['stages', 'outcomeMeasures', 'taxonomies.values'])));
     }
 
     public function update(UpdateProgramRequest $request, Organisation $organisation, string $program, UpdateProgram $updateProgram): JsonResponse|RedirectResponse
@@ -93,6 +93,8 @@ class ProgramController extends Controller
      *     request_label?: string,
      *     case_label?: string,
      *     stages?: list<array{id: int|null, label: string, retired: bool}>,
+     *     outcome_measures?: list<array{id: int|null, label: string, unit: string|null, retired: bool}>,
+     *     taxonomies?: list<array{id: int|null, label: string, retired: bool, values: list<array{id: int|null, label: string, retired: bool}>}>,
      *     configuration?: array<string, mixed>
      * }
      */
@@ -122,6 +124,32 @@ class ProgramController extends Controller
             ], $stages);
         }
 
+        if ($request->has('outcome_measures')) {
+            /** @var list<array{id?: int|null, label: string, unit?: string|null, retired: bool}> $outcomeMeasures */
+            $outcomeMeasures = $request->validated('outcome_measures');
+            $attributes['outcome_measures'] = array_map(fn (array $measure): array => [
+                'id' => isset($measure['id']) ? (int) $measure['id'] : null,
+                'label' => $measure['label'],
+                'unit' => $measure['unit'] ?? null,
+                'retired' => $measure['retired'],
+            ], $outcomeMeasures);
+        }
+
+        if ($request->has('taxonomies')) {
+            /** @var list<array{id?: int|null, label: string, retired: bool, values: list<array{id?: int|null, label: string, retired: bool}>}> $taxonomies */
+            $taxonomies = $request->validated('taxonomies');
+            $attributes['taxonomies'] = array_map(fn (array $taxonomy): array => [
+                'id' => isset($taxonomy['id']) ? (int) $taxonomy['id'] : null,
+                'label' => $taxonomy['label'],
+                'retired' => $taxonomy['retired'],
+                'values' => array_map(fn (array $value): array => [
+                    'id' => isset($value['id']) ? (int) $value['id'] : null,
+                    'label' => $value['label'],
+                    'retired' => $value['retired'],
+                ], $taxonomy['values']),
+            ], $taxonomies);
+        }
+
         if ($request->has('configuration') && is_array($configuration)) {
             /** @var array<string, mixed> $configuration */
             $attributes['configuration'] = $configuration;
@@ -140,6 +168,25 @@ class ProgramController extends Controller
                 'key' => $stage->key,
                 'label' => $stage->label,
                 'retired' => $stage->retired_at !== null,
+            ])->values(),
+            'outcome_measures' => $program->outcomeMeasures->map(fn ($measure): array => [
+                'id' => $measure->id,
+                'key' => $measure->key,
+                'label' => $measure->label,
+                'unit' => $measure->unit,
+                'retired' => $measure->retired_at !== null,
+            ])->values(),
+            'taxonomies' => $program->taxonomies->map(fn ($taxonomy): array => [
+                'id' => $taxonomy->id,
+                'key' => $taxonomy->key,
+                'label' => $taxonomy->label,
+                'retired' => $taxonomy->retired_at !== null,
+                'values' => $taxonomy->values->map(fn ($value): array => [
+                    'id' => $value->id,
+                    'key' => $value->key,
+                    'label' => $value->label,
+                    'retired' => $value->retired_at !== null,
+                ])->values(),
             ])->values(),
         ];
     }

--- a/app/Http/Controllers/Organisations/ServiceCaseController.php
+++ b/app/Http/Controllers/Organisations/ServiceCaseController.php
@@ -54,7 +54,7 @@ class ServiceCaseController extends Controller
         }
 
         $serviceCase->load([
-            'party:id,uuid,display_name', 'program:id,organisation_id,name,configuration', 'intakeRequest:id',
+            'party:id,uuid,display_name', 'program:id,organisation_id,name', 'program.outcomeMeasures', 'intakeRequest:id',
             'assignments.membership.user:id,name', 'goals', 'services', 'referrals', 'tasks', 'appointments',
             'interactions', 'notes', 'outcome', 'workflowTransitions' => fn ($query) => $query->orderByDesc('recorded_at'),
             'documents.currentVersion', 'documents.versions' => fn ($query) => $query->latest('generation'),
@@ -78,7 +78,14 @@ class ServiceCaseController extends Controller
                 'closureReason' => $serviceCase->closure_reason,
                 'followUpAt' => $serviceCase->follow_up_at?->toAtomString(),
                 'party' => ['uuid' => $serviceCase->party->uuid, 'displayName' => $serviceCase->party->display_name],
-                'program' => ['id' => $serviceCase->program->id, 'name' => $serviceCase->program->name, 'configuration' => $serviceCase->program->configuration],
+                'program' => [
+                    'id' => $serviceCase->program->id,
+                    'name' => $serviceCase->program->name,
+                    'outcomeMeasures' => $serviceCase->program->outcomeMeasures
+                        ->whereNull('retired_at')
+                        ->map(fn ($measure): array => ['key' => $measure->key, 'label' => $measure->label, 'unit' => $measure->unit])
+                        ->values(),
+                ],
                 'intakeId' => $serviceCase->intake_request_id,
                 'assignments' => $serviceCase->assignments->map(fn ($assignment): array => ['id' => $assignment->id, 'worker' => $assignment->membership->user->name, 'status' => $assignment->status->value]),
                 'goals' => $serviceCase->goals->map(fn (CaseGoal $goal): array => [...$this->item($goal->id, $goal->status->value, $goal->version, $goal->encrypted_content), 'targetAt' => $goal->target_at?->toAtomString(), 'effectiveAt' => $goal->effective_at?->toAtomString(), 'reason' => $goal->terminal_reason]),

--- a/app/Http/Requests/Organisations/UpdateProgramRequest.php
+++ b/app/Http/Requests/Organisations/UpdateProgramRequest.php
@@ -60,18 +60,51 @@ class UpdateProgramRequest extends FormRequest
             'stages.*.key' => ['nullable', 'string', 'max:64'],
             'stages.*.label' => ['required', 'string', 'max:100'],
             'stages.*.retired' => ['required', 'boolean'],
-            'configuration' => ['sometimes', 'array:outcome_measures,taxonomies,intake_fields,eligibility_fields,risk_flags'],
-            'configuration.outcome_measures' => ['required_with:configuration', 'array', 'max:20'],
-            'configuration.outcome_measures.*' => ['array:key,label,unit'],
-            'configuration.outcome_measures.*.key' => ['required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/', 'distinct'],
-            'configuration.outcome_measures.*.label' => ['required', 'string', 'max:100'],
-            'configuration.outcome_measures.*.unit' => ['nullable', 'string', 'max:50'],
-            'configuration.taxonomies' => ['required_with:configuration', 'array', 'max:20'],
-            'configuration.taxonomies.*' => ['array:key,label,values'],
-            'configuration.taxonomies.*.key' => ['required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/', 'distinct'],
-            'configuration.taxonomies.*.label' => ['required', 'string', 'max:100'],
-            'configuration.taxonomies.*.values' => ['required', 'array', 'max:50'],
-            'configuration.taxonomies.*.values.*' => ['required', 'string', 'max:100', 'distinct'],
+            'outcome_measures' => ['sometimes', 'array', 'max:20'],
+            'outcome_measures.*' => ['array:id,key,label,unit,retired'],
+            'outcome_measures.*.id' => [
+                'nullable',
+                'integer',
+                'distinct',
+                Rule::exists('program_outcome_measures', 'id')->where(
+                    fn ($query) => $query
+                        ->where('organisation_id', $organisation instanceof Organisation ? $organisation->id : 0)
+                        ->where('program_id', $program instanceof Program ? $program->id : 0),
+                ),
+            ],
+            'outcome_measures.*.key' => ['nullable', 'string', 'max:64'],
+            'outcome_measures.*.label' => ['required', 'string', 'max:100'],
+            'outcome_measures.*.unit' => ['nullable', 'string', 'max:50'],
+            'outcome_measures.*.retired' => ['required', 'boolean'],
+            'taxonomies' => ['sometimes', 'array', 'max:20'],
+            'taxonomies.*' => ['array:id,key,label,retired,values'],
+            'taxonomies.*.id' => [
+                'nullable',
+                'integer',
+                'distinct',
+                Rule::exists('program_taxonomies', 'id')->where(
+                    fn ($query) => $query
+                        ->where('organisation_id', $organisation instanceof Organisation ? $organisation->id : 0)
+                        ->where('program_id', $program instanceof Program ? $program->id : 0),
+                ),
+            ],
+            'taxonomies.*.key' => ['nullable', 'string', 'max:64'],
+            'taxonomies.*.label' => ['required', 'string', 'max:100'],
+            'taxonomies.*.retired' => ['required', 'boolean'],
+            'taxonomies.*.values' => ['required', 'array', 'max:50'],
+            'taxonomies.*.values.*' => ['array:id,key,label,retired'],
+            'taxonomies.*.values.*.id' => [
+                'nullable',
+                'integer',
+                'distinct',
+                Rule::exists('program_taxonomy_values', 'id')->where(
+                    fn ($query) => $query->where('organisation_id', $organisation instanceof Organisation ? $organisation->id : 0),
+                ),
+            ],
+            'taxonomies.*.values.*.key' => ['nullable', 'string', 'max:64'],
+            'taxonomies.*.values.*.label' => ['required', 'string', 'max:100'],
+            'taxonomies.*.values.*.retired' => ['required', 'boolean'],
+            'configuration' => ['sometimes', 'array:intake_fields,eligibility_fields,risk_flags'],
             'configuration.intake_fields' => ['sometimes', 'array', 'max:30'],
             'configuration.intake_fields.*' => ['array:key,label,type,required'],
             'configuration.intake_fields.*.key' => ['required', 'string', 'max:64', 'regex:/^[a-z][a-z0-9_]*$/', 'distinct'],
@@ -93,33 +126,124 @@ class UpdateProgramRequest extends FormRequest
     public function after(): array
     {
         return [function (Validator $validator): void {
-            if (! $this->has('stages') || $validator->errors()->hasAny(['stages', 'stages.*'])) {
-                return;
-            }
-
-            $stageInput = $this->input('stages', []);
-            /** @var list<array{id?: mixed, retired?: mixed}> $stages */
-            $stages = is_array($stageInput) ? $stageInput : [];
-
-            if (collect($stages)->every(fn (array $stage): bool => (bool) ($stage['retired'] ?? false))) {
-                $validator->errors()->add('stages', 'A Program must have at least one active stage.');
-            }
-
             $identifier = (string) $this->route('program');
             $program = ctype_digit($identifier)
                 ? Program::query()->find((int) $identifier)
                 : Program::query()->where('slug', $identifier)->first();
-            $submittedIds = collect($stages)
-                ->pluck('id')
-                ->filter()
-                ->map(fn (mixed $id): int => (int) $id)
-                ->sort()
-                ->values();
-            $existingIds = $program instanceof Program ? $program->stages()->pluck('id')->sort()->values() : null;
 
-            if ($existingIds !== null && $submittedIds->all() !== $existingIds->all()) {
-                $validator->errors()->add('stages', 'Keep every existing stage in the pathway and retire stages that are no longer used.');
+            if (! $program instanceof Program) {
+                return;
+            }
+
+            if ($this->has('stages') && ! $validator->errors()->hasAny(['stages', 'stages.*'])) {
+                $stages = $this->items('stages');
+                $hasActiveStage = false;
+
+                foreach ($stages as $stage) {
+                    if (! (bool) ($stage['retired'] ?? false)) {
+                        $hasActiveStage = true;
+                    }
+                }
+
+                if (! $hasActiveStage) {
+                    $validator->errors()->add('stages', 'A Program must have at least one active stage.');
+                }
+
+                $this->requireExistingRecords($validator, 'stages', $stages, $this->recordIds($program->stages()->pluck('id')->all()));
+            }
+
+            if ($this->has('outcome_measures') && ! $validator->errors()->hasAny(['outcome_measures', 'outcome_measures.*'])) {
+                $this->requireExistingRecords(
+                    $validator,
+                    'outcome_measures',
+                    $this->items('outcome_measures'),
+                    $this->recordIds($program->outcomeMeasures()->pluck('id')->all()),
+                );
+            }
+
+            if ($this->has('taxonomies') && ! $validator->errors()->hasAny(['taxonomies', 'taxonomies.*'])) {
+                $taxonomies = $this->items('taxonomies');
+                $this->requireExistingRecords($validator, 'taxonomies', $taxonomies, $this->recordIds($program->taxonomies()->pluck('id')->all()));
+
+                foreach ($taxonomies as $index => $taxonomy) {
+                    if (empty($taxonomy['id'])) {
+                        continue;
+                    }
+
+                    $existingValueIds = $program->taxonomies()
+                        ->whereKey((int) $taxonomy['id'])
+                        ->firstOrFail()
+                        ->values()
+                        ->pluck('id')
+                        ->all();
+                    $values = $taxonomy['values'] ?? [];
+                    $this->requireExistingRecords(
+                        $validator,
+                        "taxonomies.{$index}.values",
+                        is_array($values) ? $this->arrayItems($values) : [],
+                        $this->recordIds($existingValueIds),
+                    );
+                }
             }
         }];
+    }
+
+    /**
+     * @param  list<array<array-key, mixed>>  $submitted
+     * @param  list<int>  $existingIds
+     */
+    private function requireExistingRecords(Validator $validator, string $field, array $submitted, array $existingIds): void
+    {
+        $submittedIds = [];
+
+        foreach ($submitted as $item) {
+            if (! empty($item['id'])) {
+                $submittedIds[] = (int) $item['id'];
+            }
+        }
+        sort($submittedIds);
+        sort($existingIds);
+
+        if ($submittedIds !== $existingIds) {
+            $validator->errors()->add($field, 'Keep every existing item and retire items that are no longer used.');
+        }
+    }
+
+    /** @return list<array<array-key, mixed>> */
+    private function items(string $field): array
+    {
+        $items = $this->input($field, []);
+
+        if (! is_array($items)) {
+            return [];
+        }
+
+        return $this->arrayItems($items);
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $items
+     * @return list<array<array-key, mixed>>
+     */
+    private function arrayItems(array $items): array
+    {
+        $result = [];
+
+        foreach ($items as $item) {
+            if (is_array($item)) {
+                $result[] = $item;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $ids
+     * @return list<int>
+     */
+    private function recordIds(array $ids): array
+    {
+        return array_values(array_map(fn (mixed $id): int => (int) $id, $ids));
     }
 }

--- a/app/Models/Program.php
+++ b/app/Models/Program.php
@@ -25,6 +25,8 @@ use Laravel\Scout\Searchable;
  * @property array<string, mixed> $configuration
  * @property-read Organisation $organisation
  * @property-read Collection<int, ProgramStage> $stages
+ * @property-read Collection<int, ProgramOutcomeMeasure> $outcomeMeasures
+ * @property-read Collection<int, ProgramTaxonomy> $taxonomies
  */
 #[Fillable(['organisation_id', 'name', 'slug', 'request_label', 'case_label', 'configuration'])]
 class Program extends Model
@@ -65,6 +67,18 @@ class Program extends Model
     public function stages(): HasMany
     {
         return $this->hasMany(ProgramStage::class)->orderBy('position')->orderBy('id');
+    }
+
+    /** @return HasMany<ProgramOutcomeMeasure, $this> */
+    public function outcomeMeasures(): HasMany
+    {
+        return $this->hasMany(ProgramOutcomeMeasure::class)->orderBy('position')->orderBy('id');
+    }
+
+    /** @return HasMany<ProgramTaxonomy, $this> */
+    public function taxonomies(): HasMany
+    {
+        return $this->hasMany(ProgramTaxonomy::class)->orderBy('position')->orderBy('id');
     }
 
     /** @return array<string, int|string> */

--- a/app/Models/ProgramOutcomeMeasure.php
+++ b/app/Models/ProgramOutcomeMeasure.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use Database\Factories\ProgramOutcomeMeasureFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property int $id
+ * @property int $organisation_id
+ * @property int $program_id
+ * @property string $key
+ * @property string $label
+ * @property string|null $unit
+ * @property int $position
+ * @property Carbon|null $retired_at
+ */
+#[Fillable(['organisation_id', 'program_id', 'key', 'label', 'unit', 'position', 'retired_at'])]
+class ProgramOutcomeMeasure extends Model
+{
+    /** @use HasFactory<ProgramOutcomeMeasureFactory> */
+    use BelongsToOrganisation, HasFactory;
+
+    protected static function booted(): void
+    {
+        static::updating(function (ProgramOutcomeMeasure $measure): void {
+            if ($measure->isDirty(['program_id', 'key'])) {
+                throw new LogicException('A Program Outcome Measure stable identity is immutable.');
+            }
+        });
+    }
+
+    /** @return BelongsTo<Program, $this> */
+    public function program(): BelongsTo
+    {
+        return $this->belongsTo(Program::class);
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['retired_at' => 'immutable_datetime'];
+    }
+}

--- a/app/Models/ProgramTaxonomy.php
+++ b/app/Models/ProgramTaxonomy.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use Database\Factories\ProgramTaxonomyFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property int $id
+ * @property int $organisation_id
+ * @property int $program_id
+ * @property string $key
+ * @property string $label
+ * @property int $position
+ * @property Carbon|null $retired_at
+ * @property-read Collection<int, ProgramTaxonomyValue> $values
+ */
+#[Fillable(['organisation_id', 'program_id', 'key', 'label', 'position', 'retired_at'])]
+class ProgramTaxonomy extends Model
+{
+    /** @use HasFactory<ProgramTaxonomyFactory> */
+    use BelongsToOrganisation, HasFactory;
+
+    protected static function booted(): void
+    {
+        static::updating(function (ProgramTaxonomy $taxonomy): void {
+            if ($taxonomy->isDirty(['program_id', 'key'])) {
+                throw new LogicException('A Program Taxonomy stable identity is immutable.');
+            }
+        });
+    }
+
+    /** @return BelongsTo<Program, $this> */
+    public function program(): BelongsTo
+    {
+        return $this->belongsTo(Program::class);
+    }
+
+    /** @return HasMany<ProgramTaxonomyValue, $this> */
+    public function values(): HasMany
+    {
+        return $this->hasMany(ProgramTaxonomyValue::class)->orderBy('position')->orderBy('id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['retired_at' => 'immutable_datetime'];
+    }
+}

--- a/app/Models/ProgramTaxonomyValue.php
+++ b/app/Models/ProgramTaxonomyValue.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToOrganisation;
+use Database\Factories\ProgramTaxonomyValueFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+use LogicException;
+
+/**
+ * @property int $id
+ * @property int $organisation_id
+ * @property int $program_taxonomy_id
+ * @property string $key
+ * @property string $label
+ * @property int $position
+ * @property Carbon|null $retired_at
+ */
+#[Fillable(['organisation_id', 'program_taxonomy_id', 'key', 'label', 'position', 'retired_at'])]
+class ProgramTaxonomyValue extends Model
+{
+    /** @use HasFactory<ProgramTaxonomyValueFactory> */
+    use BelongsToOrganisation, HasFactory;
+
+    protected static function booted(): void
+    {
+        static::updating(function (ProgramTaxonomyValue $value): void {
+            if ($value->isDirty(['program_taxonomy_id', 'key'])) {
+                throw new LogicException('A Program Taxonomy Value stable identity is immutable.');
+            }
+        });
+    }
+
+    /** @return BelongsTo<ProgramTaxonomy, $this> */
+    public function taxonomy(): BelongsTo
+    {
+        return $this->belongsTo(ProgramTaxonomy::class, 'program_taxonomy_id');
+    }
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return ['retired_at' => 'immutable_datetime'];
+    }
+}

--- a/database/factories/ProgramOutcomeMeasureFactory.php
+++ b/database/factories/ProgramOutcomeMeasureFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Program;
+use App\Models\ProgramOutcomeMeasure;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<ProgramOutcomeMeasure>
+ */
+class ProgramOutcomeMeasureFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $label = fake()->unique()->sentence(2);
+
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'program_id' => Program::factory()->for(app(OrganisationContext::class)->organisation()),
+            'key' => Str::snake($label),
+            'label' => Str::title($label),
+            'unit' => fake()->randomElement(['score', 'percent', 'count']),
+            'position' => fake()->numberBetween(0, 10),
+            'retired_at' => null,
+        ];
+    }
+}

--- a/database/factories/ProgramTaxonomyFactory.php
+++ b/database/factories/ProgramTaxonomyFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Program;
+use App\Models\ProgramTaxonomy;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<ProgramTaxonomy>
+ */
+class ProgramTaxonomyFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $label = fake()->unique()->sentence(2);
+
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'program_id' => Program::factory()->for(app(OrganisationContext::class)->organisation()),
+            'key' => Str::snake($label),
+            'label' => Str::title($label),
+            'position' => fake()->numberBetween(0, 10),
+            'retired_at' => null,
+        ];
+    }
+}

--- a/database/factories/ProgramTaxonomyValueFactory.php
+++ b/database/factories/ProgramTaxonomyValueFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ProgramTaxonomy;
+use App\Models\ProgramTaxonomyValue;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<ProgramTaxonomyValue>
+ */
+class ProgramTaxonomyValueFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $label = fake()->unique()->sentence(2);
+
+        return [
+            'organisation_id' => app(OrganisationContext::class)->id(),
+            'program_taxonomy_id' => ProgramTaxonomy::factory(),
+            'key' => Str::snake($label),
+            'label' => Str::title($label),
+            'position' => fake()->numberBetween(0, 10),
+            'retired_at' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_09_01_065454_create_program_outcome_measures_and_taxonomies.php
+++ b/database/migrations/2026_09_01_065454_create_program_outcome_measures_and_taxonomies.php
@@ -1,0 +1,166 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('program_outcome_measures', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('program_id');
+            $table->string('key', 64);
+            $table->string('label', 100);
+            $table->string('unit', 50)->nullable();
+            $table->unsignedSmallInteger('position');
+            $table->timestamp('retired_at')->nullable();
+            $table->timestamps();
+            $table->foreign(['organisation_id', 'program_id'])->references(['organisation_id', 'id'])->on('programs')->cascadeOnDelete();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'program_id', 'key']);
+            $table->index(['organisation_id', 'program_id', 'retired_at', 'position']);
+        });
+
+        Schema::create('program_taxonomies', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('program_id');
+            $table->string('key', 64);
+            $table->string('label', 100);
+            $table->unsignedSmallInteger('position');
+            $table->timestamp('retired_at')->nullable();
+            $table->timestamps();
+            $table->foreign(['organisation_id', 'program_id'])->references(['organisation_id', 'id'])->on('programs')->cascadeOnDelete();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'program_id', 'key']);
+            $table->index(['organisation_id', 'program_id', 'retired_at', 'position']);
+        });
+
+        Schema::create('program_taxonomy_values', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organisation_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('program_taxonomy_id');
+            $table->string('key', 64);
+            $table->string('label', 100);
+            $table->unsignedSmallInteger('position');
+            $table->timestamp('retired_at')->nullable();
+            $table->timestamps();
+            $table->foreign(['organisation_id', 'program_taxonomy_id'])->references(['organisation_id', 'id'])->on('program_taxonomies')->cascadeOnDelete();
+            $table->unique(['organisation_id', 'id']);
+            $table->unique(['organisation_id', 'program_taxonomy_id', 'key']);
+            $table->index(['organisation_id', 'program_taxonomy_id', 'retired_at', 'position']);
+        });
+
+        DB::table('programs')->orderBy('id')->each(function (object $program): void {
+            $configuration = is_string($program->configuration)
+                ? json_decode($program->configuration, true, flags: JSON_THROW_ON_ERROR)
+                : (array) $program->configuration;
+
+            foreach (array_values($configuration['outcome_measures'] ?? []) as $position => $measure) {
+                if (! is_array($measure) || ! isset($measure['key'], $measure['label'])) {
+                    continue;
+                }
+
+                DB::table('program_outcome_measures')->insert([
+                    'organisation_id' => $program->organisation_id,
+                    'program_id' => $program->id,
+                    'key' => $measure['key'],
+                    'label' => $measure['label'],
+                    'unit' => $measure['unit'] ?? null,
+                    'position' => $position,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+
+            foreach (array_values($configuration['taxonomies'] ?? []) as $position => $taxonomy) {
+                if (! is_array($taxonomy) || ! isset($taxonomy['key'], $taxonomy['label'])) {
+                    continue;
+                }
+
+                $taxonomyId = DB::table('program_taxonomies')->insertGetId([
+                    'organisation_id' => $program->organisation_id,
+                    'program_id' => $program->id,
+                    'key' => $taxonomy['key'],
+                    'label' => $taxonomy['label'],
+                    'position' => $position,
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+                $usedKeys = [];
+
+                foreach (array_values($taxonomy['values'] ?? []) as $valuePosition => $label) {
+                    if (! is_string($label)) {
+                        continue;
+                    }
+
+                    $base = Str::of($label)->ascii()->snake()->limit(56, '')->toString() ?: 'value';
+                    $key = $base;
+                    $suffix = 2;
+
+                    while (in_array($key, $usedKeys, true)) {
+                        $key = Str::limit($base, 56, '').'_'.$suffix;
+                        $suffix++;
+                    }
+                    $usedKeys[] = $key;
+
+                    DB::table('program_taxonomy_values')->insert([
+                        'organisation_id' => $program->organisation_id,
+                        'program_taxonomy_id' => $taxonomyId,
+                        'key' => $key,
+                        'label' => $label,
+                        'position' => $valuePosition,
+                        'created_at' => now(),
+                        'updated_at' => now(),
+                    ]);
+                }
+            }
+
+            unset($configuration['outcome_measures'], $configuration['taxonomies']);
+            DB::table('programs')->where('id', $program->id)->update([
+                'configuration' => json_encode($configuration, JSON_THROW_ON_ERROR),
+            ]);
+        });
+    }
+
+    public function down(): void
+    {
+        DB::table('programs')->orderBy('id')->each(function (object $program): void {
+            $configuration = is_string($program->configuration)
+                ? json_decode($program->configuration, true, flags: JSON_THROW_ON_ERROR)
+                : (array) $program->configuration;
+            $configuration['outcome_measures'] = DB::table('program_outcome_measures')
+                ->where('program_id', $program->id)
+                ->orderBy('position')
+                ->get(['key', 'label', 'unit'])
+                ->map(fn (object $measure): array => ['key' => $measure->key, 'label' => $measure->label, 'unit' => $measure->unit])
+                ->all();
+            $configuration['taxonomies'] = DB::table('program_taxonomies')
+                ->where('program_id', $program->id)
+                ->orderBy('position')
+                ->get(['id', 'key', 'label'])
+                ->map(fn (object $taxonomy): array => [
+                    'key' => $taxonomy->key,
+                    'label' => $taxonomy->label,
+                    'values' => DB::table('program_taxonomy_values')
+                        ->where('program_taxonomy_id', $taxonomy->id)
+                        ->orderBy('position')
+                        ->pluck('label')
+                        ->all(),
+                ])->all();
+
+            DB::table('programs')->where('id', $program->id)->update([
+                'configuration' => json_encode($configuration, JSON_THROW_ON_ERROR),
+            ]);
+        });
+
+        Schema::dropIfExists('program_taxonomy_values');
+        Schema::dropIfExists('program_taxonomies');
+        Schema::dropIfExists('program_outcome_measures');
+    }
+};

--- a/resources/js/pages/cases/show.tsx
+++ b/resources/js/pages/cases/show.tsx
@@ -869,7 +869,7 @@ export default function CaseShow({
                                                         required
                                                     />
                                                 </div>
-                                                {caseRecord.program.configuration.outcome_measures.map(
+                                                {caseRecord.program.outcomeMeasures.map(
                                                     (measure: any) => (
                                                         <div
                                                             key={measure.key}

--- a/resources/js/pages/programs/index.tsx
+++ b/resources/js/pages/programs/index.tsx
@@ -25,6 +25,29 @@ type ProgramStage = {
     retired: boolean;
 };
 
+type OutcomeMeasure = {
+    id: number | null;
+    key: string | null;
+    label: string;
+    unit: string;
+    retired: boolean;
+};
+
+type TaxonomyValue = {
+    id: number | null;
+    key: string | null;
+    label: string;
+    retired: boolean;
+};
+
+type ProgramTaxonomy = {
+    id: number | null;
+    key: string | null;
+    label: string;
+    retired: boolean;
+    values: TaxonomyValue[];
+};
+
 type Program = {
     id: number;
     name: string;
@@ -32,6 +55,8 @@ type Program = {
     request_label: string;
     case_label: string;
     stages: ProgramStage[];
+    outcome_measures: OutcomeMeasure[];
+    taxonomies: ProgramTaxonomy[];
     canUpdate: boolean;
 };
 
@@ -48,6 +73,11 @@ function ProgramEditor({
         request_label: program.request_label,
         case_label: program.case_label,
         stages: program.stages,
+        outcome_measures: program.outcome_measures.map((measure) => ({
+            ...measure,
+            unit: measure.unit ?? '',
+        })),
+        taxonomies: program.taxonomies,
     });
     const errors = form.errors as Record<string, string>;
 
@@ -81,6 +111,117 @@ function ProgramEditor({
             ...form.data.stages,
             { id: null, key: null, label: '', retired: false },
         ]);
+    };
+
+    const updateMeasure = (
+        measureIndex: number,
+        attributes: Partial<OutcomeMeasure>,
+    ) => {
+        form.setData(
+            'outcome_measures',
+            form.data.outcome_measures.map((measure, index) =>
+                index === measureIndex
+                    ? { ...measure, ...attributes }
+                    : measure,
+            ),
+        );
+    };
+
+    const moveMeasure = (measureIndex: number, direction: -1 | 1) => {
+        const targetIndex = measureIndex + direction;
+
+        if (targetIndex < 0 || targetIndex >= form.data.outcome_measures.length)
+            return;
+
+        const measures = [...form.data.outcome_measures];
+        [measures[measureIndex], measures[targetIndex]] = [
+            measures[targetIndex],
+            measures[measureIndex],
+        ];
+        form.setData('outcome_measures', measures);
+    };
+
+    const addMeasure = () => {
+        form.setData('outcome_measures', [
+            ...form.data.outcome_measures,
+            { id: null, key: null, label: '', unit: '', retired: false },
+        ]);
+    };
+
+    const updateTaxonomy = (
+        taxonomyIndex: number,
+        attributes: Partial<ProgramTaxonomy>,
+    ) => {
+        form.setData(
+            'taxonomies',
+            form.data.taxonomies.map((taxonomy, index) =>
+                index === taxonomyIndex
+                    ? { ...taxonomy, ...attributes }
+                    : taxonomy,
+            ),
+        );
+    };
+
+    const moveTaxonomy = (taxonomyIndex: number, direction: -1 | 1) => {
+        const targetIndex = taxonomyIndex + direction;
+
+        if (targetIndex < 0 || targetIndex >= form.data.taxonomies.length)
+            return;
+
+        const taxonomies = [...form.data.taxonomies];
+        [taxonomies[taxonomyIndex], taxonomies[targetIndex]] = [
+            taxonomies[targetIndex],
+            taxonomies[taxonomyIndex],
+        ];
+        form.setData('taxonomies', taxonomies);
+    };
+
+    const addTaxonomy = () => {
+        form.setData('taxonomies', [
+            ...form.data.taxonomies,
+            { id: null, key: null, label: '', retired: false, values: [] },
+        ]);
+    };
+
+    const updateTaxonomyValue = (
+        taxonomyIndex: number,
+        valueIndex: number,
+        attributes: Partial<TaxonomyValue>,
+    ) => {
+        const taxonomy = form.data.taxonomies[taxonomyIndex];
+        updateTaxonomy(taxonomyIndex, {
+            values: taxonomy.values.map((value, index) =>
+                index === valueIndex ? { ...value, ...attributes } : value,
+            ),
+        });
+    };
+
+    const addTaxonomyValue = (taxonomyIndex: number) => {
+        const taxonomy = form.data.taxonomies[taxonomyIndex];
+        updateTaxonomy(taxonomyIndex, {
+            values: [
+                ...taxonomy.values,
+                { id: null, key: null, label: '', retired: false },
+            ],
+        });
+    };
+
+    const moveTaxonomyValue = (
+        taxonomyIndex: number,
+        valueIndex: number,
+        direction: -1 | 1,
+    ) => {
+        const taxonomy = form.data.taxonomies[taxonomyIndex];
+        const targetIndex = valueIndex + direction;
+
+        if (targetIndex < 0 || targetIndex >= taxonomy.values.length) return;
+
+        const values = [...taxonomy.values];
+        [values[valueIndex], values[targetIndex]] = [
+            values[targetIndex],
+            values[valueIndex],
+        ];
+        updateTaxonomy(taxonomyIndex, { values });
     };
 
     const save = (event: FormEvent<HTMLFormElement>) => {
@@ -330,6 +471,463 @@ function ProgramEditor({
                             ))}
                         </div>
                         <InputError message={errors.stages} />
+                    </section>
+
+                    <section className="space-y-4">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div>
+                                <h3 className="font-semibold">
+                                    Outcome measures
+                                </h3>
+                                <p className="text-muted-foreground text-sm">
+                                    Define the numeric results staff record when
+                                    closing work. Stable references keep earlier
+                                    outcomes meaningful.
+                                </p>
+                            </div>
+                            {program.canUpdate ? (
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={addMeasure}
+                                >
+                                    <Plus /> Add measure
+                                </Button>
+                            ) : null}
+                        </div>
+                        <div className="space-y-2">
+                            {form.data.outcome_measures.map(
+                                (measure, measureIndex) => (
+                                    <div
+                                        key={
+                                            measure.id ??
+                                            `new-measure-${measureIndex}`
+                                        }
+                                        className={`grid gap-3 rounded-xl border p-3 md:grid-cols-[1fr_10rem_auto] md:items-start ${
+                                            measure.retired
+                                                ? 'bg-muted/35 border-border/50'
+                                                : 'bg-card'
+                                        }`}
+                                    >
+                                        <div className="grid gap-1">
+                                            <Input
+                                                aria-label={`Outcome measure ${measureIndex + 1} label`}
+                                                value={measure.label}
+                                                onChange={(event) =>
+                                                    updateMeasure(
+                                                        measureIndex,
+                                                        {
+                                                            label: event.target
+                                                                .value,
+                                                        },
+                                                    )
+                                                }
+                                                placeholder="Housing stability"
+                                                disabled={
+                                                    !program.canUpdate ||
+                                                    measure.retired
+                                                }
+                                            />
+                                            <span className="text-muted-foreground font-mono text-xs">
+                                                {measure.key ??
+                                                    'Stable reference created on save'}
+                                            </span>
+                                            <InputError
+                                                message={
+                                                    errors[
+                                                        `outcome_measures.${measureIndex}.label`
+                                                    ]
+                                                }
+                                            />
+                                        </div>
+                                        <div className="grid gap-1">
+                                            <Input
+                                                aria-label={`Outcome measure ${measureIndex + 1} unit`}
+                                                value={measure.unit}
+                                                onChange={(event) =>
+                                                    updateMeasure(
+                                                        measureIndex,
+                                                        {
+                                                            unit: event.target
+                                                                .value,
+                                                        },
+                                                    )
+                                                }
+                                                placeholder="score"
+                                                disabled={
+                                                    !program.canUpdate ||
+                                                    measure.retired
+                                                }
+                                            />
+                                            <span className="text-muted-foreground text-xs">
+                                                Unit
+                                            </span>
+                                        </div>
+                                        {program.canUpdate ? (
+                                            <div className="flex items-center gap-1">
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    aria-label={`Move ${measure.label || 'measure'} up`}
+                                                    disabled={
+                                                        measureIndex === 0
+                                                    }
+                                                    onClick={() =>
+                                                        moveMeasure(
+                                                            measureIndex,
+                                                            -1,
+                                                        )
+                                                    }
+                                                >
+                                                    <ArrowUp />
+                                                </Button>
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    aria-label={`Move ${measure.label || 'measure'} down`}
+                                                    disabled={
+                                                        measureIndex ===
+                                                        form.data
+                                                            .outcome_measures
+                                                            .length -
+                                                            1
+                                                    }
+                                                    onClick={() =>
+                                                        moveMeasure(
+                                                            measureIndex,
+                                                            1,
+                                                        )
+                                                    }
+                                                >
+                                                    <ArrowDown />
+                                                </Button>
+                                                <Button
+                                                    type="button"
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    aria-label={
+                                                        measure.retired
+                                                            ? `Restore ${measure.label}`
+                                                            : `Retire ${measure.label || 'measure'}`
+                                                    }
+                                                    onClick={() =>
+                                                        updateMeasure(
+                                                            measureIndex,
+                                                            {
+                                                                retired:
+                                                                    !measure.retired,
+                                                            },
+                                                        )
+                                                    }
+                                                >
+                                                    {measure.retired ? (
+                                                        <RotateCcw />
+                                                    ) : (
+                                                        <Archive />
+                                                    )}
+                                                </Button>
+                                            </div>
+                                        ) : null}
+                                    </div>
+                                ),
+                            )}
+                        </div>
+                        <InputError message={errors.outcome_measures} />
+                    </section>
+
+                    <section className="space-y-4">
+                        <div className="flex flex-wrap items-start justify-between gap-3">
+                            <div>
+                                <h3 className="font-semibold">Taxonomies</h3>
+                                <p className="text-muted-foreground text-sm">
+                                    Maintain the shared classifications staff
+                                    use, with clear allowed values instead of
+                                    free-form JSON.
+                                </p>
+                            </div>
+                            {program.canUpdate ? (
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    size="sm"
+                                    onClick={addTaxonomy}
+                                >
+                                    <Plus /> Add taxonomy
+                                </Button>
+                            ) : null}
+                        </div>
+                        <div className="space-y-3">
+                            {form.data.taxonomies.map(
+                                (taxonomy, taxonomyIndex) => (
+                                    <div
+                                        key={
+                                            taxonomy.id ??
+                                            `new-taxonomy-${taxonomyIndex}`
+                                        }
+                                        className={`space-y-3 rounded-xl border p-4 ${
+                                            taxonomy.retired
+                                                ? 'bg-muted/35 border-border/50'
+                                                : 'bg-card'
+                                        }`}
+                                    >
+                                        <div className="flex flex-wrap items-start gap-2">
+                                            <div className="min-w-56 flex-1">
+                                                <Input
+                                                    aria-label={`Taxonomy ${taxonomyIndex + 1} label`}
+                                                    value={taxonomy.label}
+                                                    onChange={(event) =>
+                                                        updateTaxonomy(
+                                                            taxonomyIndex,
+                                                            {
+                                                                label: event
+                                                                    .target
+                                                                    .value,
+                                                            },
+                                                        )
+                                                    }
+                                                    placeholder="Presenting need"
+                                                    disabled={
+                                                        !program.canUpdate ||
+                                                        taxonomy.retired
+                                                    }
+                                                />
+                                                <span className="text-muted-foreground font-mono text-xs">
+                                                    {taxonomy.key ??
+                                                        'Stable reference created on save'}
+                                                </span>
+                                                <InputError
+                                                    message={
+                                                        errors[
+                                                            `taxonomies.${taxonomyIndex}.label`
+                                                        ]
+                                                    }
+                                                />
+                                            </div>
+                                            {program.canUpdate ? (
+                                                <div className="flex items-center gap-1">
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        aria-label={`Move ${taxonomy.label || 'taxonomy'} up`}
+                                                        disabled={
+                                                            taxonomyIndex === 0
+                                                        }
+                                                        onClick={() =>
+                                                            moveTaxonomy(
+                                                                taxonomyIndex,
+                                                                -1,
+                                                            )
+                                                        }
+                                                    >
+                                                        <ArrowUp />
+                                                    </Button>
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        aria-label={`Move ${taxonomy.label || 'taxonomy'} down`}
+                                                        disabled={
+                                                            taxonomyIndex ===
+                                                            form.data.taxonomies
+                                                                .length -
+                                                                1
+                                                        }
+                                                        onClick={() =>
+                                                            moveTaxonomy(
+                                                                taxonomyIndex,
+                                                                1,
+                                                            )
+                                                        }
+                                                    >
+                                                        <ArrowDown />
+                                                    </Button>
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        aria-label={
+                                                            taxonomy.retired
+                                                                ? `Restore ${taxonomy.label}`
+                                                                : `Retire ${taxonomy.label || 'taxonomy'}`
+                                                        }
+                                                        onClick={() =>
+                                                            updateTaxonomy(
+                                                                taxonomyIndex,
+                                                                {
+                                                                    retired:
+                                                                        !taxonomy.retired,
+                                                                },
+                                                            )
+                                                        }
+                                                    >
+                                                        {taxonomy.retired ? (
+                                                            <RotateCcw />
+                                                        ) : (
+                                                            <Archive />
+                                                        )}
+                                                    </Button>
+                                                </div>
+                                            ) : null}
+                                        </div>
+                                        <div className="space-y-2 border-l pl-4">
+                                            <div className="flex items-center justify-between gap-2">
+                                                <span className="text-sm font-medium">
+                                                    Allowed values
+                                                </span>
+                                                {program.canUpdate &&
+                                                !taxonomy.retired ? (
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="sm"
+                                                        onClick={() =>
+                                                            addTaxonomyValue(
+                                                                taxonomyIndex,
+                                                            )
+                                                        }
+                                                    >
+                                                        <Plus /> Add value
+                                                    </Button>
+                                                ) : null}
+                                            </div>
+                                            {taxonomy.values.map(
+                                                (value, valueIndex) => (
+                                                    <div
+                                                        key={
+                                                            value.id ??
+                                                            `new-value-${valueIndex}`
+                                                        }
+                                                        className="flex items-start gap-2"
+                                                    >
+                                                        <div className="min-w-40 flex-1">
+                                                            <Input
+                                                                aria-label={`${taxonomy.label || 'Taxonomy'} value ${valueIndex + 1}`}
+                                                                value={
+                                                                    value.label
+                                                                }
+                                                                onChange={(
+                                                                    event,
+                                                                ) =>
+                                                                    updateTaxonomyValue(
+                                                                        taxonomyIndex,
+                                                                        valueIndex,
+                                                                        {
+                                                                            label: event
+                                                                                .target
+                                                                                .value,
+                                                                        },
+                                                                    )
+                                                                }
+                                                                placeholder="Housing"
+                                                                disabled={
+                                                                    !program.canUpdate ||
+                                                                    taxonomy.retired ||
+                                                                    value.retired
+                                                                }
+                                                            />
+                                                            <span className="text-muted-foreground font-mono text-xs">
+                                                                {value.key ??
+                                                                    'Reference created on save'}
+                                                            </span>
+                                                            <InputError
+                                                                message={
+                                                                    errors[
+                                                                        `taxonomies.${taxonomyIndex}.values.${valueIndex}.label`
+                                                                    ]
+                                                                }
+                                                            />
+                                                        </div>
+                                                        {program.canUpdate ? (
+                                                            <div className="flex items-center gap-1">
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="ghost"
+                                                                    size="icon"
+                                                                    aria-label={`Move ${value.label || 'value'} up`}
+                                                                    disabled={
+                                                                        valueIndex ===
+                                                                        0
+                                                                    }
+                                                                    onClick={() =>
+                                                                        moveTaxonomyValue(
+                                                                            taxonomyIndex,
+                                                                            valueIndex,
+                                                                            -1,
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    <ArrowUp />
+                                                                </Button>
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="ghost"
+                                                                    size="icon"
+                                                                    aria-label={`Move ${value.label || 'value'} down`}
+                                                                    disabled={
+                                                                        valueIndex ===
+                                                                        taxonomy
+                                                                            .values
+                                                                            .length -
+                                                                            1
+                                                                    }
+                                                                    onClick={() =>
+                                                                        moveTaxonomyValue(
+                                                                            taxonomyIndex,
+                                                                            valueIndex,
+                                                                            1,
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    <ArrowDown />
+                                                                </Button>
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="ghost"
+                                                                    size="icon"
+                                                                    aria-label={
+                                                                        value.retired
+                                                                            ? `Restore ${value.label}`
+                                                                            : `Retire ${value.label || 'value'}`
+                                                                    }
+                                                                    onClick={() =>
+                                                                        updateTaxonomyValue(
+                                                                            taxonomyIndex,
+                                                                            valueIndex,
+                                                                            {
+                                                                                retired:
+                                                                                    !value.retired,
+                                                                            },
+                                                                        )
+                                                                    }
+                                                                >
+                                                                    {value.retired ? (
+                                                                        <RotateCcw />
+                                                                    ) : (
+                                                                        <Archive />
+                                                                    )}
+                                                                </Button>
+                                                            </div>
+                                                        ) : null}
+                                                    </div>
+                                                ),
+                                            )}
+                                            <InputError
+                                                message={
+                                                    errors[
+                                                        `taxonomies.${taxonomyIndex}.values`
+                                                    ]
+                                                }
+                                            />
+                                        </div>
+                                    </div>
+                                ),
+                            )}
+                        </div>
+                        <InputError message={errors.taxonomies} />
                     </section>
 
                     {program.canUpdate ? (

--- a/tests/Feature/CaseDeliveryWorkflowTest.php
+++ b/tests/Feature/CaseDeliveryWorkflowTest.php
@@ -54,11 +54,9 @@ function caseDeliveryFixture(): array
 
     [$program, $party, $case] = app(OrganisationContext::class)->run($organisation, function () use ($organisation, $manager, $managerMembership, $workerMembership): array {
         $program = Program::factory()->for($organisation)->create(['configuration' => [
-            'labels' => ['request' => 'Housing request', 'case' => 'Housing journey'],
-            'stages' => [['key' => 'received', 'label' => 'Received']],
-            'outcome_measures' => [['key' => 'housing_stability', 'label' => 'Housing stability', 'unit' => 'score']],
-            'taxonomies' => [], 'intake_fields' => [], 'eligibility_fields' => [], 'risk_flags' => [],
+            'intake_fields' => [], 'eligibility_fields' => [], 'risk_flags' => [],
         ]]);
+        $program->outcomeMeasures()->create(['key' => 'housing_stability', 'label' => 'Housing stability', 'unit' => 'score', 'position' => 0]);
         $managerMembership->programs()->attach($program);
         $workerMembership->programs()->attach($program);
         $party = Party::factory()->for($organisation)->create();

--- a/tests/Feature/IntakeRequestWorkflowTest.php
+++ b/tests/Feature/IntakeRequestWorkflowTest.php
@@ -34,10 +34,6 @@ function intakeWorkflowFixture(): array
     $workerMembership = $organisation->memberships()->create(['user_id' => $worker->id, 'role' => OrganisationRole::CaseWorker]);
     [$program, $party] = app(OrganisationContext::class)->run($organisation, function () use ($organisation, $managerMembership, $workerMembership): array {
         $program = Program::factory()->for($organisation)->create(['configuration' => [
-            'labels' => ['request' => 'Housing request', 'case' => 'Housing journey'],
-            'stages' => [['key' => 'received', 'label' => 'Received']],
-            'outcome_measures' => [['key' => 'housing_stability', 'label' => 'Housing stability', 'unit' => 'score']],
-            'taxonomies' => [['key' => 'need', 'label' => 'Need', 'values' => ['Housing']]],
             'intake_fields' => [['key' => 'current_situation', 'label' => 'Current situation', 'type' => 'textarea', 'required' => true]],
             'eligibility_fields' => [['key' => 'service_area', 'label' => 'Lives in service area']],
             'risk_flags' => [['key' => 'housing_loss', 'label' => 'At risk of losing housing']],

--- a/tests/Feature/ProgramConfigurationTest.php
+++ b/tests/Feature/ProgramConfigurationTest.php
@@ -23,8 +23,9 @@ function createProgramConfigurationFixture(): array
             'request_label' => 'Request',
             'case_label' => 'Case',
             'configuration' => [
-                'outcome_measures' => [['key' => 'progress', 'label' => 'Progress', 'unit' => 'score']],
-                'taxonomies' => [],
+                'intake_fields' => [],
+                'eligibility_fields' => [],
+                'risk_flags' => [],
             ],
         ]);
         $received = $program->stages()->create(['key' => 'received', 'label' => 'Received', 'position' => 0]);
@@ -63,8 +64,9 @@ it('lets an administrator manage Program terminology and an ordered service path
         expect($program->request_label)->toBe('Support request')
             ->and($program->case_label)->toBe('Support journey')
             ->and($program->configuration)->toBe([
-                'outcome_measures' => [['key' => 'progress', 'label' => 'Progress', 'unit' => 'score']],
-                'taxonomies' => [],
+                'intake_fields' => [],
+                'eligibility_fields' => [],
+                'risk_flags' => [],
             ])
             ->and($program->stages()->pluck('key')->all())->toBe(['active', 'received', 'review_progress'])
             ->and($received->refresh()->retired_at)->not->toBeNull();

--- a/tests/Feature/ProgramOutcomeTaxonomyTest.php
+++ b/tests/Feature/ProgramOutcomeTaxonomyTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\Program;
+use App\Models\ProgramOutcomeMeasure;
+use App\Models\ProgramTaxonomy;
+use App\Models\ProgramTaxonomyValue;
+use App\Models\User;
+use App\OrganisationContext;
+
+/** @return array{administrator: User, organisation: Organisation, program: Program, progress: ProgramOutcomeMeasure, wellbeing: ProgramOutcomeMeasure, taxonomy: ProgramTaxonomy, housing: ProgramTaxonomyValue, food: ProgramTaxonomyValue} */
+function createProgramOutcomeTaxonomyFixture(): array
+{
+    $administrator = User::factory()->create();
+    $organisation = Organisation::factory()->active()->create();
+    $organisation->memberships()->create([
+        'user_id' => $administrator->id,
+        'role' => OrganisationRole::OrganisationAdministrator,
+    ]);
+
+    return app(OrganisationContext::class)->run($organisation, function () use ($administrator, $organisation): array {
+        $program = Program::factory()->for($organisation)->create();
+        $progress = $program->outcomeMeasures()->create(['key' => 'progress', 'label' => 'Progress', 'unit' => 'score', 'position' => 0]);
+        $wellbeing = $program->outcomeMeasures()->create(['key' => 'wellbeing', 'label' => 'Wellbeing', 'unit' => 'score', 'position' => 1]);
+        $taxonomy = $program->taxonomies()->create(['key' => 'need', 'label' => 'Presenting need', 'position' => 0]);
+        $housing = $taxonomy->values()->create(['key' => 'housing', 'label' => 'Housing', 'position' => 0]);
+        $food = $taxonomy->values()->create(['key' => 'food', 'label' => 'Food', 'position' => 1]);
+
+        return compact('administrator', 'organisation', 'program', 'progress', 'wellbeing', 'taxonomy', 'housing', 'food');
+    });
+}
+
+it('manages ordered outcome measures taxonomies and allowed values without JSON', function () {
+    extract(createProgramOutcomeTaxonomyFixture());
+
+    $this->actingAs($administrator)
+        ->patchJson(route('organisations.programs.update', [$organisation, $program]), [
+            'name' => $program->name,
+            'slug' => $program->slug,
+            'outcome_measures' => [
+                ['id' => $wellbeing->id, 'key' => $wellbeing->key, 'label' => 'Personal wellbeing', 'unit' => 'percent', 'retired' => false],
+                ['id' => $progress->id, 'key' => $progress->key, 'label' => 'Progress', 'unit' => 'score', 'retired' => true],
+                ['id' => null, 'key' => null, 'label' => 'Housing stability', 'unit' => 'score', 'retired' => false],
+            ],
+            'taxonomies' => [
+                [
+                    'id' => $taxonomy->id,
+                    'key' => $taxonomy->key,
+                    'label' => 'Primary need',
+                    'retired' => false,
+                    'values' => [
+                        ['id' => $food->id, 'key' => $food->key, 'label' => 'Food security', 'retired' => false],
+                        ['id' => $housing->id, 'key' => $housing->key, 'label' => 'Housing', 'retired' => true],
+                        ['id' => null, 'key' => null, 'label' => 'Employment', 'retired' => false],
+                    ],
+                ],
+            ],
+        ])
+        ->assertOk()
+        ->assertJsonPath('outcome_measures.0.key', 'wellbeing')
+        ->assertJsonPath('outcome_measures.0.label', 'Personal wellbeing')
+        ->assertJsonPath('outcome_measures.1.retired', true)
+        ->assertJsonPath('outcome_measures.2.key', 'housing_stability')
+        ->assertJsonPath('taxonomies.0.key', 'need')
+        ->assertJsonPath('taxonomies.0.values.0.key', 'food')
+        ->assertJsonPath('taxonomies.0.values.2.key', 'employment');
+
+    app(OrganisationContext::class)->run($organisation, function () use ($program, $progress, $housing): void {
+        expect($program->outcomeMeasures()->pluck('key')->all())->toBe(['wellbeing', 'progress', 'housing_stability'])
+            ->and($program->taxonomies()->firstOrFail()->values()->pluck('key')->all())->toBe(['food', 'housing', 'employment'])
+            ->and($progress->refresh()->retired_at)->not->toBeNull()
+            ->and($housing->refresh()->retired_at)->not->toBeNull()
+            ->and($program->refresh()->configuration)->not->toHaveKeys(['outcome_measures', 'taxonomies']);
+    });
+});
+
+it('requires existing measures taxonomies and values to be retired rather than omitted', function () {
+    extract(createProgramOutcomeTaxonomyFixture());
+
+    $this->actingAs($administrator)
+        ->patchJson(route('organisations.programs.update', [$organisation, $program]), [
+            'name' => $program->name,
+            'slug' => $program->slug,
+            'outcome_measures' => [
+                ['id' => $progress->id, 'key' => $progress->key, 'label' => 'Progress', 'unit' => 'score', 'retired' => false],
+            ],
+            'taxonomies' => [
+                [
+                    'id' => $taxonomy->id,
+                    'key' => $taxonomy->key,
+                    'label' => 'Need',
+                    'retired' => false,
+                    'values' => [
+                        ['id' => $housing->id, 'key' => $housing->key, 'label' => 'Housing', 'retired' => false],
+                    ],
+                ],
+            ],
+        ])
+        ->assertUnprocessable()
+        ->assertJsonValidationErrors(['outcome_measures', 'taxonomies.0.values']);
+});
+
+it('keeps outcome taxonomy and value stable identities immutable', function () {
+    extract(createProgramOutcomeTaxonomyFixture());
+
+    app(OrganisationContext::class)->run($organisation, function () use ($progress, $taxonomy, $housing): void {
+        expect(fn () => $progress->update(['key' => 'changed']))->toThrow(LogicException::class, 'stable identity')
+            ->and(fn () => $taxonomy->update(['key' => 'changed']))->toThrow(LogicException::class, 'stable identity')
+            ->and(fn () => $housing->update(['key' => 'changed']))->toThrow(LogicException::class, 'stable identity');
+    });
+});


### PR DESCRIPTION
## Summary
- promote Program outcome measures, taxonomies, and allowed values into tenant-scoped first-class records
- replace JSON-backed editing with ordered structured controls and stable retirement semantics
- migrate existing configuration and update case outcome consumers and demo scenarios

## Verification
- `php artisan test --compact` (372 tests, 2456 assertions)
- `npm run test -- --run` (9 tests)
- `composer types:check`
- `npm run types:check`
- `npm run check`
- `npm run build`
- reviewed against `codex/issue-81-program-stages`; no remaining actionable findings

Closes #82