### PR TITLE
Add purpose-built Message Template editor

### DIFF
--- a/app/Actions/Configuration/ValidateConfigurationDefinition.php
+++ b/app/Actions/Configuration/ValidateConfigurationDefinition.php
@@ -53,6 +53,16 @@ final class ValidateConfigurationDefinition
             if ($area === OrganisationConfigurationArea::MessageTemplate && ($definition['channel'] ?? null) === 'email' && blank($definition['subject'] ?? null)) {
                 $validator->errors()->add('subject', 'Email templates require a subject.');
             }
+            if ($area === OrganisationConfigurationArea::MessageTemplate) {
+                foreach (['subject', 'body'] as $field) {
+                    $template = (string) ($definition[$field] ?? '');
+                    $remainder = str_replace(['{{ supporter_name }}', '{{ donation_count }}', '{{ activity_frequency }}', '{{ activity_value }}'], '', $template);
+
+                    if (str_contains($remainder, '{{') || str_contains($remainder, '}}')) {
+                        $validator->errors()->add($field, 'The template contains an unsupported variable.');
+                    }
+                }
+            }
             if ($area === OrganisationConfigurationArea::IntakeRules && ! collect($requiredFields)->contains('presenting_needs')) {
                 $validator->errors()->add('required_fields', 'Intake rules must keep presenting needs required.');
             }

--- a/app/Http/Controllers/Organisations/MessageTemplateController.php
+++ b/app/Http/Controllers/Organisations/MessageTemplateController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Organisations;
 use App\Actions\Configuration\ActivateOrganisationConfiguration;
 use App\Actions\Configuration\CreateOrganisationConfiguration;
 use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
 use App\Enums\SupporterJourneyKind;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Organisations\StoreMessageTemplateRequest;
