### PR TITLE
Add purpose-built public form editor

### DIFF
--- a/app/Actions/Configuration/PublicFormDefinition.php
+++ b/app/Actions/Configuration/PublicFormDefinition.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace App\Actions\Configuration;
+
+final class PublicFormDefinition
+{
+    /**
+     * @return array<string, array{label: string, description: string, fields: list<array{key: string, label: string, type: string, fixed_required: bool}>}>
+     */
+    public static function catalogue(): array
+    {
+        return [
+            'event_registration' => [
+                'label' => 'Event registration',
+                'description' => 'Collect the identity needed to reserve a place at a community event.',
+                'fields' => [
+                    ['key' => 'name', 'label' => 'Name', 'type' => 'text', 'fixed_required' => true],
+                    ['key' => 'email', 'label' => 'Email address', 'type' => 'email', 'fixed_required' => true],
+                ],
+            ],
+            'volunteer_registration' => [
+                'label' => 'Volunteer application',
+                'description' => 'Collect volunteer interests and availability for an opportunity.',
+                'fields' => [
+                    ['key' => 'name', 'label' => 'Name', 'type' => 'text', 'fixed_required' => true],
+                    ['key' => 'email', 'label' => 'Email address', 'type' => 'email', 'fixed_required' => true],
+                    ['key' => 'interests', 'label' => 'Interests', 'type' => 'multiselect', 'fixed_required' => false],
+                    ['key' => 'availability', 'label' => 'Availability', 'type' => 'multiselect', 'fixed_required' => true],
+                ],
+            ],
+            'in_kind_offer' => [
+                'label' => 'In-kind offer',
+                'description' => 'Collect the details needed to assess a donated item or service.',
+                'fields' => [
+                    ['key' => 'name', 'label' => 'Name', 'type' => 'text', 'fixed_required' => true],
+                    ['key' => 'email', 'label' => 'Email address', 'type' => 'email', 'fixed_required' => true],
+                    ['key' => 'category', 'label' => 'Category', 'type' => 'text', 'fixed_required' => true],
+                    ['key' => 'description', 'label' => 'Description', 'type' => 'textarea', 'fixed_required' => true],
+                    ['key' => 'quantity', 'label' => 'Quantity', 'type' => 'number', 'fixed_required' => true],
+                    ['key' => 'unit', 'label' => 'Unit', 'type' => 'text', 'fixed_required' => true],
+                    ['key' => 'estimated_value_minor', 'label' => 'Estimated value', 'type' => 'money', 'fixed_required' => false],
+                    ['key' => 'currency', 'label' => 'Currency', 'type' => 'currency', 'fixed_required' => false],
+                    ['key' => 'condition', 'label' => 'Condition', 'type' => 'text', 'fixed_required' => true],
+                ],
+            ],
+            'supporter_profile' => [
+                'label' => 'Supporter profile',
+                'description' => 'Collect the supporter contact details used by the self-service portal.',
+                'fields' => [
+                    ['key' => 'name', 'label' => 'Name', 'type' => 'text', 'fixed_required' => true],
+                    ['key' => 'email', 'label' => 'Email address', 'type' => 'email', 'fixed_required' => true],
+                    ['key' => 'telephone', 'label' => 'Telephone number', 'type' => 'tel', 'fixed_required' => false],
+                ],
+            ],
+        ];
+    }
+
+    /** @return list<string> */
+    public static function purposes(): array
+    {
+        return array_keys(self::catalogue());
+    }
+
+    /** @return list<array{key: string, label: string, type: string, fixed_required: bool}> */
+    public static function fields(string $purpose): array
+    {
+        return self::catalogue()[$purpose]['fields'] ?? [];
+    }
+
+    /** @return list<string> */
+    public static function fieldKeys(string $purpose): array
+    {
+        return array_column(self::fields($purpose), 'key');
+    }
+
+    /** @return list<string> */
+    public static function fixedRequiredKeys(string $purpose): array
+    {
+        return array_column(array_filter(
+            self::fields($purpose),
+            fn (array $field): bool => $field['fixed_required'],
+        ), 'key');
+    }
+
+    /**
+     * @param  array<string, mixed>  $definition
+     * @return list<array{key: string, label: string, type: string, required: bool, fixedRequired: bool}>
+     */
+    public static function displayFields(string $purpose, array $definition): array
+    {
+        $catalogue = [];
+        foreach (self::fields($purpose) as $field) {
+            $catalogue[$field['key']] = $field;
+        }
+        $required = array_values(array_filter(
+            is_array($definition['required_fields'] ?? null) ? $definition['required_fields'] : [],
+            is_string(...),
+        ));
+        $orderedKeys = [];
+        $storedFields = is_array($definition['fields'] ?? null) ? $definition['fields'] : [];
+        foreach ($storedFields as $storedField) {
+            if (is_array($storedField) && is_string($storedField['key'] ?? null) && isset($catalogue[$storedField['key']])) {
+                $orderedKeys[] = $storedField['key'];
+            }
+        }
+        if ($orderedKeys === []) {
+            $orderedKeys = array_keys($catalogue);
+        }
+
+        $displayFields = [];
+        foreach ($orderedKeys as $key) {
+            $field = $catalogue[$key];
+            $displayFields[] = [
+                'key' => $field['key'],
+                'label' => $field['label'],
+                'type' => $field['type'],
+                'required' => $field['fixed_required'] || in_array($key, $required, true),
+                'fixedRequired' => $field['fixed_required'],
+            ];
+        }
+
+        return $displayFields;
+    }
+
+    /**
+     * @param  list<string>  $orderedKeys
+     * @param  list<string>  $requiredKeys
+     * @return array{form: string, required_fields: list<string>, fields: list<array{key: string, type: string, required: bool}>}
+     */
+    public static function build(string $purpose, array $orderedKeys, array $requiredKeys): array
+    {
+        $catalogue = [];
+        foreach (self::fields($purpose) as $field) {
+            $catalogue[$field['key']] = $field;
+        }
+        $required = array_values(array_unique([...self::fixedRequiredKeys($purpose), ...$requiredKeys]));
+        $fields = [];
+        $orderedRequired = [];
+        foreach ($orderedKeys as $key) {
+            $isRequired = in_array($key, $required, true);
+            if ($isRequired) {
+                $orderedRequired[] = $key;
+            }
+            $fields[] = ['key' => $key, 'type' => $catalogue[$key]['type'], 'required' => $isRequired];
+        }
+
+        return [
+            'form' => $purpose,
+            'required_fields' => $orderedRequired,
+            'fields' => $fields,
+        ];
+    }
+}

