### PR TITLE
Add purpose-built Intake Rules editor

### DIFF
--- a/app/Http/Controllers/Organisations/IntakeRulesController.php
+++ b/app/Http/Controllers/Organisations/IntakeRulesController.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Configuration\ActivateOrganisationConfiguration;
+use App\Actions\Configuration\CreateOrganisationConfiguration;
+use App\Enums\IntakeUrgency;
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\StoreIntakeRulesRequest;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class IntakeRulesController extends Controller
+{
+    private const FIXED_REQUIRED_FIELDS = ['party_uuid', 'program_id', 'source', 'narrative', 'presenting_needs'];
+
+    public function index(Organisation $currentOrganisation): Response
+    {
+        Gate::authorize('viewAny', [OrganisationConfiguration::class, $currentOrganisation]);
+        $rules = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::IntakeRules)
+            ->where('configuration_key', 'default')
+            ->latest('version')
+            ->get();
+
+        return Inertia::render('intake-rules/index', [
+            'rules' => $rules->map(fn (OrganisationConfiguration $rule): array => [
+                'id' => $rule->id,
+                'version' => $rule->version,
+                'status' => $rule->status->value,
+                'requiredFields' => $rule->definition['required_fields'],
+                'defaultUrgency' => $rule->definition['default_urgency'],
+                'restrictedAccessBypassAllowed' => $rule->definition['allow_restricted_access_bypass'],
+                'activatedAt' => $rule->activated_at?->toAtomString(),
+                'canActivate' => $rule->status === OrganisationConfigurationStatus::Draft
+                    && $rules->first()?->id === $rule->id,
+            ]),
+            'fixedRequiredFields' => collect(self::FIXED_REQUIRED_FIELDS)->map(fn (string $field): array => [
+                'value' => $field,
+                'label' => match ($field) {
+                    'party_uuid' => 'Party identity',
+                    'program_id' => 'Program',
+                    'source' => 'Referral source',
+                    'narrative' => 'Referral narrative',
+                    'presenting_needs' => 'Presenting needs',
+                    default => str($field)->replace('_', ' ')->title()->toString(),
+                },
+            ]),
+            'urgencies' => collect(IntakeUrgency::cases())->map(fn (IntakeUrgency $urgency): array => [
+                'value' => $urgency->value,
+                'label' => str($urgency->value)->title()->toString(),
+            ]),
+        ]);
+    }
+
+    public function store(StoreIntakeRulesRequest $request, Organisation $currentOrganisation, CreateOrganisationConfiguration $create): RedirectResponse
+    {
+        Gate::authorize('create', [OrganisationConfiguration::class, $currentOrganisation]);
+        $create->handle($currentOrganisation, OrganisationConfigurationArea::IntakeRules, 'default', [
+            'required_fields' => [...self::FIXED_REQUIRED_FIELDS, ...$request->array('required_contact_fields')],
+            'default_urgency' => $request->string('default_urgency')->toString(),
+            'allow_restricted_access_bypass' => false,
+        ], $request->user());
+
+        return back();
+    }
+
+    public function activate(Organisation $currentOrganisation, string $intakeRule, ActivateOrganisationConfiguration $activate): RedirectResponse
+    {
+        $rule = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::IntakeRules)
+            ->where('configuration_key', 'default')
+            ->findOrFail($intakeRule);
+        Gate::authorize('update', $rule);
+        $latestId = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::IntakeRules)
+            ->where('configuration_key', 'default')
+            ->latest('version')
+            ->value('id');
+        abort_unless($rule->status === OrganisationConfigurationStatus::Draft && $rule->id === $latestId, 409);
+        $activate->handle($rule, request()->user());
+
+        return back();
+    }
+}