@@ -21,25 +22,27 @@ class MessageTemplateController extends Controller
     public function index(Organisation $currentOrganisation): Response
     {
         Gate::authorize('viewAny', [OrganisationConfiguration::class, $currentOrganisation]);
+        $templates = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::MessageTemplate)
+            ->orderBy('configuration_key')
+            ->orderByDesc('version')
+            ->get();
 
         return Inertia::render('message-templates/index', [
-            'templates' => OrganisationConfiguration::query()
-                ->where('area', OrganisationConfigurationArea::MessageTemplate)
-                ->orderBy('configuration_key')
-                ->orderByDesc('version')
-                ->get()
-                ->map(fn (OrganisationConfiguration $template): array => [
-                    'id' => $template->id,
-                    'key' => $template->configuration_key,
-                    'name' => Str::of($template->configuration_key)->replace(['-', '_'], ' ')->title()->toString(),
-                    'version' => $template->version,
-                    'status' => $template->status->value,
-                    'channel' => $template->definition['channel'],
-                    'subject' => $template->definition['subject'] ?? '',
-                    'body' => $template->definition['body'],
-                    'journeyKind' => $template->definition['journey_kind'],
-                    'activatedAt' => $template->activated_at?->toAtomString(),
-                ]),
+            'templates' => $templates->map(fn (OrganisationConfiguration $template): array => [
+                'id' => $template->id,
+                'key' => $template->configuration_key,
+                'name' => Str::of($template->configuration_key)->replace(['-', '_'], ' ')->title()->toString(),
+                'version' => $template->version,
+                'status' => $template->status->value,
+                'channel' => $template->definition['channel'],
+                'subject' => $template->definition['subject'] ?? '',
+                'body' => $template->definition['body'],
+                'journeyKind' => $template->definition['journey_kind'],
+                'activatedAt' => $template->activated_at?->toAtomString(),
+                'canActivate' => $template->status === OrganisationConfigurationStatus::Draft
+                    && $templates->where('configuration_key', $template->configuration_key)->max('version') === $template->version,
+            ]),
             'journeyKinds' => collect(SupporterJourneyKind::cases())->map(fn (SupporterJourneyKind $kind): array => [
                 'value' => $kind->value,
                 'label' => $kind->label(),
@@ -70,6 +73,12 @@ class MessageTemplateController extends Controller
             ->where('area', OrganisationConfigurationArea::MessageTemplate)
             ->findOrFail($messageTemplate);
         Gate::authorize('update', $template);
+        $latestId = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::MessageTemplate)
+            ->where('configuration_key', $template->configuration_key)
+            ->latest('version')
+            ->value('id');
+        abort_unless($template->status === OrganisationConfigurationStatus::Draft && $template->id === $latestId, 409);
         $activate->handle($template, request()->user());
 
         return back();

--- a/app/Http/Controllers/Organisations/MessageTemplateController.php
+++ b/app/Http/Controllers/Organisations/MessageTemplateController.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Configuration\ActivateOrganisationConfiguration;
+use App\Actions\Configuration\CreateOrganisationConfiguration;
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\SupporterJourneyKind;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\StoreMessageTemplateRequest;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Str;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class MessageTemplateController extends Controller
+{
+    public function index(Organisation $currentOrganisation): Response
+    {
+        Gate::authorize('viewAny', [OrganisationConfiguration::class, $currentOrganisation]);
+
+        return Inertia::render('message-templates/index', [
+            'templates' => OrganisationConfiguration::query()
+                ->where('area', OrganisationConfigurationArea::MessageTemplate)
+                ->orderBy('configuration_key')
+                ->orderByDesc('version')
+                ->get()
+                ->map(fn (OrganisationConfiguration $template): array => [
+                    'id' => $template->id,
+                    'key' => $template->configuration_key,
+                    'name' => Str::of($template->configuration_key)->replace(['-', '_'], ' ')->title()->toString(),
+                    'version' => $template->version,
+                    'status' => $template->status->value,
+                    'channel' => $template->definition['channel'],
+                    'subject' => $template->definition['subject'] ?? '',
+                    'body' => $template->definition['body'],
+                    'journeyKind' => $template->definition['journey_kind'],
+                    'activatedAt' => $template->activated_at?->toAtomString(),
+                ]),
+            'journeyKinds' => collect(SupporterJourneyKind::cases())->map(fn (SupporterJourneyKind $kind): array => [
+                'value' => $kind->value,
+                'label' => $kind->label(),
+            ]),
+        ]);
+    }
+
+    public function store(StoreMessageTemplateRequest $request, Organisation $currentOrganisation, CreateOrganisationConfiguration $create): RedirectResponse
+    {
+        Gate::authorize('create', [OrganisationConfiguration::class, $currentOrganisation]);
+        $key = $request->filled('template_key')
+            ? $request->string('template_key')->toString()
+            : Str::of($request->string('name')->toString())->ascii()->slug()->limit(100, '')->toString();
+        $channel = $request->string('channel')->toString();
+        $create->handle($currentOrganisation, OrganisationConfigurationArea::MessageTemplate, $key, [
+            'channel' => $channel,
+            'subject' => $channel === 'email' ? $request->string('subject')->toString() : null,
+            'body' => $request->string('body')->toString(),
+            'journey_kind' => $request->string('journey_kind')->toString(),
+        ], $request->user());
+
+        return back();
+    }
+
+    public function activate(Organisation $currentOrganisation, string $messageTemplate, ActivateOrganisationConfiguration $activate): RedirectResponse
+    {
+        $template = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::MessageTemplate)
+            ->findOrFail($messageTemplate);
+        Gate::authorize('update', $template);
+        $activate->handle($template, request()->user());
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Organisations/OrganisationConfigurationController.php
+++ b/app/Http/Controllers/Organisations/OrganisationConfigurationController.php
@@ -23,7 +23,7 @@ class OrganisationConfigurationController extends Controller
         Gate::authorize('viewAny', [OrganisationConfiguration::class, $currentOrganisation]);
 
         return Inertia::render('organisation-configurations/index', [
-            'configurations' => OrganisationConfiguration::query()->latest()->get()->map(fn (OrganisationConfiguration $configuration): array => [
+            'configurations' => OrganisationConfiguration::query()->where('area', '!=', OrganisationConfigurationArea::MessageTemplate)->latest()->get()->map(fn (OrganisationConfiguration $configuration): array => [
                 'id' => $configuration->id,
                 'area' => $configuration->area->value,
                 'key' => $configuration->configuration_key,
@@ -32,7 +32,10 @@ class OrganisationConfigurationController extends Controller
                 'definition' => $configuration->definition,
                 'activatedAt' => $configuration->activated_at?->toAtomString(),
             ]),
-            'areas' => collect(OrganisationConfigurationArea::cases())->map(fn (OrganisationConfigurationArea $area): array => ['value' => $area->value, 'label' => $area->label()]),
+            'areas' => collect(OrganisationConfigurationArea::cases())
+                ->reject(fn (OrganisationConfigurationArea $area): bool => $area === OrganisationConfigurationArea::MessageTemplate)
+                ->map(fn (OrganisationConfigurationArea $area): array => ['value' => $area->value, 'label' => $area->label()])
+                ->values(),
         ]);
     }
 
@@ -56,6 +59,7 @@ class OrganisationConfigurationController extends Controller
     public function activate(Organisation $currentOrganisation, string $configuration, ActivateOrganisationConfiguration $activate): RedirectResponse
     {
         $version = OrganisationConfiguration::query()->findOrFail($configuration);
+        abort_if($version->area === OrganisationConfigurationArea::MessageTemplate, 404);
         Gate::authorize('update', $version);
         $activate->handle($version, request()->user());
 

--- a/app/Http/Requests/Organisations/StoreMessageTemplateRequest.php
+++ b/app/Http/Requests/Organisations/StoreMessageTemplateRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\SupporterJourneyKind;
+use App\Models\Organisation;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+
+class StoreMessageTemplateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        $organisation = $this->route('current_organisation');
+        $organisationId = $organisation instanceof Organisation ? $organisation->id : 0;
+
+        return [
+            'template_key' => ['nullable', 'string', 'max:100', 'alpha_dash:ascii', Rule::exists('organisation_configurations', 'configuration_key')->where(fn ($query) => $query->where('organisation_id', $organisationId)->where('area', OrganisationConfigurationArea::MessageTemplate->value))],
+            'name' => ['required', 'string', 'max:100'],
+            'channel' => ['required', Rule::in(['email', 'sms'])],
+            'subject' => ['nullable', 'string', 'max:160', 'required_if:channel,email'],
+            'body' => ['required', 'string', 'max:4000'],
+            'journey_kind' => ['required', Rule::enum(SupporterJourneyKind::class)],
+        ];
+    }
+
+    /** @return array<int, callable(Validator): void> */
+    public function after(): array
+    {
+        return [function (Validator $validator): void {
+            if (Str::of($this->string('name')->toString())->ascii()->slug()->isEmpty()) {
+                $validator->errors()->add('name', 'The template name must include letters or numbers.');
+            }
+
+            foreach (['subject', 'body'] as $field) {
+                $template = (string) $this->input($field);
+                $remainder = str_replace(['{{ supporter_name }}', '{{ donation_count }}', '{{ activity_frequency }}', '{{ activity_value }}'], '', $template);
+
+                if (str_contains($remainder, '{{') || str_contains($remainder, '}}')) {
+                    $validator->errors()->add($field, 'Only supporter_name, donation_count, activity_frequency, and activity_value variables are available.');
+                }
+            }
+
+            if ($this->input('channel') === 'sms' && mb_strlen((string) $this->input('body')) > 480) {
+                $validator->errors()->add('body', 'SMS templates may not exceed 480 characters.');
+            }
+        }];
+    }
+}

--- a/app/Http/Requests/Organisations/StoreOrganisationConfigurationRequest.php
+++ b/app/Http/Requests/Organisations/StoreOrganisationConfigurationRequest.php
@@ -18,7 +18,7 @@ class StoreOrganisationConfigurationRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'area' => ['required', Rule::enum(OrganisationConfigurationArea::class)],
+            'area' => ['required', Rule::enum(OrganisationConfigurationArea::class), Rule::notIn([OrganisationConfigurationArea::MessageTemplate->value])],
             'configuration_key' => ['required', 'string', 'alpha_dash:ascii', 'max:100'],
             'definition_json' => ['required', 'string', 'json', 'max:20000'],
         ];

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -35,6 +35,7 @@ import { index as auditIndex } from '@/routes/audit';
 import { index as communityEngagementIndex } from '@/routes/community-engagement';
 import { index as donationsIndex } from '@/routes/donations';
 import { index as intakesIndex } from '@/routes/intakes';
+import { index as messageTemplatesIndex } from '@/routes/message-templates';
 import { index as configurationsIndex } from '@/routes/organisation-configurations';
 import { index as impactSnapshotsIndex } from '@/routes/impact-snapshots';
 import { index as partiesIndex } from '@/routes/parties';
@@ -139,6 +140,13 @@ export function AppSidebar() {
         ...(page.props.canViewOrganisationConfigurations &&
         page.props.currentOrganisation
             ? [
+                  {
+                      title: 'Message templates',
+                      href: messageTemplatesIndex(
+                          page.props.currentOrganisation.slug,
+                      ),
+                      icon: MessagesSquare,
+                  },
                   {
                       title: 'Organisation configuration',
                       href: configurationsIndex(

--- a/resources/js/pages/message-templates/index.tsx
+++ b/resources/js/pages/message-templates/index.tsx
@@ -21,6 +21,7 @@ type MessageTemplate = {
     body: string;
     journeyKind: string;
     activatedAt: string | null;
+    canActivate: boolean;
 };
 
 type JourneyKind = { value: string; label: string };
@@ -282,7 +283,7 @@ export default function MessageTemplatesIndex({
                                 >
                                     New version
                                 </Button>
-                                {template.status === 'draft' ? (
+                                {template.canActivate ? (
                                     <Form
                                         {...activate.form([
                                             organisation.slug,

--- a/resources/js/pages/message-templates/index.tsx
+++ b/resources/js/pages/message-templates/index.tsx
@@ -1,0 +1,313 @@
+import { Form, Head, useForm, usePage } from '@inertiajs/react';
+import type { FormEvent } from 'react';
+import Heading from '@/components/heading';
+import InputError from '@/components/input-error';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { activate, index, store } from '@/routes/message-templates';
+
+type MessageTemplate = {
+    id: string;
+    key: string;
+    name: string;
+    version: number;
+    status: string;
+    channel: 'email' | 'sms';
+    subject: string;
+    body: string;
+    journeyKind: string;
+    activatedAt: string | null;
+};
+
+type JourneyKind = { value: string; label: string };
+
+const sampleValues: Record<string, string> = {
+    supporter_name: 'Amina',
+    donation_count: '3',
+    activity_frequency: '5',
+    activity_value: '18 hours',
+};
+
+function preview(template: string) {
+    return Object.entries(sampleValues).reduce(
+        (message, [variable, value]) =>
+            message.replaceAll(`{{ ${variable} }}`, value),
+        template,
+    );
+}
+
+export default function MessageTemplatesIndex({
+    templates,
+    journeyKinds,
+}: {
+    templates: MessageTemplate[];
+    journeyKinds: JourneyKind[];
+}) {
+    const organisation = usePage().props.currentOrganisation!;
+    const form = useForm({
+        template_key: '',
+        name: '',
+        channel: 'email' as 'email' | 'sms',
+        subject: '',
+        body: 'Hello {{ supporter_name }},',
+        journey_kind: journeyKinds[0]?.value ?? 'general',
+    });
+
+    const submit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        form.post(store.url(organisation.slug), {
+            preserveScroll: true,
+            onSuccess: () => form.reset(),
+        });
+    };
+
+    const useAsStartingPoint = (template: MessageTemplate) => {
+        form.setData({
+            template_key: template.key,
+            name: template.name,
+            channel: template.channel,
+            subject: template.subject,
+            body: template.body,
+            journey_kind: template.journeyKind,
+        });
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+
+    return (
+        <div className="space-y-6 p-4">
+            <Head title="Message templates" />
+            <Heading
+                title="Message templates"
+                description="Create reusable email and SMS messages, preview them with example data, then activate the exact version journeys should use."
+            />
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Create a template draft</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <form
+                        className="grid gap-6 lg:grid-cols-2"
+                        onSubmit={submit}
+                    >
+                        <div className="space-y-4">
+                            <div className="grid gap-2">
+                                <Label htmlFor="template-name">
+                                    Template name
+                                </Label>
+                                <Input
+                                    id="template-name"
+                                    value={form.data.name}
+                                    onChange={(event) =>
+                                        form.setData({
+                                            ...form.data,
+                                            template_key: '',
+                                            name: event.target.value,
+                                        })
+                                    }
+                                    placeholder="Donor re-engagement"
+                                    required
+                                />
+                                <InputError message={form.errors.name} />
+                                <p className="text-muted-foreground text-xs">
+                                    Reusing a name creates the next immutable
+                                    version. Changing the name after choosing a
+                                    starting point creates a separate template.
+                                </p>
+                            </div>
+                            <div className="grid gap-4 sm:grid-cols-2">
+                                <div className="grid gap-2">
+                                    <Label htmlFor="template-channel">
+                                        Channel
+                                    </Label>
+                                    <select
+                                        id="template-channel"
+                                        className="h-9 rounded-md border bg-transparent px-3"
+                                        value={form.data.channel}
+                                        onChange={(event) =>
+                                            form.setData(
+                                                'channel',
+                                                event.target.value as
+                                                    | 'email'
+                                                    | 'sms',
+                                            )
+                                        }
+                                    >
+                                        <option value="email">Email</option>
+                                        <option value="sms">SMS</option>
+                                    </select>
+                                    <InputError message={form.errors.channel} />
+                                </div>
+                                <div className="grid gap-2">
+                                    <Label htmlFor="template-journey-kind">
+                                        Journey kind
+                                    </Label>
+                                    <select
+                                        id="template-journey-kind"
+                                        className="h-9 rounded-md border bg-transparent px-3"
+                                        value={form.data.journey_kind}
+                                        onChange={(event) =>
+                                            form.setData(
+                                                'journey_kind',
+                                                event.target.value,
+                                            )
+                                        }
+                                    >
+                                        {journeyKinds.map((kind) => (
+                                            <option
+                                                key={kind.value}
+                                                value={kind.value}
+                                            >
+                                                {kind.label}
+                                            </option>
+                                        ))}
+                                    </select>
+                                    <InputError
+                                        message={form.errors.journey_kind}
+                                    />
+                                </div>
+                            </div>
+                            {form.data.channel === 'email' ? (
+                                <div className="grid gap-2">
+                                    <Label htmlFor="template-subject">
+                                        Subject
+                                    </Label>
+                                    <Input
+                                        id="template-subject"
+                                        value={form.data.subject}
+                                        onChange={(event) =>
+                                            form.setData(
+                                                'subject',
+                                                event.target.value,
+                                            )
+                                        }
+                                        required
+                                    />
+                                    <InputError message={form.errors.subject} />
+                                </div>
+                            ) : null}
+                            <div className="grid gap-2">
+                                <Label htmlFor="template-body">Message</Label>
+                                <Textarea
+                                    id="template-body"
+                                    rows={8}
+                                    value={form.data.body}
+                                    onChange={(event) =>
+                                        form.setData('body', event.target.value)
+                                    }
+                                    required
+                                />
+                                <div className="text-muted-foreground flex justify-between gap-3 text-xs">
+                                    <span>
+                                        Variables: supporter_name,
+                                        donation_count, activity_frequency,
+                                        activity_value
+                                    </span>
+                                    <span>
+                                        {form.data.body.length}/
+                                        {form.data.channel === 'sms'
+                                            ? '480'
+                                            : '4000'}
+                                    </span>
+                                </div>
+                                <InputError message={form.errors.body} />
+                            </div>
+                            <Button disabled={form.processing}>
+                                {form.processing
+                                    ? 'Creating draft…'
+                                    : 'Create draft'}
+                            </Button>
+                        </div>
+
+                        <div className="bg-muted/40 rounded-xl border p-5">
+                            <div className="mb-4 flex items-center justify-between gap-2">
+                                <strong>Preview</strong>
+                                <Badge variant="outline">
+                                    {form.data.channel.toUpperCase()}
+                                </Badge>
+                            </div>
+                            {form.data.channel === 'email' ? (
+                                <p className="border-b pb-3 font-semibold">
+                                    {preview(form.data.subject) ||
+                                        'Email subject'}
+                                </p>
+                            ) : null}
+                            <p className="mt-4 whitespace-pre-wrap">
+                                {preview(form.data.body)}
+                            </p>
+                        </div>
+                    </form>
+                </CardContent>
+            </Card>
+
+            <section className="space-y-3">
+                <h2 className="text-xl font-semibold">Version history</h2>
+                {templates.map((template) => (
+                    <Card key={template.id}>
+                        <CardContent className="grid gap-4 pt-6 lg:grid-cols-[1fr_auto]">
+                            <div className="space-y-3">
+                                <div className="flex flex-wrap items-center gap-2">
+                                    <strong>
+                                        {template.name} · v{template.version}
+                                    </strong>
+                                    <Badge>{template.status}</Badge>
+                                    <Badge variant="outline">
+                                        {template.channel.toUpperCase()}
+                                    </Badge>
+                                    <Badge variant="secondary">
+                                        {template.journeyKind.replaceAll(
+                                            '_',
+                                            ' ',
+                                        )}
+                                    </Badge>
+                                </div>
+                                {template.channel === 'email' ? (
+                                    <p className="font-semibold">
+                                        {preview(template.subject)}
+                                    </p>
+                                ) : null}
+                                <p className="text-muted-foreground text-sm whitespace-pre-wrap">
+                                    {preview(template.body)}
+                                </p>
+                            </div>
+                            <div className="flex flex-wrap items-start gap-2">
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    onClick={() => useAsStartingPoint(template)}
+                                >
+                                    New version
+                                </Button>
+                                {template.status === 'draft' ? (
+                                    <Form
+                                        {...activate.form([
+                                            organisation.slug,
+                                            template.id,
+                                        ])}
+                                    >
+                                        <Button>Activate</Button>
+                                    </Form>
+                                ) : null}
+                            </div>
+                        </CardContent>
+                    </Card>
+                ))}
+            </section>
+        </div>
+    );
+}
+
+MessageTemplatesIndex.layout = (props: {
+    currentOrganisation: { slug: string };
+}) => ({
+    breadcrumbs: [
+        {
+            title: 'Message templates',
+            href: index(props.currentOrganisation.slug),
+        },
+    ],
+});

--- a/resources/js/pages/organisation-configurations/index.tsx
+++ b/resources/js/pages/organisation-configurations/index.tsx
@@ -116,8 +116,7 @@ export default function OrganisationConfigurationsIndex({
                                         journey or intake defaults, and the form
                                         name (for example
                                         volunteer_registration) for public
-                                        forms. Message-template keys are your
-                                        choice.
+                                        forms.
                                     </small>
                                 </label>
                                 <label className="grid gap-1">

--- a/resources/js/pages/organisation-configurations/index.tsx
+++ b/resources/js/pages/organisation-configurations/index.tsx
@@ -23,16 +23,6 @@ const examples: Record<string, string> = {
         null,
         2,
     ),
-    message_template: JSON.stringify(
-        {
-            channel: 'sms',
-            subject: null,
-            body: 'Thanks {{ supporter_name }}',
-            journey_kind: 're_engagement',
-        },
-        null,
-        2,
-    ),
     supporter_journey: JSON.stringify(
         {
             default_kind: 're_engagement',

--- a/routes/web.php
+++ b/routes/web.php
@@ -18,6 +18,7 @@ use App\Http\Controllers\Organisations\ImpactChartExportController;
 use App\Http\Controllers\Organisations\ImpactReportExportController;
 use App\Http\Controllers\Organisations\IntakeRequestController;
 use App\Http\Controllers\Organisations\IntakeTransitionController;
+use App\Http\Controllers\Organisations\MessageTemplateController;
 use App\Http\Controllers\Organisations\OrganisationConfigurationController;
 use App\Http\Controllers\Organisations\OrganisationInvitationController;
 use App\Http\Controllers\Organisations\PartyAddressController;
@@ -162,6 +163,9 @@ Route::prefix('{current_organisation}')
         Route::get('organisation-configurations', [OrganisationConfigurationController::class, 'index'])->name('organisation-configurations.index');
         Route::post('organisation-configurations', [OrganisationConfigurationController::class, 'store'])->name('organisation-configurations.store');
         Route::post('organisation-configurations/{configuration}/activate', [OrganisationConfigurationController::class, 'activate'])->name('organisation-configurations.activate');
+        Route::get('message-templates', [MessageTemplateController::class, 'index'])->name('message-templates.index');
+        Route::post('message-templates', [MessageTemplateController::class, 'store'])->name('message-templates.store');
+        Route::post('message-templates/{messageTemplate}/activate', [MessageTemplateController::class, 'activate'])->name('message-templates.activate');
         Route::get('impact-snapshots', [PublishedImpactSnapshotController::class, 'index'])->name('impact-snapshots.index');
         Route::post('impact-snapshots', [PublishedImpactSnapshotController::class, 'store'])->name('impact-snapshots.store');
         Route::get('impact-snapshots/{snapshot}/download', [PublishedImpactSnapshotController::class, 'download'])->name('impact-snapshots.download');

--- a/tests/Feature/MessageTemplateEditorTest.php
+++ b/tests/Feature/MessageTemplateEditorTest.php
@@ -1,0 +1,161 @@
+<?php
+
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use App\Models\User;
+use App\OrganisationContext;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/** @return array{organisation: Organisation, administrator: User, officer: User} */
+function messageTemplateEditorFixture(): array
+{
+    $organisation = Organisation::factory()->active()->create();
+    $administrator = User::factory()->create();
+    $officer = User::factory()->create();
+    $organisation->memberships()->create(['user_id' => $administrator->id, 'role' => OrganisationRole::OrganisationAdministrator]);
+    $organisation->memberships()->create(['user_id' => $officer->id, 'role' => OrganisationRole::EngagementOfficer]);
+
+    return compact('organisation', 'administrator', 'officer');
+}
+
+it('creates previews activates and versions message templates without JSON', function () {
+    extract(messageTemplateEditorFixture());
+
+    $this->actingAs($administrator)
+        ->post(route('message-templates.store', $organisation), [
+            'name' => 'Donor re-engagement',
+            'channel' => 'sms',
+            'subject' => 'This stale email subject must not be stored',
+            'body' => 'Hello {{ supporter_name }}, thank you for your {{ donation_count }} gifts.',
+            'journey_kind' => 're_engagement',
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    $first = app(OrganisationContext::class)->run($organisation, fn (): OrganisationConfiguration => OrganisationConfiguration::query()
+        ->where('area', OrganisationConfigurationArea::MessageTemplate)
+        ->where('configuration_key', 'donor-re-engagement')
+        ->sole());
+    expect($first->version)->toBe(1)
+        ->and($first->status)->toBe(OrganisationConfigurationStatus::Draft)
+        ->and($first->definition)->toBe([
+            'channel' => 'sms',
+            'subject' => null,
+            'body' => 'Hello {{ supporter_name }}, thank you for your {{ donation_count }} gifts.',
+            'journey_kind' => 're_engagement',
+        ]);
+
+    $this->actingAs($administrator)
+        ->get(route('message-templates.index', $organisation))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('message-templates/index')
+            ->where('templates.0.name', 'Donor Re Engagement')
+            ->where('templates.0.version', 1)
+            ->where('templates.0.body', 'Hello {{ supporter_name }}, thank you for your {{ donation_count }} gifts.')
+            ->where('templates.0.status', 'draft'));
+
+    $this->actingAs($administrator)
+        ->post(route('message-templates.activate', [$organisation, $first]))
+        ->assertRedirect();
+    $this->actingAs($administrator)
+        ->post(route('message-templates.store', $organisation), [
+            'name' => 'Donor re-engagement',
+            'channel' => 'email',
+            'subject' => 'We miss you, {{ supporter_name }}',
+            'body' => 'You have supported us {{ donation_count }} times.',
+            'journey_kind' => 're_engagement',
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($first): void {
+        $versions = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::MessageTemplate)
+            ->where('configuration_key', 'donor-re-engagement')
+            ->orderBy('version')
+            ->get();
+        expect($versions)->toHaveCount(2)
+            ->and($versions[0]->refresh()->status)->toBe(OrganisationConfigurationStatus::Active)
+            ->and($versions[1]->version)->toBe(2)
+            ->and($versions[1]->supersedes_id)->toBe($first->id)
+            ->and(fn () => $versions[0]->update(['definition' => ['changed' => true]]))->toThrow(LogicException::class);
+    });
+});
+
+it('returns channel and variable validation errors on their fields', function () {
+    extract(messageTemplateEditorFixture());
+
+    $this->actingAs($administrator)
+        ->post(route('message-templates.store', $organisation), [
+            'name' => 'Invalid email',
+            'channel' => 'email',
+            'subject' => '',
+            'body' => 'Hello {{ secret_value }}',
+            'journey_kind' => 'general',
+        ])
+        ->assertSessionHasErrors(['subject', 'body']);
+
+    $this->actingAs($administrator)
+        ->post(route('message-templates.store', $organisation), [
+            'name' => 'Long SMS',
+            'channel' => 'sms',
+            'subject' => '',
+            'body' => str_repeat('x', 481),
+            'journey_kind' => 'general',
+        ])
+        ->assertSessionHasErrors('body');
+});
+
+it('removes message templates from the generic JSON workflow and enforces administrator access', function () {
+    extract(messageTemplateEditorFixture());
+
+    app(OrganisationContext::class)->run($organisation, fn () => OrganisationConfiguration::factory()->create([
+        'area' => OrganisationConfigurationArea::MessageTemplate,
+        'configuration_key' => 'historical_template',
+        'definition' => ['channel' => 'sms', 'subject' => null, 'body' => 'Historical body', 'journey_kind' => 'general'],
+    ]));
+
+    $this->actingAs($administrator)
+        ->get(route('organisation-configurations.index', $organisation))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('areas', fn ($areas) => collect($areas)->doesntContain('value', 'message_template'))
+            ->where('configurations', fn ($configurations) => collect($configurations)->doesntContain('area', 'message_template')));
+    $this->actingAs($administrator)
+        ->post(route('organisation-configurations.store', $organisation), [
+            'area' => 'message_template',
+            'configuration_key' => 'raw-json',
+            'definition_json' => json_encode(['channel' => 'sms'], JSON_THROW_ON_ERROR),
+        ])
+        ->assertSessionHasErrors('area');
+    $historicalTemplate = app(OrganisationContext::class)->run($organisation, fn (): OrganisationConfiguration => OrganisationConfiguration::query()
+        ->where('area', OrganisationConfigurationArea::MessageTemplate)
+        ->where('configuration_key', 'historical_template')
+        ->sole());
+    $this->actingAs($administrator)
+        ->post(route('organisation-configurations.activate', [$organisation, $historicalTemplate]))
+        ->assertNotFound();
+    $this->actingAs($administrator)
+        ->post(route('message-templates.store', $organisation), [
+            'template_key' => 'historical_template',
+            'name' => 'Historical Template',
+            'channel' => 'sms',
+            'subject' => '',
+            'body' => 'A new version of the historical body',
+            'journey_kind' => 'general',
+        ])
+        ->assertSessionHasNoErrors();
+    app(OrganisationContext::class)->run($organisation, function (): void {
+        expect(OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::MessageTemplate)
+            ->where('configuration_key', 'historical_template')
+            ->max('version'))->toBe(2);
+    });
+    $this->actingAs($officer)
+        ->get(route('message-templates.index', $organisation))
+        ->assertForbidden();
+});

--- a/tests/Feature/MessageTemplateEditorTest.php
+++ b/tests/Feature/MessageTemplateEditorTest.php
@@ -110,6 +110,36 @@ it('returns channel and variable validation errors on their fields', function ()
         ->assertSessionHasErrors('body');
 });
 
+it('only offers activation for the latest template draft', function () {
+    extract(messageTemplateEditorFixture());
+
+    foreach (['First draft', 'Second draft'] as $body) {
+        $this->actingAs($administrator)
+            ->post(route('message-templates.store', $organisation), [
+                'name' => 'Welcome email',
+                'channel' => 'email',
+                'subject' => 'Welcome',
+                'body' => $body,
+                'journey_kind' => 'general',
+            ])
+            ->assertSessionHasNoErrors();
+    }
+
+    $drafts = app(OrganisationContext::class)->run($organisation, fn () => OrganisationConfiguration::query()
+        ->where('area', OrganisationConfigurationArea::MessageTemplate)
+        ->where('configuration_key', 'welcome-email')
+        ->orderBy('version')
+        ->get());
+    $this->actingAs($administrator)
+        ->get(route('message-templates.index', $organisation))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('templates.0.canActivate', true)
+            ->where('templates.1.canActivate', false));
+    $this->actingAs($administrator)
+        ->post(route('message-templates.activate', [$organisation, $drafts->first()]))
+        ->assertStatus(409);
+});
+
 it('removes message templates from the generic JSON workflow and enforces administrator access', function () {
     extract(messageTemplateEditorFixture());
 


### PR DESCRIPTION
Closes #84

## Summary
- replace the Message Template JSON workflow with channel, subject, body, journey-kind, and live-preview controls
- preserve immutable draft/version/activation behavior and reuse existing template histories without a data migration
- validate supported variables and channel rules at both the form and configuration boundaries
- remove Message Templates from the generic JSON configuration endpoints and navigation

## Verification
- `php artisan test --compact`: 378 tests, 2547 assertions
- focused editor/journey tests: 7 tests, 93 assertions
- `composer types:check`
- `npm run types:check`
- `npm run test:run`: 9 tests
- `npm run build`
- `npm run check -- --fix`
- `vendor/bin/pint --dirty --format agent`

## Review
Reviewed against `codex/issue-83-program-intake-definitions`; fixed preservation of legacy underscore keys, stale SMS subjects, and the generic activation endpoint bypass. No remaining actionable findings.