--- a/app/Actions/Configuration/ValidateConfigurationDefinition.php
+++ b/app/Actions/Configuration/ValidateConfigurationDefinition.php
@@ -19,7 +19,15 @@ final class ValidateConfigurationDefinition
     public function handle(OrganisationConfigurationArea $area, array $definition): array
     {
         $rules = match ($area) {
-            OrganisationConfigurationArea::PublicForm => ['form' => ['required', Rule::in(['event_registration', 'volunteer_registration', 'in_kind_offer', 'supporter_profile'])], 'required_fields' => ['required', 'array', 'min:1'], 'required_fields.*' => ['required', 'string', 'distinct']],
+            OrganisationConfigurationArea::PublicForm => [
+                'form' => ['required', Rule::in(PublicFormDefinition::purposes())],
+                'required_fields' => ['required', 'array', 'min:1'],
+                'required_fields.*' => ['required', 'string', 'distinct'],
+                'fields' => ['sometimes', 'array', 'min:1'],
+                'fields.*.key' => ['required', 'string', 'distinct'],
+                'fields.*.type' => ['required', 'string'],
+                'fields.*.required' => ['required', 'boolean'],
+            ],
             OrganisationConfigurationArea::MessageTemplate => ['channel' => ['required', Rule::in(['email', 'sms'])], 'subject' => ['nullable', 'string', 'max:160'], 'body' => ['required', 'string', 'max:4000'], 'journey_kind' => ['required', Rule::enum(SupporterJourneyKind::class)]],
             OrganisationConfigurationArea::SupporterJourney => ['default_kind' => ['required', Rule::enum(SupporterJourneyKind::class)], 'default_channel' => ['required', Rule::in(['email', 'sms'])], 'default_message_template_id' => ['nullable', 'uuid'], 'require_approval' => ['required', 'accepted'], 'dispatch_rechecks_consent' => ['required', 'accepted'], 'frequency_cap_days' => ['required', 'integer', 'min:'.config('engagement.frequency_cap_days'), 'max:365']],
             OrganisationConfigurationArea::IntakeRules => ['required_fields' => ['required', 'array', 'min:2'], 'required_fields.*' => ['required', Rule::in(['party_uuid', 'email', 'telephone', 'source', 'narrative', 'presenting_needs', 'program_id']), 'distinct'], 'default_urgency' => ['required', Rule::in(['routine', 'priority', 'urgent'])], 'allow_restricted_access_bypass' => ['required', 'declined']],
@@ -36,15 +44,34 @@ final class ValidateConfigurationDefinition
                 if ($required->intersect(['organisation_id', 'party_id', 'status', 'consent_decision'])->isNotEmpty()) {
                     $validator->errors()->add('required_fields', 'System and consent safeguards cannot be configured as form fields.');
                 }
-                $allowed = match ($definition['form'] ?? null) {
-                    'event_registration' => ['name', 'email'],
-                    'volunteer_registration' => ['name', 'email', 'interests', 'availability'],
-                    'in_kind_offer' => ['name', 'email', 'category', 'description', 'quantity', 'unit', 'estimated_value_minor', 'currency', 'condition'],
-                    'supporter_profile' => ['name', 'email', 'telephone'],
-                    default => [],
-                };
+                $purpose = is_string($definition['form'] ?? null) ? $definition['form'] : '';
+                $allowed = PublicFormDefinition::fieldKeys($purpose);
                 if ($required->diff($allowed)->isNotEmpty()) {
                     $validator->errors()->add('required_fields', 'The form contains unsupported fields.');
+                }
+                if (array_key_exists('fields', $definition) && is_array($definition['fields'])) {
+                    $fields = collect($definition['fields']);
+                    $fieldKeys = $fields->pluck('key');
+                    if ($fieldKeys->count() !== count($allowed) || $fieldKeys->diff($allowed)->isNotEmpty() || collect($allowed)->diff($fieldKeys)->isNotEmpty()) {
+                        $validator->errors()->add('fields', 'The form must contain every supported field exactly once.');
+                    }
+                    $catalogue = collect(PublicFormDefinition::fields($purpose))->keyBy('key');
+                    foreach ($fields as $index => $field) {
+                        if (! is_array($field) || ! is_string($field['key'] ?? null) || ! $catalogue->has($field['key'])) {
+                            continue;
+                        }
+                        $catalogueField = $catalogue->get($field['key']);
+                        if (($field['type'] ?? null) !== $catalogueField['type']) {
+                            $validator->errors()->add("fields.{$index}.type", 'The field type cannot be changed.');
+                        }
+                        $isRequired = filter_var($field['required'] ?? false, FILTER_VALIDATE_BOOL);
+                        if ($catalogueField['fixed_required'] && ! $isRequired) {
+                            $validator->errors()->add("fields.{$index}.required", 'This field must remain required.');
+                        }
+                        if ($isRequired !== $required->contains($field['key'])) {
+                            $validator->errors()->add("fields.{$index}.required", 'The required state must match the form definition.');
+                        }
+                    }
                 }
             }
             if ($area === OrganisationConfigurationArea::MessageTemplate && ($definition['channel'] ?? null) === 'sms' && mb_strlen((string) ($definition['body'] ?? '')) > 480) {

--- a/app/Http/Controllers/Organisations/OrganisationConfigurationController.php
+++ b/app/Http/Controllers/Organisations/OrganisationConfigurationController.php
@@ -23,7 +23,7 @@ class OrganisationConfigurationController extends Controller
         Gate::authorize('viewAny', [OrganisationConfiguration::class, $currentOrganisation]);
 
         return Inertia::render('organisation-configurations/index', [
-            'configurations' => OrganisationConfiguration::query()->whereNotIn('area', [OrganisationConfigurationArea::MessageTemplate->value, OrganisationConfigurationArea::SupporterJourney->value, OrganisationConfigurationArea::IntakeRules->value])->latest()->get()->map(fn (OrganisationConfiguration $configuration): array => [
+            'configurations' => OrganisationConfiguration::query()->whereNotIn('area', [OrganisationConfigurationArea::PublicForm->value, OrganisationConfigurationArea::MessageTemplate->value, OrganisationConfigurationArea::SupporterJourney->value, OrganisationConfigurationArea::IntakeRules->value])->latest()->get()->map(fn (OrganisationConfiguration $configuration): array => [
                 'id' => $configuration->id,
                 'area' => $configuration->area->value,
                 'key' => $configuration->configuration_key,
@@ -33,7 +33,7 @@ class OrganisationConfigurationController extends Controller
                 'activatedAt' => $configuration->activated_at?->toAtomString(),
             ]),
             'areas' => collect(OrganisationConfigurationArea::cases())
-                ->reject(fn (OrganisationConfigurationArea $area): bool => in_array($area, [OrganisationConfigurationArea::MessageTemplate, OrganisationConfigurationArea::SupporterJourney, OrganisationConfigurationArea::IntakeRules], true))
+                ->reject(fn (OrganisationConfigurationArea $area): bool => in_array($area, [OrganisationConfigurationArea::PublicForm, OrganisationConfigurationArea::MessageTemplate, OrganisationConfigurationArea::SupporterJourney, OrganisationConfigurationArea::IntakeRules], true))
                 ->map(fn (OrganisationConfigurationArea $area): array => ['value' => $area->value, 'label' => $area->label()])
                 ->values(),
         ]);
@@ -59,7 +59,7 @@ class OrganisationConfigurationController extends Controller
     public function activate(Organisation $currentOrganisation, string $configuration, ActivateOrganisationConfiguration $activate): RedirectResponse
     {
         $version = OrganisationConfiguration::query()->findOrFail($configuration);
-        abort_if(in_array($version->area, [OrganisationConfigurationArea::MessageTemplate, OrganisationConfigurationArea::SupporterJourney, OrganisationConfigurationArea::IntakeRules], true), 404);
+        abort_if(in_array($version->area, [OrganisationConfigurationArea::PublicForm, OrganisationConfigurationArea::MessageTemplate, OrganisationConfigurationArea::SupporterJourney, OrganisationConfigurationArea::IntakeRules], true), 404);
         Gate::authorize('update', $version);
         $activate->handle($version, request()->user());
 

--- a/app/Http/Controllers/Organisations/PublicFormController.php
+++ b/app/Http/Controllers/Organisations/PublicFormController.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Configuration\ActivateOrganisationConfiguration;
+use App\Actions\Configuration\CreateOrganisationConfiguration;
+use App\Actions\Configuration\PublicFormDefinition;
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\StorePublicFormRequest;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class PublicFormController extends Controller
+{
+    public function index(Organisation $currentOrganisation): Response
+    {
+        Gate::authorize('viewAny', [OrganisationConfiguration::class, $currentOrganisation]);
+        $forms = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::PublicForm)
+            ->latest('version')
+            ->get();
+
+        return Inertia::render('public-forms/index', [
+            'purposes' => collect(PublicFormDefinition::catalogue())->map(fn (array $purpose, string $value): array => [
+                'value' => $value,
+                'label' => $purpose['label'],
+                'description' => $purpose['description'],
+                'fields' => collect($purpose['fields'])->map(fn (array $field): array => [
+                    'key' => $field['key'],
+                    'label' => $field['label'],
+                    'type' => $field['type'],
+                    'required' => $field['fixed_required'],
+                    'fixedRequired' => $field['fixed_required'],
+                ])->all(),
+            ])->values(),
+            'forms' => $forms->map(fn (OrganisationConfiguration $form): array => [
+                'id' => $form->id,
+                'purpose' => $this->purpose($form),
+                'purposeLabel' => PublicFormDefinition::catalogue()[$this->purpose($form)]['label'],
+                'version' => $form->version,
+                'status' => $form->status->value,
+                'fields' => PublicFormDefinition::displayFields($this->purpose($form), $form->definition),
+                'activatedAt' => $form->activated_at?->toAtomString(),
+                'canActivate' => $form->status === OrganisationConfigurationStatus::Draft
+                    && $forms->firstWhere('configuration_key', $form->configuration_key)?->id === $form->id,
+            ]),
+        ]);
+    }
+
+    public function store(StorePublicFormRequest $request, Organisation $currentOrganisation, CreateOrganisationConfiguration $create): RedirectResponse
+    {
+        Gate::authorize('create', [OrganisationConfiguration::class, $currentOrganisation]);
+        $purpose = $request->string('form')->toString();
+        $orderedFields = array_values(array_filter($request->array('ordered_fields'), is_string(...)));
+        $requiredFields = array_values(array_filter($request->array('required_fields'), is_string(...)));
+        $create->handle(
+            $currentOrganisation,
+            OrganisationConfigurationArea::PublicForm,
+            $purpose,
+            PublicFormDefinition::build($purpose, $orderedFields, $requiredFields),
+            $request->user(),
+        );
+
+        return back();
+    }
+
+    public function activate(Organisation $currentOrganisation, string $publicForm, ActivateOrganisationConfiguration $activate): RedirectResponse
+    {
+        $form = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::PublicForm)
+            ->findOrFail($publicForm);
+        Gate::authorize('update', $form);
+        $latestId = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::PublicForm)
+            ->where('configuration_key', $form->configuration_key)
+            ->latest('version')
+            ->value('id');
+        abort_unless($form->status === OrganisationConfigurationStatus::Draft && $form->id === $latestId, 409);
+        $activate->handle($form, request()->user());
+
+        return back();
+    }
+
+    private function purpose(OrganisationConfiguration $form): string
+    {
+        $purpose = $form->definition['form'] ?? null;
+
+        return is_string($purpose) && in_array($purpose, PublicFormDefinition::purposes(), true)
+            ? $purpose
+            : $form->configuration_key;
+    }
+}

--- a/app/Http/Requests/Organisations/StoreOrganisationConfigurationRequest.php
+++ b/app/Http/Requests/Organisations/StoreOrganisationConfigurationRequest.php
@@ -18,7 +18,7 @@ class StoreOrganisationConfigurationRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'area' => ['required', Rule::enum(OrganisationConfigurationArea::class), Rule::notIn([OrganisationConfigurationArea::MessageTemplate->value, OrganisationConfigurationArea::SupporterJourney->value, OrganisationConfigurationArea::IntakeRules->value])],
+            'area' => ['required', Rule::enum(OrganisationConfigurationArea::class), Rule::notIn([OrganisationConfigurationArea::PublicForm->value, OrganisationConfigurationArea::MessageTemplate->value, OrganisationConfigurationArea::SupporterJourney->value, OrganisationConfigurationArea::IntakeRules->value])],
             'configuration_key' => ['required', 'string', 'alpha_dash:ascii', 'max:100'],
             'definition_json' => ['required', 'string', 'json', 'max:20000'],
         ];

--- a/app/Http/Requests/Organisations/StorePublicFormRequest.php
+++ b/app/Http/Requests/Organisations/StorePublicFormRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Actions\Configuration\PublicFormDefinition;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
+
+class StorePublicFormRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'form' => ['required', Rule::in(PublicFormDefinition::purposes())],
+            'ordered_fields' => ['required', 'array', 'min:1'],
+            'ordered_fields.*' => ['required', 'string', 'distinct'],
+            'required_fields' => ['present', 'array'],
+            'required_fields.*' => ['required', 'string', 'distinct'],
+        ];
+    }
+
+    /** @return list<callable(Validator): void> */
+    public function after(): array
+    {
+        return [function ($validator): void {
+            $purpose = $this->string('form')->toString();
+            $allowed = collect(PublicFormDefinition::fieldKeys($purpose));
+            $ordered = collect(array_values(array_filter($this->array('ordered_fields'), is_string(...))));
+            $required = collect(array_values(array_filter($this->array('required_fields'), is_string(...))));
+
+            if ($ordered->count() !== $allowed->count() || $ordered->diff($allowed)->isNotEmpty() || $allowed->diff($ordered)->isNotEmpty()) {
+                $validator->errors()->add('ordered_fields', 'Keep every supported field in the form.');
+            }
+            if ($required->diff($allowed)->isNotEmpty()) {
+                $validator->errors()->add('required_fields', 'The form contains an unsupported required field.');
+            }
+        }];
+    }
+}

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -7,6 +7,7 @@ import {
     LayoutGrid,
     ListFilter,
     MessagesSquare,
+    PanelsTopLeft,
     Scale,
     ScrollText,
     Settings2,
@@ -41,6 +42,7 @@ import { index as configurationsIndex } from '@/routes/organisation-configuratio
 import { index as impactSnapshotsIndex } from '@/routes/impact-snapshots';
 import { index as partiesIndex } from '@/routes/parties';
 import { index as programsIndex } from '@/routes/programs';
+import { index as publicFormsIndex } from '@/routes/public-forms';
 import { index as supporterJourneysIndex } from '@/routes/supporter-journeys';
 import { index as supporterJourneyPolicyIndex } from '@/routes/supporter-journey-policy';
 import { index as volunteersIndex } from '@/routes/volunteers';
@@ -162,6 +164,13 @@ export function AppSidebar() {
                           page.props.currentOrganisation.slug,
                       ),
                       icon: ClipboardList,
+                  },
+                  {
+                      title: 'Public forms',
+                      href: publicFormsIndex(
+                          page.props.currentOrganisation.slug,
+                      ),
+                      icon: PanelsTopLeft,
                   },
                   {
                       title: 'Organisation configuration',

--- a/resources/js/pages/organisation-configurations/index.tsx
+++ b/resources/js/pages/organisation-configurations/index.tsx
@@ -18,11 +18,6 @@ type Configuration = {
 type Area = { value: string; label: string };
 
 const examples: Record<string, string> = {
-    public_form: JSON.stringify(
-        { form: 'event_registration', required_fields: ['name', 'email'] },
-        null,
-        2,
-    ),
     reporting: JSON.stringify(
         {
             public_metric_ids: ['engagement.event_attendance'],
@@ -92,10 +87,7 @@ export default function OrganisationConfigurationsIndex({
                                         message={errors.configuration_key}
                                     />
                                     <small className="text-muted-foreground">
-                                        Use impact for reporting and the form
-                                        name (for example
-                                        volunteer_registration) for public
-                                        forms.
+                                        Use impact for reporting definitions.
                                     </small>
                                 </label>
                                 <label className="grid gap-1">

--- a/resources/js/pages/public-forms/index.tsx
+++ b/resources/js/pages/public-forms/index.tsx
@@ -1,0 +1,401 @@
+import { Form, Head, useForm, usePage } from '@inertiajs/react';
+import { ArrowDown, ArrowUp, LockKeyhole } from 'lucide-react';
+import type { FormEvent } from 'react';
+import Heading from '@/components/heading';
+import InputError from '@/components/input-error';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { activate, index, store } from '@/routes/public-forms';
+
+type FormField = {
+    key: string;
+    label: string;
+    type: string;
+    required: boolean;
+    fixedRequired: boolean;
+};
+
+type Purpose = {
+    value: string;
+    label: string;
+    description: string;
+    fields: FormField[];
+};
+
+type PublicFormVersion = {
+    id: string;
+    purpose: string;
+    purposeLabel: string;
+    version: number;
+    status: string;
+    fields: FormField[];
+    activatedAt: string | null;
+    canActivate: boolean;
+};
+
+function FieldPreview({ field }: { field: FormField }) {
+    return (
+        <label className="grid gap-1.5">
+            <span className="text-sm font-medium">
+                {field.label}
+                {field.required ? (
+                    <span className="text-destructive"> *</span>
+                ) : null}
+            </span>
+            {field.type === 'textarea' ? (
+                <textarea
+                    className="bg-background min-h-20 rounded-md border px-3 py-2"
+                    disabled
+                />
+            ) : field.type === 'multiselect' ? (
+                <select
+                    className="bg-background h-20 rounded-md border px-3"
+                    disabled
+                    multiple
+                >
+                    <option>Example option</option>
+                </select>
+            ) : (
+                <input
+                    className="bg-background h-9 rounded-md border px-3"
+                    disabled
+                    placeholder={
+                        field.type === 'currency'
+                            ? 'ZAR'
+                            : field.type === 'money'
+                              ? '0.00'
+                              : undefined
+                    }
+                    type={
+                        field.type === 'money' || field.type === 'number'
+                            ? 'number'
+                            : field.type
+                    }
+                />
+            )}
+        </label>
+    );
+}
+
+export default function PublicFormsIndex({
+    purposes,
+    forms,
+}: {
+    purposes: Purpose[];
+    forms: PublicFormVersion[];
+}) {
+    const organisation = usePage().props.currentOrganisation!;
+    const initialPurpose = purposes[0];
+    const editor = useForm({
+        form: initialPurpose?.value ?? '',
+        ordered_fields: initialPurpose?.fields.map((field) => field.key) ?? [],
+        required_fields:
+            initialPurpose?.fields
+                .filter((field) => field.required)
+                .map((field) => field.key) ?? [],
+    });
+    const selectedPurpose = purposes.find(
+        (purpose) => purpose.value === editor.data.form,
+    );
+    const catalogue = new Map(
+        selectedPurpose?.fields.map((field) => [field.key, field]) ?? [],
+    );
+    const orderedFields = editor.data.ordered_fields
+        .map((key) => catalogue.get(key))
+        .filter((field): field is FormField => field !== undefined)
+        .map((field) => ({
+            ...field,
+            required:
+                field.fixedRequired ||
+                editor.data.required_fields.includes(field.key),
+        }));
+
+    const selectPurpose = (purposeValue: string) => {
+        const purpose = purposes.find(
+            (candidate) => candidate.value === purposeValue,
+        );
+        editor.setData({
+            form: purposeValue,
+            ordered_fields: purpose?.fields.map((field) => field.key) ?? [],
+            required_fields:
+                purpose?.fields
+                    .filter((field) => field.required)
+                    .map((field) => field.key) ?? [],
+        });
+        editor.clearErrors();
+    };
+
+    const move = (indexToMove: number, direction: -1 | 1) => {
+        const destination = indexToMove + direction;
+        if (
+            destination < 0 ||
+            destination >= editor.data.ordered_fields.length
+        ) {
+            return;
+        }
+        const reordered = [...editor.data.ordered_fields];
+        [reordered[indexToMove], reordered[destination]] = [
+            reordered[destination],
+            reordered[indexToMove],
+        ];
+        editor.setData('ordered_fields', reordered);
+    };
+
+    const toggleRequired = (key: string, checked: boolean) => {
+        editor.setData(
+            'required_fields',
+            checked
+                ? [...editor.data.required_fields, key]
+                : editor.data.required_fields.filter(
+                      (candidate) => candidate !== key,
+                  ),
+        );
+    };
+
+    const useAsStartingPoint = (form: PublicFormVersion) => {
+        editor.setData({
+            form: form.purpose,
+            ordered_fields: form.fields.map((field) => field.key),
+            required_fields: form.fields
+                .filter((field) => field.required)
+                .map((field) => field.key),
+        });
+        editor.clearErrors();
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+
+    const submit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        editor.post(store.url(organisation.slug), {
+            preserveScroll: true,
+        });
+    };
+
+    return (
+        <div className="space-y-6 p-4">
+            <Head title="Public forms" />
+            <Heading
+                title="Public forms"
+                description="Arrange supported fields, choose optional requirements, preview the result, and publish an immutable version—without editing JSON."
+            />
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Create a public form draft</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <form
+                        className="grid gap-6 xl:grid-cols-[minmax(0,1fr)_minmax(20rem,0.85fr)]"
+                        onSubmit={submit}
+                    >
+                        <div className="space-y-5">
+                            <div className="grid gap-2">
+                                <Label htmlFor="form-purpose">
+                                    Form purpose
+                                </Label>
+                                <select
+                                    id="form-purpose"
+                                    className="h-9 rounded-md border bg-transparent px-3"
+                                    value={editor.data.form}
+                                    onChange={(event) =>
+                                        selectPurpose(event.target.value)
+                                    }
+                                >
+                                    {purposes.map((purpose) => (
+                                        <option
+                                            key={purpose.value}
+                                            value={purpose.value}
+                                        >
+                                            {purpose.label}
+                                        </option>
+                                    ))}
+                                </select>
+                                <p className="text-muted-foreground text-sm">
+                                    {selectedPurpose?.description}
+                                </p>
+                                <InputError message={editor.errors.form} />
+                            </div>
+
+                            <fieldset className="space-y-3">
+                                <legend className="font-medium">
+                                    Fields and order
+                                </legend>
+                                <p className="text-muted-foreground text-sm">
+                                    All supported fields stay present. Reorder
+                                    them and choose whether configurable fields
+                                    must be completed.
+                                </p>
+                                {orderedFields.map((field, fieldIndex) => (
+                                    <div
+                                        key={field.key}
+                                        className="flex flex-wrap items-center gap-3 rounded-lg border p-3"
+                                    >
+                                        <div className="min-w-36 flex-1">
+                                            <div className="font-medium">
+                                                {field.label}
+                                            </div>
+                                            <div className="text-muted-foreground text-xs">
+                                                {field.type}
+                                            </div>
+                                        </div>
+                                        <label className="flex items-center gap-2 text-sm">
+                                            <input
+                                                type="checkbox"
+                                                checked={field.required}
+                                                disabled={field.fixedRequired}
+                                                onChange={(event) =>
+                                                    toggleRequired(
+                                                        field.key,
+                                                        event.target.checked,
+                                                    )
+                                                }
+                                            />
+                                            Required
+                                            {field.fixedRequired ? (
+                                                <LockKeyhole
+                                                    aria-label="Required by the submission workflow"
+                                                    className="size-3.5"
+                                                />
+                                            ) : null}
+                                        </label>
+                                        <div className="flex gap-1">
+                                            <Button
+                                                type="button"
+                                                size="icon"
+                                                variant="outline"
+                                                disabled={fieldIndex === 0}
+                                                aria-label={`Move ${field.label} up`}
+                                                onClick={() =>
+                                                    move(fieldIndex, -1)
+                                                }
+                                            >
+                                                <ArrowUp />
+                                            </Button>
+                                            <Button
+                                                type="button"
+                                                size="icon"
+                                                variant="outline"
+                                                disabled={
+                                                    fieldIndex ===
+                                                    orderedFields.length - 1
+                                                }
+                                                aria-label={`Move ${field.label} down`}
+                                                onClick={() =>
+                                                    move(fieldIndex, 1)
+                                                }
+                                            >
+                                                <ArrowDown />
+                                            </Button>
+                                        </div>
+                                    </div>
+                                ))}
+                                <InputError
+                                    message={editor.errors.ordered_fields}
+                                />
+                                <InputError
+                                    message={editor.errors.required_fields}
+                                />
+                            </fieldset>
+
+                            <Button disabled={editor.processing}>
+                                {editor.processing
+                                    ? 'Creating draft…'
+                                    : 'Create public form draft'}
+                            </Button>
+                        </div>
+
+                        <div className="bg-muted/40 space-y-4 rounded-xl border p-5">
+                            <div>
+                                <strong>Preview</strong>
+                                <p className="text-muted-foreground text-sm">
+                                    {selectedPurpose?.label}
+                                </p>
+                            </div>
+                            <div className="bg-background grid gap-4 rounded-lg border p-4">
+                                {orderedFields.map((field) => (
+                                    <FieldPreview
+                                        key={field.key}
+                                        field={field}
+                                    />
+                                ))}
+                                <Button type="button" disabled>
+                                    Submit
+                                </Button>
+                            </div>
+                            <p className="text-muted-foreground text-xs">
+                                Consent controls remain owned by the public
+                                workflow and cannot be changed here.
+                            </p>
+                        </div>
+                    </form>
+                </CardContent>
+            </Card>
+
+            <section className="space-y-3">
+                <h2 className="text-xl font-semibold">Version history</h2>
+                {forms.length === 0 ? (
+                    <p className="text-muted-foreground text-sm">
+                        No public form versions yet. Built-in form behavior
+                        remains in place until a draft is activated.
+                    </p>
+                ) : null}
+                {forms.map((form) => (
+                    <Card key={form.id}>
+                        <CardContent className="grid gap-4 pt-6 lg:grid-cols-[1fr_auto]">
+                            <div className="space-y-3">
+                                <div className="flex flex-wrap items-center gap-2">
+                                    <strong>
+                                        {form.purposeLabel} · v{form.version}
+                                    </strong>
+                                    <Badge>{form.status}</Badge>
+                                </div>
+                                <ol className="grid gap-1 text-sm sm:grid-cols-2">
+                                    {form.fields.map((field, fieldIndex) => (
+                                        <li key={field.key}>
+                                            {fieldIndex + 1}. {field.label}
+                                            {field.required
+                                                ? ' · required'
+                                                : ' · optional'}
+                                        </li>
+                                    ))}
+                                </ol>
+                            </div>
+                            <div className="flex flex-wrap items-start gap-2">
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    onClick={() => useAsStartingPoint(form)}
+                                >
+                                    New version
+                                </Button>
+                                {form.canActivate ? (
+                                    <Form
+                                        {...activate.form([
+                                            organisation.slug,
+                                            form.id,
+                                        ])}
+                                    >
+                                        <Button>Activate</Button>
+                                    </Form>
+                                ) : null}
+                            </div>
+                        </CardContent>
+                    </Card>
+                ))}
+            </section>
+        </div>
+    );
+}
+
+PublicFormsIndex.layout = (props: {
+    currentOrganisation: { slug: string };
+}) => ({
+    breadcrumbs: [
+        {
+            title: 'Public forms',
+            href: index(props.currentOrganisation.slug),
+        },
+    ],
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,6 +30,7 @@ use App\Http\Controllers\Organisations\PartyRelationshipController;
 use App\Http\Controllers\Organisations\PartySafeContactInstructionController;
 use App\Http\Controllers\Organisations\PortalAccessGrantController as OrganisationPortalAccessGrantController;
 use App\Http\Controllers\Organisations\ProgramController;
+use App\Http\Controllers\Organisations\PublicFormController;
 use App\Http\Controllers\Organisations\PublishedImpactSnapshotController;
 use App\Http\Controllers\Organisations\ServiceCaseController;
 use App\Http\Controllers\Organisations\ServiceOperationsExportController;
@@ -174,6 +175,9 @@ Route::prefix('{current_organisation}')
         Route::get('intake-rules', [IntakeRulesController::class, 'index'])->name('intake-rules.index');
         Route::post('intake-rules', [IntakeRulesController::class, 'store'])->name('intake-rules.store');
         Route::post('intake-rules/{intakeRule}/activate', [IntakeRulesController::class, 'activate'])->name('intake-rules.activate');
+        Route::get('public-forms', [PublicFormController::class, 'index'])->name('public-forms.index');
+        Route::post('public-forms', [PublicFormController::class, 'store'])->name('public-forms.store');
+        Route::post('public-forms/{publicForm}/activate', [PublicFormController::class, 'activate'])->name('public-forms.activate');
         Route::get('impact-snapshots', [PublishedImpactSnapshotController::class, 'index'])->name('impact-snapshots.index');
         Route::post('impact-snapshots', [PublishedImpactSnapshotController::class, 'store'])->name('impact-snapshots.store');
         Route::get('impact-snapshots/{snapshot}/download', [PublishedImpactSnapshotController::class, 'download'])->name('impact-snapshots.download');

--- a/tests/Feature/ConfigurableEngagementJourneyTest.php
+++ b/tests/Feature/ConfigurableEngagementJourneyTest.php
@@ -92,14 +92,14 @@ it('versions, previews, audits, and protects organisation configuration', functi
         expect($publicFormValidator->errors()->has('interests'))->toBeTrue();
     });
 
-    $this->actingAs($administrator)->get(route('organisation-configurations.index', $organisation))
+    $this->actingAs($administrator)->get(route('public-forms.index', $organisation))
         ->assertOk()
         ->assertSee('interests');
     $this->actingAs($administrator)->post(route('organisation-configurations.store', $organisation), [
         'area' => OrganisationConfigurationArea::PublicForm->value,
         'configuration_key' => 'volunteer_registration',
         'definition_json' => json_encode(['form' => 'volunteer_registration', 'required_fields' => ['name']], JSON_THROW_ON_ERROR),
-    ])->assertSessionHasErrors('definition_json');
+    ])->assertSessionHasErrors('area');
     $this->actingAs($officer)->get(route('organisation-configurations.index', $organisation))->assertForbidden();
 });
 

--- a/tests/Feature/PublicFormEditorTest.php
+++ b/tests/Feature/PublicFormEditorTest.php
@@ -1,0 +1,146 @@
+<?php
+
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use App\Models\User;
+use App\OrganisationContext;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/** @return array{organisation: Organisation, administrator: User, officer: User} */
+function publicFormEditorFixture(): array
+{
+    $organisation = Organisation::factory()->active()->create();
+    $administrator = User::factory()->create();
+    $officer = User::factory()->create();
+    $organisation->memberships()->create(['user_id' => $administrator->id, 'role' => OrganisationRole::OrganisationAdministrator]);
+    $organisation->memberships()->create(['user_id' => $officer->id, 'role' => OrganisationRole::CaseWorker]);
+
+    return compact('organisation', 'administrator', 'officer');
+}
+
+it('creates previews and activates an ordered purpose-built public form', function () {
+    extract(publicFormEditorFixture());
+
+    $this->actingAs($administrator)
+        ->post(route('public-forms.store', $organisation), [
+            'form' => 'volunteer_registration',
+            'ordered_fields' => ['email', 'name', 'availability', 'interests'],
+            'required_fields' => ['interests'],
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    $form = app(OrganisationContext::class)->run($organisation, fn (): OrganisationConfiguration => OrganisationConfiguration::query()
+        ->where('area', OrganisationConfigurationArea::PublicForm)
+        ->where('configuration_key', 'volunteer_registration')
+        ->sole());
+
+    expect($form->definition)->toBe([
+        'form' => 'volunteer_registration',
+        'required_fields' => ['email', 'name', 'availability', 'interests'],
+        'fields' => [
+            ['key' => 'email', 'type' => 'email', 'required' => true],
+            ['key' => 'name', 'type' => 'text', 'required' => true],
+            ['key' => 'availability', 'type' => 'multiselect', 'required' => true],
+            ['key' => 'interests', 'type' => 'multiselect', 'required' => true],
+        ],
+    ])->and($form->status)->toBe(OrganisationConfigurationStatus::Draft);
+
+    $this->actingAs($administrator)
+        ->get(route('public-forms.index', $organisation))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('public-forms/index')
+            ->where('forms.0.purpose', 'volunteer_registration')
+            ->where('forms.0.fields.0.key', 'email')
+            ->where('forms.0.fields.3.required', true)
+            ->where('forms.0.canActivate', true));
+
+    $this->actingAs($administrator)
+        ->post(route('public-forms.activate', [$organisation, $form]))
+        ->assertRedirect();
+    expect($form->refresh()->status)->toBe(OrganisationConfigurationStatus::Active);
+});
+
+it('derives the structured editor state from legacy public form definitions', function () {
+    extract(publicFormEditorFixture());
+
+    $legacy = app(OrganisationContext::class)->run($organisation, fn (): OrganisationConfiguration => OrganisationConfiguration::factory()->create([
+        'area' => OrganisationConfigurationArea::PublicForm,
+        'configuration_key' => 'legacy_supporter_details',
+        'definition' => [
+            'form' => 'supporter_profile',
+            'required_fields' => ['name', 'email', 'telephone'],
+        ],
+    ]));
+
+    $this->actingAs($administrator)
+        ->get(route('public-forms.index', $organisation))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('forms.0.id', $legacy->id)
+            ->where('forms.0.purpose', 'supporter_profile')
+            ->where('forms.0.purposeLabel', 'Supporter profile')
+            ->where('forms.0.fields', [
+                ['key' => 'name', 'label' => 'Name', 'type' => 'text', 'required' => true, 'fixedRequired' => true],
+                ['key' => 'email', 'label' => 'Email address', 'type' => 'email', 'required' => true, 'fixedRequired' => true],
+                ['key' => 'telephone', 'label' => 'Telephone number', 'type' => 'tel', 'required' => true, 'fixedRequired' => false],
+            ]));
+
+    expect($legacy->refresh()->definition)->not->toHaveKey('fields');
+});
+
+it('rejects malformed form definitions and the generic JSON workflow', function () {
+    extract(publicFormEditorFixture());
+
+    $this->actingAs($administrator)
+        ->post(route('public-forms.store', $organisation), [
+            'form' => 'event_registration',
+            'ordered_fields' => ['name', 'name'],
+            'required_fields' => ['organisation_id'],
+        ])
+        ->assertSessionHasErrors(['ordered_fields.1', 'ordered_fields', 'required_fields']);
+    $this->actingAs($administrator)
+        ->get(route('organisation-configurations.index', $organisation))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('areas', fn ($areas) => collect($areas)->doesntContain('value', 'public_form'))
+            ->where('configurations', fn ($configurations) => collect($configurations)->doesntContain('area', 'public_form')));
+    $this->actingAs($administrator)
+        ->post(route('organisation-configurations.store', $organisation), [
+            'area' => 'public_form',
+            'configuration_key' => 'event_registration',
+            'definition_json' => '{"form":"event_registration","required_fields":["name","email"]}',
+        ])
+        ->assertSessionHasErrors('area');
+    $this->actingAs($officer)
+        ->get(route('public-forms.index', $organisation))
+        ->assertForbidden();
+});
+
+it('only permits activation of the latest draft for each public form purpose', function () {
+    extract(publicFormEditorFixture());
+
+    foreach ([['name', 'email'], ['email', 'name']] as $orderedFields) {
+        $this->actingAs($administrator)
+            ->post(route('public-forms.store', $organisation), [
+                'form' => 'event_registration',
+                'ordered_fields' => $orderedFields,
+                'required_fields' => [],
+            ])
+            ->assertSessionHasNoErrors();
+    }
+    $drafts = app(OrganisationContext::class)->run($organisation, fn () => OrganisationConfiguration::query()
+        ->where('area', OrganisationConfigurationArea::PublicForm)
+        ->where('configuration_key', 'event_registration')
+        ->orderBy('version')
+        ->get());
+
+    $this->actingAs($administrator)
+        ->post(route('organisation-configurations.activate', [$organisation, $drafts->last()]))
+        ->assertNotFound();
+    $this->actingAs($administrator)
+        ->post(route('public-forms.activate', [$organisation, $drafts->first()]))
+        ->assertStatus(409);
+});


### PR DESCRIPTION
Closes #87

## Summary
- add a structured Public Form editor with supported purposes, ordered fields, explicit required-state controls, and live preview
- preserve immutable version history and project legacy JSON definitions into the editor without rewriting them
- remove Public Forms from the generic JSON configuration workflow and protect latest-draft activation
- cover authorization, validation, legacy compatibility, workflow, and activation behavior

## Verification
- `php artisan test --compact` (391 tests, 2,795 assertions)
- `composer run types:check`
- `npm run check`
- `npm run types:check`
- `npm test`
- `npm run build:ssr`

## Stack
Base: #95