--- a/app/Http/Controllers/Organisations/OrganisationConfigurationController.php
+++ b/app/Http/Controllers/Organisations/OrganisationConfigurationController.php
@@ -23,7 +23,7 @@ class OrganisationConfigurationController extends Controller
         Gate::authorize('viewAny', [OrganisationConfiguration::class, $currentOrganisation]);
 
         return Inertia::render('organisation-configurations/index', [
-            'configurations' => OrganisationConfiguration::query()->whereNotIn('area', [OrganisationConfigurationArea::MessageTemplate->value, OrganisationConfigurationArea::SupporterJourney->value])->latest()->get()->map(fn (OrganisationConfiguration $configuration): array => [
+            'configurations' => OrganisationConfiguration::query()->whereNotIn('area', [OrganisationConfigurationArea::MessageTemplate->value, OrganisationConfigurationArea::SupporterJourney->value, OrganisationConfigurationArea::IntakeRules->value])->latest()->get()->map(fn (OrganisationConfiguration $configuration): array => [
                 'id' => $configuration->id,
                 'area' => $configuration->area->value,
                 'key' => $configuration->configuration_key,
@@ -33,7 +33,7 @@ class OrganisationConfigurationController extends Controller
                 'activatedAt' => $configuration->activated_at?->toAtomString(),
             ]),
             'areas' => collect(OrganisationConfigurationArea::cases())
-                ->reject(fn (OrganisationConfigurationArea $area): bool => in_array($area, [OrganisationConfigurationArea::MessageTemplate, OrganisationConfigurationArea::SupporterJourney], true))
+                ->reject(fn (OrganisationConfigurationArea $area): bool => in_array($area, [OrganisationConfigurationArea::MessageTemplate, OrganisationConfigurationArea::SupporterJourney, OrganisationConfigurationArea::IntakeRules], true))
                 ->map(fn (OrganisationConfigurationArea $area): array => ['value' => $area->value, 'label' => $area->label()])
                 ->values(),
         ]);
@@ -59,7 +59,7 @@ class OrganisationConfigurationController extends Controller
     public function activate(Organisation $currentOrganisation, string $configuration, ActivateOrganisationConfiguration $activate): RedirectResponse
     {
         $version = OrganisationConfiguration::query()->findOrFail($configuration);
-        abort_if(in_array($version->area, [OrganisationConfigurationArea::MessageTemplate, OrganisationConfigurationArea::SupporterJourney], true), 404);
+        abort_if(in_array($version->area, [OrganisationConfigurationArea::MessageTemplate, OrganisationConfigurationArea::SupporterJourney, OrganisationConfigurationArea::IntakeRules], true), 404);
         Gate::authorize('update', $version);
         $activate->handle($version, request()->user());
 

--- a/app/Http/Requests/Organisations/StoreIntakeRulesRequest.php
+++ b/app/Http/Requests/Organisations/StoreIntakeRulesRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Enums\IntakeUrgency;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreIntakeRulesRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'required_contact_fields' => ['present', 'array', 'max:2'],
+            'required_contact_fields.*' => ['string', Rule::in(['email', 'telephone']), 'distinct'],
+            'default_urgency' => ['required', Rule::enum(IntakeUrgency::class)],
+            'allow_restricted_access_bypass' => ['required', 'declined'],
+        ];
+    }
+}

--- a/app/Http/Requests/Organisations/StoreOrganisationConfigurationRequest.php
+++ b/app/Http/Requests/Organisations/StoreOrganisationConfigurationRequest.php
@@ -18,7 +18,7 @@ class StoreOrganisationConfigurationRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'area' => ['required', Rule::enum(OrganisationConfigurationArea::class), Rule::notIn([OrganisationConfigurationArea::MessageTemplate->value, OrganisationConfigurationArea::SupporterJourney->value])],
+            'area' => ['required', Rule::enum(OrganisationConfigurationArea::class), Rule::notIn([OrganisationConfigurationArea::MessageTemplate->value, OrganisationConfigurationArea::SupporterJourney->value, OrganisationConfigurationArea::IntakeRules->value])],
             'configuration_key' => ['required', 'string', 'alpha_dash:ascii', 'max:100'],
             'definition_json' => ['required', 'string', 'json', 'max:20000'],
         ];

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -35,6 +35,7 @@ import { index as auditIndex } from '@/routes/audit';
 import { index as communityEngagementIndex } from '@/routes/community-engagement';
 import { index as donationsIndex } from '@/routes/donations';
 import { index as intakesIndex } from '@/routes/intakes';
+import { index as intakeRulesIndex } from '@/routes/intake-rules';
 import { index as messageTemplatesIndex } from '@/routes/message-templates';
 import { index as configurationsIndex } from '@/routes/organisation-configurations';
 import { index as impactSnapshotsIndex } from '@/routes/impact-snapshots';
@@ -154,6 +155,13 @@ export function AppSidebar() {
                           page.props.currentOrganisation.slug,
                       ),
                       icon: SlidersHorizontal,
+                  },
+                  {
+                      title: 'Intake rules',
+                      href: intakeRulesIndex(
+                          page.props.currentOrganisation.slug,
+                      ),
+                      icon: ClipboardList,
                   },
                   {
                       title: 'Organisation configuration',

--- a/resources/js/pages/intake-rules/index.tsx
+++ b/resources/js/pages/intake-rules/index.tsx
@@ -1,0 +1,274 @@
+import { Form, Head, useForm, usePage } from '@inertiajs/react';
+import type { FormEvent } from 'react';
+import Heading from '@/components/heading';
+import InputError from '@/components/input-error';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { activate, index, store } from '@/routes/intake-rules';
+
+type IntakeRule = {
+    id: string;
+    version: number;
+    status: string;
+    requiredFields: string[];
+    defaultUrgency: string;
+    restrictedAccessBypassAllowed: boolean;
+    activatedAt: string | null;
+    canActivate: boolean;
+};
+
+type Option = { value: string; label: string };
+
+const contactFields: Option[] = [
+    { value: 'email', label: 'Email address' },
+    { value: 'telephone', label: 'Telephone number' },
+];
+
+export default function IntakeRulesIndex({
+    rules,
+    fixedRequiredFields,
+    urgencies,
+}: {
+    rules: IntakeRule[];
+    fixedRequiredFields: Option[];
+    urgencies: Option[];
+}) {
+    const organisation = usePage().props.currentOrganisation!;
+    const form = useForm({
+        required_contact_fields: [] as string[],
+        default_urgency: 'routine',
+        allow_restricted_access_bypass: false,
+    });
+
+    const submit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        form.post(store.url(organisation.slug), {
+            preserveScroll: true,
+            onSuccess: () => form.reset(),
+        });
+    };
+
+    const toggleContact = (field: string, checked: boolean) => {
+        form.setData(
+            'required_contact_fields',
+            checked
+                ? [...form.data.required_contact_fields, field]
+                : form.data.required_contact_fields.filter(
+                      (candidate) => candidate !== field,
+                  ),
+        );
+    };
+
+    const useAsStartingPoint = (rule: IntakeRule) => {
+        form.setData({
+            required_contact_fields: contactFields
+                .map((field) => field.value)
+                .filter((field) => rule.requiredFields.includes(field)),
+            default_urgency: rule.defaultUrgency,
+            allow_restricted_access_bypass: false,
+        });
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+
+    return (
+        <div className="space-y-6 p-4">
+            <Head title="Intake rules" />
+            <Heading
+                title="Intake rules"
+                description="Choose organisation-wide intake defaults while keeping identity, service context, and restricted-access protections fixed."
+            />
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Create an intake rules draft</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <form
+                        className="grid gap-6 lg:grid-cols-2"
+                        onSubmit={submit}
+                    >
+                        <div className="space-y-5">
+                            <fieldset className="space-y-3">
+                                <legend className="font-medium">
+                                    Required contact details
+                                </legend>
+                                <p className="text-muted-foreground text-sm">
+                                    Choose which contact details staff must
+                                    record before an intake can be accepted.
+                                </p>
+                                {contactFields.map((field) => (
+                                    <label
+                                        key={field.value}
+                                        className="flex items-center gap-2 rounded-lg border p-3"
+                                    >
+                                        <input
+                                            type="checkbox"
+                                            checked={form.data.required_contact_fields.includes(
+                                                field.value,
+                                            )}
+                                            onChange={(event) =>
+                                                toggleContact(
+                                                    field.value,
+                                                    event.target.checked,
+                                                )
+                                            }
+                                        />
+                                        {field.label}
+                                    </label>
+                                ))}
+                                <InputError
+                                    message={
+                                        form.errors.required_contact_fields
+                                    }
+                                />
+                            </fieldset>
+
+                            <div className="grid gap-2">
+                                <Label htmlFor="default-urgency">
+                                    Default urgency
+                                </Label>
+                                <select
+                                    id="default-urgency"
+                                    className="h-9 rounded-md border bg-transparent px-3"
+                                    value={form.data.default_urgency}
+                                    onChange={(event) =>
+                                        form.setData(
+                                            'default_urgency',
+                                            event.target.value,
+                                        )
+                                    }
+                                >
+                                    {urgencies.map((urgency) => (
+                                        <option
+                                            key={urgency.value}
+                                            value={urgency.value}
+                                        >
+                                            {urgency.label}
+                                        </option>
+                                    ))}
+                                </select>
+                                <InputError
+                                    message={form.errors.default_urgency}
+                                />
+                            </div>
+
+                            <Button disabled={form.processing}>
+                                {form.processing
+                                    ? 'Creating draft…'
+                                    : 'Create intake rules draft'}
+                            </Button>
+                        </div>
+
+                        <div className="bg-muted/40 space-y-4 rounded-xl border p-5">
+                            <strong>Fixed safeguards and context</strong>
+                            <div className="grid gap-2 sm:grid-cols-2">
+                                {fixedRequiredFields.map((field) => (
+                                    <div
+                                        key={field.value}
+                                        className="bg-background rounded-lg border p-3 text-sm"
+                                    >
+                                        <span aria-hidden="true">✓ </span>
+                                        {field.label} required
+                                    </div>
+                                ))}
+                            </div>
+                            <div className="bg-background rounded-lg border p-4">
+                                <div className="flex items-center gap-2">
+                                    <input
+                                        type="checkbox"
+                                        checked={false}
+                                        disabled
+                                        readOnly
+                                    />
+                                    <span className="font-medium">
+                                        Restricted-access bypass disabled
+                                    </span>
+                                </div>
+                                <p className="text-muted-foreground mt-2 text-sm">
+                                    Intake settings cannot weaken restricted
+                                    case access or staff authorization.
+                                </p>
+                            </div>
+                        </div>
+                    </form>
+                </CardContent>
+            </Card>
+
+            <section className="space-y-3">
+                <h2 className="text-xl font-semibold">Version history</h2>
+                {rules.length === 0 ? (
+                    <p className="text-muted-foreground text-sm">
+                        No intake rules versions yet. Platform defaults remain
+                        active until a draft is activated.
+                    </p>
+                ) : null}
+                {rules.map((rule) => (
+                    <Card key={rule.id}>
+                        <CardContent className="grid gap-4 pt-6 lg:grid-cols-[1fr_auto]">
+                            <div className="space-y-3">
+                                <div className="flex flex-wrap items-center gap-2">
+                                    <strong>
+                                        Intake rules · v{rule.version}
+                                    </strong>
+                                    <Badge>{rule.status}</Badge>
+                                    <Badge variant="outline">
+                                        {rule.defaultUrgency} urgency
+                                    </Badge>
+                                </div>
+                                <p className="text-sm">
+                                    Required contact details:{' '}
+                                    {contactFields
+                                        .filter((field) =>
+                                            rule.requiredFields.includes(
+                                                field.value,
+                                            ),
+                                        )
+                                        .map((field) => field.label)
+                                        .join(', ') || 'None'}
+                                </p>
+                                <p className="text-muted-foreground text-sm">
+                                    Party identity, program, referral source,
+                                    narrative, and presenting needs remain
+                                    required. Restricted-access bypass remains
+                                    disabled.
+                                </p>
+                            </div>
+                            <div className="flex flex-wrap items-start gap-2">
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    onClick={() => useAsStartingPoint(rule)}
+                                >
+                                    New version
+                                </Button>
+                                {rule.canActivate ? (
+                                    <Form
+                                        {...activate.form([
+                                            organisation.slug,
+                                            rule.id,
+                                        ])}
+                                    >
+                                        <Button>Activate</Button>
+                                    </Form>
+                                ) : null}
+                            </div>
+                        </CardContent>
+                    </Card>
+                ))}
+            </section>
+        </div>
+    );
+}
+
+IntakeRulesIndex.layout = (props: {
+    currentOrganisation: { slug: string };
+}) => ({
+    breadcrumbs: [
+        {
+            title: 'Intake rules',
+            href: index(props.currentOrganisation.slug),
+        },
+    ],
+});

--- a/resources/js/pages/organisation-configurations/index.tsx
+++ b/resources/js/pages/organisation-configurations/index.tsx
@@ -23,15 +23,6 @@ const examples: Record<string, string> = {
         null,
         2,
     ),
-    intake_rules: JSON.stringify(
-        {
-            required_fields: ['party_uuid', 'email', 'presenting_needs'],
-            default_urgency: 'routine',
-            allow_restricted_access_bypass: false,
-        },
-        null,
-        2,
-    ),
     reporting: JSON.stringify(
         {
             public_metric_ids: ['engagement.event_attendance'],
@@ -101,10 +92,10 @@ export default function OrganisationConfigurationsIndex({
                                         message={errors.configuration_key}
                                     />
                                     <small className="text-muted-foreground">
-                                        Use impact for reporting, default for
-                                        intake defaults, and the form name (for
-                                        example volunteer_registration) for
-                                        public forms.
+                                        Use impact for reporting and the form
+                                        name (for example
+                                        volunteer_registration) for public
+                                        forms.
                                     </small>
                                 </label>
                                 <label className="grid gap-1">

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,6 +17,7 @@ use App\Http\Controllers\Organisations\DonationController;
 use App\Http\Controllers\Organisations\ImpactChartExportController;
 use App\Http\Controllers\Organisations\ImpactReportExportController;
 use App\Http\Controllers\Organisations\IntakeRequestController;
+use App\Http\Controllers\Organisations\IntakeRulesController;
 use App\Http\Controllers\Organisations\IntakeTransitionController;
 use App\Http\Controllers\Organisations\MessageTemplateController;
 use App\Http\Controllers\Organisations\OrganisationConfigurationController;
@@ -170,6 +171,9 @@ Route::prefix('{current_organisation}')
         Route::get('supporter-journey-policy', [SupporterJourneyPolicyController::class, 'index'])->name('supporter-journey-policy.index');
         Route::post('supporter-journey-policy', [SupporterJourneyPolicyController::class, 'store'])->name('supporter-journey-policy.store');
         Route::post('supporter-journey-policy/{supporterJourneyPolicy}/activate', [SupporterJourneyPolicyController::class, 'activate'])->name('supporter-journey-policy.activate');
+        Route::get('intake-rules', [IntakeRulesController::class, 'index'])->name('intake-rules.index');
+        Route::post('intake-rules', [IntakeRulesController::class, 'store'])->name('intake-rules.store');
+        Route::post('intake-rules/{intakeRule}/activate', [IntakeRulesController::class, 'activate'])->name('intake-rules.activate');
         Route::get('impact-snapshots', [PublishedImpactSnapshotController::class, 'index'])->name('impact-snapshots.index');
         Route::post('impact-snapshots', [PublishedImpactSnapshotController::class, 'store'])->name('impact-snapshots.store');
         Route::get('impact-snapshots/{snapshot}/download', [PublishedImpactSnapshotController::class, 'download'])->name('impact-snapshots.download');

--- a/tests/Feature/IntakeRulesEditorTest.php
+++ b/tests/Feature/IntakeRulesEditorTest.php
@@ -1,0 +1,156 @@
+<?php
+
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use App\Models\User;
+use App\OrganisationContext;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/** @return array{organisation: Organisation, administrator: User, officer: User} */
+function intakeRulesEditorFixture(): array
+{
+    $organisation = Organisation::factory()->active()->create();
+    $administrator = User::factory()->create();
+    $officer = User::factory()->create();
+    $organisation->memberships()->create(['user_id' => $administrator->id, 'role' => OrganisationRole::OrganisationAdministrator]);
+    $organisation->memberships()->create(['user_id' => $officer->id, 'role' => OrganisationRole::CaseWorker]);
+
+    return compact('organisation', 'administrator', 'officer');
+}
+
+it('creates previews and activates typed intake rules with fixed safeguards', function () {
+    extract(intakeRulesEditorFixture());
+
+    $this->actingAs($administrator)
+        ->post(route('intake-rules.store', $organisation), [
+            'required_contact_fields' => ['email'],
+            'default_urgency' => 'priority',
+            'allow_restricted_access_bypass' => false,
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    $rule = app(OrganisationContext::class)->run($organisation, fn (): OrganisationConfiguration => OrganisationConfiguration::query()
+        ->where('area', OrganisationConfigurationArea::IntakeRules)
+        ->where('configuration_key', 'default')
+        ->sole());
+    expect($rule->definition)->toMatchArray([
+        'required_fields' => ['party_uuid', 'program_id', 'source', 'narrative', 'presenting_needs', 'email'],
+        'default_urgency' => 'priority',
+        'allow_restricted_access_bypass' => false,
+    ])->and($rule->status)->toBe(OrganisationConfigurationStatus::Draft);
+
+    $this->actingAs($administrator)
+        ->get(route('intake-rules.index', $organisation))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('intake-rules/index')
+            ->where('rules.0.defaultUrgency', 'priority')
+            ->where('rules.0.requiredFields.5', 'email')
+            ->where('rules.0.canActivate', true));
+    $this->actingAs($administrator)
+        ->post(route('intake-rules.activate', [$organisation, $rule]))
+        ->assertRedirect();
+    expect($rule->refresh()->status)->toBe(OrganisationConfigurationStatus::Active);
+});
+
+it('keeps legacy rules behavior and immutable history without a data migration', function () {
+    extract(intakeRulesEditorFixture());
+
+    $legacy = app(OrganisationContext::class)->run($organisation, fn (): OrganisationConfiguration => OrganisationConfiguration::factory()->create([
+        'area' => OrganisationConfigurationArea::IntakeRules,
+        'configuration_key' => 'default',
+        'definition' => [
+            'required_fields' => ['party_uuid', 'telephone', 'presenting_needs'],
+            'default_urgency' => 'urgent',
+            'allow_restricted_access_bypass' => false,
+        ],
+    ]));
+
+    $this->actingAs($administrator)
+        ->get(route('intake-rules.index', $organisation))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('rules.0.requiredFields', ['party_uuid', 'telephone', 'presenting_needs'])
+            ->where('rules.0.defaultUrgency', 'urgent'));
+    $this->actingAs($administrator)
+        ->post(route('intake-rules.store', $organisation), [
+            'required_contact_fields' => ['telephone'],
+            'default_urgency' => 'urgent',
+            'allow_restricted_access_bypass' => false,
+        ])
+        ->assertSessionHasNoErrors();
+
+    app(OrganisationContext::class)->run($organisation, function () use ($legacy): void {
+        $versions = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::IntakeRules)
+            ->where('configuration_key', 'default')
+            ->orderBy('version')
+            ->get();
+        expect($versions)->toHaveCount(2)
+            ->and($versions[0]->status)->toBe(OrganisationConfigurationStatus::Active)
+            ->and($versions[1]->status)->toBe(OrganisationConfigurationStatus::Draft)
+            ->and($versions[1]->supersedes_id)->toBe($legacy->id)
+            ->and($versions[1]->definition['default_urgency'])->toBe($legacy->definition['default_urgency'])
+            ->and(fn () => $versions[0]->update(['definition' => ['changed' => true]]))->toThrow(LogicException::class);
+    });
+});
+
+it('validates safeguards and removes intake rules from the generic JSON workflow', function () {
+    extract(intakeRulesEditorFixture());
+
+    $this->actingAs($administrator)
+        ->post(route('intake-rules.store', $organisation), [
+            'required_contact_fields' => ['postal_address'],
+            'default_urgency' => 'emergency',
+            'allow_restricted_access_bypass' => true,
+        ])
+        ->assertSessionHasErrors(['required_contact_fields.0', 'default_urgency', 'allow_restricted_access_bypass']);
+    $this->actingAs($administrator)
+        ->get(route('organisation-configurations.index', $organisation))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('areas', fn ($areas) => collect($areas)->doesntContain('value', 'intake_rules'))
+            ->where('configurations', fn ($configurations) => collect($configurations)->doesntContain('area', 'intake_rules')));
+    $this->actingAs($administrator)
+        ->post(route('organisation-configurations.store', $organisation), [
+            'area' => 'intake_rules',
+            'configuration_key' => 'default',
+            'definition_json' => '{}',
+        ])
+        ->assertSessionHasErrors('area');
+    $this->actingAs($officer)
+        ->get(route('intake-rules.index', $organisation))
+        ->assertForbidden();
+});
+
+it('only permits activation of the latest intake rules draft', function () {
+    extract(intakeRulesEditorFixture());
+
+    foreach (['routine', 'priority'] as $urgency) {
+        $this->actingAs($administrator)
+            ->post(route('intake-rules.store', $organisation), [
+                'required_contact_fields' => [],
+                'default_urgency' => $urgency,
+                'allow_restricted_access_bypass' => false,
+            ])
+            ->assertSessionHasNoErrors();
+    }
+    $drafts = app(OrganisationContext::class)->run($organisation, fn () => OrganisationConfiguration::query()
+        ->where('area', OrganisationConfigurationArea::IntakeRules)
+        ->where('configuration_key', 'default')
+        ->orderBy('version')
+        ->get());
+    $this->actingAs($administrator)
+        ->get(route('intake-rules.index', $organisation))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('rules.0.canActivate', true)
+            ->where('rules.1.canActivate', false));
+    $this->actingAs($administrator)
+        ->post(route('organisation-configurations.activate', [$organisation, $drafts->last()]))
+        ->assertNotFound();
+    $this->actingAs($administrator)
+        ->post(route('intake-rules.activate', [$organisation, $drafts->first()]))
+        ->assertStatus(409);
+});


### PR DESCRIPTION
Closes #86

## Summary
- replace Intake Rules JSON with required-contact and default-urgency controls
- make Party identity, Program, referral source, narrative, presenting needs, and restricted-access protections visibly fixed
- preserve legacy active/history definitions without changing intake behavior and keep immutable draft/version activation
- remove Intake Rules from generic JSON creation and activation

## Verification
- `php artisan test --compact`: 387 tests, 2741 assertions
- focused editor tests: 4 tests, 73 assertions
- `composer types:check`
- `npm run types:check`
- `npm test`: 9 tests
- `npm run build`
- `npm run check -- --fix`
- `vendor/bin/pint --dirty --format agent`

## Review
Reviewed against `codex/issue-85-supporter-journey-policy-editor`; confirmed active-rule consumption, aligned visible fixed requirements with the intake boundary, blocked generic endpoints, and enforced latest-draft-only activation. No remaining actionable findings.