### PR TITLE
Add reporting publication editor

### DIFF
--- a/app/Http/Controllers/Organisations/OrganisationConfigurationController.php
+++ b/app/Http/Controllers/Organisations/OrganisationConfigurationController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Organisations;
 
-use App\Actions\Configuration\ActivateOrganisationConfiguration;
 use App\Actions\Configuration\CreateOrganisationConfiguration;
 use App\Enums\OrganisationConfigurationArea;
 use App\Http\Controllers\Controller;
@@ -23,19 +22,8 @@ class OrganisationConfigurationController extends Controller
         Gate::authorize('viewAny', [OrganisationConfiguration::class, $currentOrganisation]);
 
         return Inertia::render('organisation-configurations/index', [
-            'configurations' => OrganisationConfiguration::query()->whereNotIn('area', [OrganisationConfigurationArea::PublicForm->value, OrganisationConfigurationArea::MessageTemplate->value, OrganisationConfigurationArea::SupporterJourney->value, OrganisationConfigurationArea::IntakeRules->value])->latest()->get()->map(fn (OrganisationConfiguration $configuration): array => [
-                'id' => $configuration->id,
-                'area' => $configuration->area->value,
-                'key' => $configuration->configuration_key,
-                'version' => $configuration->version,
-                'status' => $configuration->status->value,
-                'definition' => $configuration->definition,
-                'activatedAt' => $configuration->activated_at?->toAtomString(),
-            ]),
-            'areas' => collect(OrganisationConfigurationArea::cases())
-                ->reject(fn (OrganisationConfigurationArea $area): bool => in_array($area, [OrganisationConfigurationArea::PublicForm, OrganisationConfigurationArea::MessageTemplate, OrganisationConfigurationArea::SupporterJourney, OrganisationConfigurationArea::IntakeRules], true))
-                ->map(fn (OrganisationConfigurationArea $area): array => ['value' => $area->value, 'label' => $area->label()])
-                ->values(),
+            'configurations' => [],
+            'areas' => [],
         ]);
     }
 
@@ -56,13 +44,8 @@ class OrganisationConfigurationController extends Controller
         return back();
     }
 
-    public function activate(Organisation $currentOrganisation, string $configuration, ActivateOrganisationConfiguration $activate): RedirectResponse
+    public function activate(): never
     {
-        $version = OrganisationConfiguration::query()->findOrFail($configuration);
-        abort_if(in_array($version->area, [OrganisationConfigurationArea::PublicForm, OrganisationConfigurationArea::MessageTemplate, OrganisationConfigurationArea::SupporterJourney, OrganisationConfigurationArea::IntakeRules], true), 404);
-        Gate::authorize('update', $version);
-        $activate->handle($version, request()->user());
-
-        return back();
+        abort(404);
     }
 }

--- a/app/Http/Controllers/Organisations/ReportingPublicationController.php
+++ b/app/Http/Controllers/Organisations/ReportingPublicationController.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Http\Controllers\Organisations;
+
+use App\Actions\Configuration\ActivateOrganisationConfiguration;
+use App\Actions\Configuration\CreateOrganisationConfiguration;
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Organisations\StoreReportingPublicationRequest;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use App\Reporting\MetricRegistry;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+final class ReportingPublicationController extends Controller
+{
+    public function index(Organisation $currentOrganisation, MetricRegistry $metrics): Response
+    {
+        Gate::authorize('viewAny', [OrganisationConfiguration::class, $currentOrganisation]);
+        $catalogue = collect($metrics->all())->keyBy('id');
+        $versions = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::Reporting)
+            ->where('configuration_key', 'impact')
+            ->latest('version')
+            ->get();
+
+        return Inertia::render('reporting-publication/index', [
+            'metrics' => $catalogue->values(),
+            'versions' => $versions->map(function (OrganisationConfiguration $version) use ($catalogue, $versions): array {
+                $publicMetrics = $this->selectedMetrics($version->definition['public_metric_ids'] ?? [], $catalogue);
+                $packMetrics = $this->selectedMetrics($version->definition['pack_metric_ids'] ?? [], $catalogue);
+                $hasUnavailableMetrics = collect([...$publicMetrics, ...$packMetrics])->contains('available', false);
+
+                return [
+                    'id' => $version->id,
+                    'version' => $version->version,
+                    'status' => $version->status->value,
+                    'publicMetrics' => $publicMetrics,
+                    'packMetrics' => $packMetrics,
+                    'activatedAt' => $version->activated_at?->toAtomString(),
+                    'hasUnavailableMetrics' => $hasUnavailableMetrics,
+                    'canActivate' => $version->status === OrganisationConfigurationStatus::Draft
+                        && $versions->first()?->id === $version->id
+                        && ! $hasUnavailableMetrics,
+                ];
+            }),
+        ]);
+    }
+
+    public function store(StoreReportingPublicationRequest $request, Organisation $currentOrganisation, CreateOrganisationConfiguration $create): RedirectResponse
+    {
+        Gate::authorize('create', [OrganisationConfiguration::class, $currentOrganisation]);
+        $create->handle($currentOrganisation, OrganisationConfigurationArea::Reporting, 'impact', [
+            'public_metric_ids' => array_values(array_filter($request->array('public_metric_ids'), is_string(...))),
+            'pack_metric_ids' => array_values(array_filter($request->array('pack_metric_ids'), is_string(...))),
+        ], $request->user());
+
+        return back();
+    }
+
+    public function activate(Organisation $currentOrganisation, string $reportingPublication, ActivateOrganisationConfiguration $activate, MetricRegistry $metrics): RedirectResponse
+    {
+        $version = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::Reporting)
+            ->where('configuration_key', 'impact')
+            ->findOrFail($reportingPublication);
+        Gate::authorize('update', $version);
+        $latestId = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::Reporting)
+            ->where('configuration_key', 'impact')
+            ->latest('version')
+            ->value('id');
+        abort_unless($version->status === OrganisationConfigurationStatus::Draft && $version->id === $latestId, 409);
+        $configuredIds = [...($version->definition['public_metric_ids'] ?? []), ...($version->definition['pack_metric_ids'] ?? [])];
+        abort_if(collect($configuredIds)->diff($metrics->ids())->isNotEmpty(), 409);
+        $activate->handle($version, request()->user());
+
+        return back();
+    }
+
+    /**
+     * @param  Collection<string, array{id: string, version: string, category: string, domain: string, label: string, description: string, formula: string, unit: string, dimensions: list<string>}>  $catalogue
+     * @return list<array{id: string, label: string, domain: string|null, unit: string|null, available: bool}>
+     */
+    private function selectedMetrics(mixed $selectedIds, Collection $catalogue): array
+    {
+        if (! is_array($selectedIds)) {
+            return [];
+        }
+
+        $selectedMetrics = [];
+        foreach ($selectedIds as $id) {
+            if (! is_string($id)) {
+                continue;
+            }
+            $metric = $catalogue->get($id);
+            $selectedMetrics[] = [
+                'id' => $id,
+                'label' => $metric['label'] ?? $id,
+                'domain' => $metric['domain'] ?? null,
+                'unit' => $metric['unit'] ?? null,
+                'available' => $metric !== null,
+            ];
+        }
+
+        return $selectedMetrics;
+    }
+}

--- a/app/Http/Requests/Organisations/StoreOrganisationConfigurationRequest.php
+++ b/app/Http/Requests/Organisations/StoreOrganisationConfigurationRequest.php
@@ -18,7 +18,7 @@ class StoreOrganisationConfigurationRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'area' => ['required', Rule::enum(OrganisationConfigurationArea::class), Rule::notIn([OrganisationConfigurationArea::PublicForm->value, OrganisationConfigurationArea::MessageTemplate->value, OrganisationConfigurationArea::SupporterJourney->value, OrganisationConfigurationArea::IntakeRules->value])],
+            'area' => ['required', Rule::enum(OrganisationConfigurationArea::class), Rule::notIn([OrganisationConfigurationArea::Reporting->value, OrganisationConfigurationArea::PublicForm->value, OrganisationConfigurationArea::MessageTemplate->value, OrganisationConfigurationArea::SupporterJourney->value, OrganisationConfigurationArea::IntakeRules->value])],
             'configuration_key' => ['required', 'string', 'alpha_dash:ascii', 'max:100'],
             'definition_json' => ['required', 'string', 'json', 'max:20000'],
         ];

--- a/app/Http/Requests/Organisations/StoreReportingPublicationRequest.php
+++ b/app/Http/Requests/Organisations/StoreReportingPublicationRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Requests\Organisations;
+
+use App\Reporting\MetricRegistry;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class StoreReportingPublicationRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'public_metric_ids' => ['required', 'array', 'min:1'],
+            'public_metric_ids.*' => ['required', 'string', Rule::in(app(MetricRegistry::class)->ids()), 'distinct'],
+            'pack_metric_ids' => ['required', 'array', 'min:1'],
+            'pack_metric_ids.*' => ['required', 'string', Rule::in(app(MetricRegistry::class)->ids()), 'distinct'],
+        ];
+    }
+}

--- a/app/Reporting/MetricRegistry.php
+++ b/app/Reporting/MetricRegistry.php
@@ -11,15 +11,21 @@ class MetricRegistry
     /** @return list<string> */
     public function ids(): array
     {
-        $ids = [];
+        return array_column($this->all(), 'id');
+    }
+
+    /** @return list<array{id: string, version: string, category: string, domain: string, label: string, description: string, formula: string, unit: string, dimensions: list<string>}> */
+    public function all(): array
+    {
+        $definitions = [];
 
         foreach (OrganisationRole::cases() as $role) {
             foreach ($this->forRole($role) as $definition) {
-                $ids[$definition['id']] = true;
+                $definitions[$definition['id']] = $definition;
             }
         }
 
-        return array_keys($ids);
+        return array_values($definitions);
     }
 
     /** @return list<array{id: string, version: string, category: string, domain: string, label: string, description: string, formula: string, unit: string, dimensions: list<string>}> */

--- a/resources/js/components/app-sidebar.tsx
+++ b/resources/js/components/app-sidebar.tsx
@@ -1,5 +1,6 @@
 import { Link, usePage } from '@inertiajs/react';
 import {
+    BarChart3,
     ClipboardList,
     CalendarDays,
     FolderGit2,
@@ -43,6 +44,7 @@ import { index as impactSnapshotsIndex } from '@/routes/impact-snapshots';
 import { index as partiesIndex } from '@/routes/parties';
 import { index as programsIndex } from '@/routes/programs';
 import { index as publicFormsIndex } from '@/routes/public-forms';
+import { index as reportingPublicationIndex } from '@/routes/reporting-publication';
 import { index as supporterJourneysIndex } from '@/routes/supporter-journeys';
 import { index as supporterJourneyPolicyIndex } from '@/routes/supporter-journey-policy';
 import { index as volunteersIndex } from '@/routes/volunteers';
@@ -171,6 +173,13 @@ export function AppSidebar() {
                           page.props.currentOrganisation.slug,
                       ),
                       icon: PanelsTopLeft,
+                  },
+                  {
+                      title: 'Reporting publication',
+                      href: reportingPublicationIndex(
+                          page.props.currentOrganisation.slug,
+                      ),
+                      icon: BarChart3,
                   },
                   {
                       title: 'Organisation configuration',

--- a/resources/js/pages/organisation-configurations/index.tsx
+++ b/resources/js/pages/organisation-configurations/index.tsx
@@ -17,21 +17,6 @@ type Configuration = {
 };
 type Area = { value: string; label: string };
 
-const examples: Record<string, string> = {
-    reporting: JSON.stringify(
-        {
-            public_metric_ids: ['engagement.event_attendance'],
-            pack_metric_ids: [
-                'service.requests_received',
-                'engagement.event_attendance',
-                'data.missing_service_area_rate',
-            ],
-        },
-        null,
-        2,
-    ),
-};
-
 export default function OrganisationConfigurationsIndex({
     configurations,
     areas,
@@ -47,85 +32,79 @@ export default function OrganisationConfigurationsIndex({
                 title="Organisation configuration"
                 description="Create immutable, validated versions. Preview the exact definition below, then explicitly activate it. Fixed consent, access, and service-data safeguards cannot be disabled."
             />
-            <Card>
-                <CardHeader>
-                    <CardTitle>Create configuration version</CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <Form
-                        {...store.form(organisation.slug)}
-                        className="grid gap-4"
-                    >
-                        {({ errors, processing }) => (
-                            <>
-                                <label className="grid gap-1">
-                                    <span>Area</span>
-                                    <select
-                                        name="area"
-                                        className="h-9 rounded border bg-transparent px-3"
-                                    >
-                                        {areas.map((area) => (
-                                            <option
-                                                key={area.value}
-                                                value={area.value}
-                                            >
-                                                {area.label}
-                                            </option>
-                                        ))}
-                                    </select>
-                                    <InputError message={errors.area} />
-                                </label>
-                                <label className="grid gap-1">
-                                    <span>Configuration key</span>
-                                    <input
-                                        name="configuration_key"
-                                        defaultValue="impact"
-                                        required
-                                        className="h-9 rounded border bg-transparent px-3"
-                                    />
-                                    <InputError
-                                        message={errors.configuration_key}
-                                    />
-                                    <small className="text-muted-foreground">
-                                        Use impact for reporting definitions.
-                                    </small>
-                                </label>
-                                <label className="grid gap-1">
-                                    <span>Validated JSON definition</span>
-                                    <textarea
-                                        name="definition_json"
-                                        rows={10}
-                                        defaultValue={examples.reporting}
-                                        required
-                                        className="rounded border bg-transparent p-3 font-mono text-sm"
-                                    />
-                                    <InputError
-                                        message={errors.definition_json}
-                                    />
-                                </label>
-                                <details>
-                                    <summary>Safe examples by area</summary>
-                                    {Object.entries(examples).map(
-                                        ([area, example]) => (
-                                            <div key={area} className="mt-3">
-                                                <strong>
-                                                    {area.replaceAll('_', ' ')}
-                                                </strong>
-                                                <pre className="bg-muted overflow-auto rounded p-3 text-xs">
-                                                    {example}
-                                                </pre>
-                                            </div>
-                                        ),
-                                    )}
-                                </details>
-                                <Button disabled={processing}>
-                                    Validate and create draft
-                                </Button>
-                            </>
-                        )}
-                    </Form>
-                </CardContent>
-            </Card>
+            {areas.length > 0 ? (
+                <Card>
+                    <CardHeader>
+                        <CardTitle>Create configuration version</CardTitle>
+                    </CardHeader>
+                    <CardContent>
+                        <Form
+                            {...store.form(organisation.slug)}
+                            className="grid gap-4"
+                        >
+                            {({ errors, processing }) => (
+                                <>
+                                    <label className="grid gap-1">
+                                        <span>Area</span>
+                                        <select
+                                            name="area"
+                                            className="h-9 rounded border bg-transparent px-3"
+                                        >
+                                            {areas.map((area) => (
+                                                <option
+                                                    key={area.value}
+                                                    value={area.value}
+                                                >
+                                                    {area.label}
+                                                </option>
+                                            ))}
+                                        </select>
+                                        <InputError message={errors.area} />
+                                    </label>
+                                    <label className="grid gap-1">
+                                        <span>Configuration key</span>
+                                        <input
+                                            name="configuration_key"
+                                            defaultValue="impact"
+                                            required
+                                            className="h-9 rounded border bg-transparent px-3"
+                                        />
+                                        <InputError
+                                            message={errors.configuration_key}
+                                        />
+                                        <small className="text-muted-foreground">
+                                            Use a stable name for this
+                                            definition.
+                                        </small>
+                                    </label>
+                                    <label className="grid gap-1">
+                                        <span>Validated JSON definition</span>
+                                        <textarea
+                                            name="definition_json"
+                                            rows={10}
+                                            required
+                                            className="rounded border bg-transparent p-3 font-mono text-sm"
+                                        />
+                                        <InputError
+                                            message={errors.definition_json}
+                                        />
+                                    </label>
+                                    <Button disabled={processing}>
+                                        Validate and create draft
+                                    </Button>
+                                </>
+                            )}
+                        </Form>
+                    </CardContent>
+                </Card>
+            ) : (
+                <Card>
+                    <CardContent className="pt-6 text-sm">
+                        All configuration areas now have dedicated editors in
+                        the workspace navigation.
+                    </CardContent>
+                </Card>
+            )}
             <section className="space-y-3">
                 <h2 className="text-xl font-semibold">
                     Version history and preview

--- a/resources/js/pages/reporting-publication/index.tsx
+++ b/resources/js/pages/reporting-publication/index.tsx
@@ -1,0 +1,368 @@
+import { Form, Head, useForm, usePage } from '@inertiajs/react';
+import { Search } from 'lucide-react';
+import type { FormEvent } from 'react';
+import { useState } from 'react';
+import Heading from '@/components/heading';
+import InputError from '@/components/input-error';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { activate, index, store } from '@/routes/reporting-publication';
+
+type Metric = {
+    id: string;
+    version: string;
+    category: string;
+    domain: string;
+    label: string;
+    description: string;
+    formula: string;
+    unit: string;
+    dimensions: string[];
+};
+
+type SelectedMetric = {
+    id: string;
+    label: string;
+    domain: string | null;
+    unit: string | null;
+    available: boolean;
+};
+
+type ReportingVersion = {
+    id: string;
+    version: number;
+    status: string;
+    publicMetrics: SelectedMetric[];
+    packMetrics: SelectedMetric[];
+    activatedAt: string | null;
+    hasUnavailableMetrics: boolean;
+    canActivate: boolean;
+};
+
+function MetricSelection({
+    title,
+    description,
+    metrics,
+    selected,
+    onToggle,
+}: {
+    title: string;
+    description: string;
+    metrics: Metric[];
+    selected: string[];
+    onToggle: (id: string, checked: boolean) => void;
+}) {
+    return (
+        <fieldset className="space-y-3">
+            <legend className="font-semibold">{title}</legend>
+            <p className="text-muted-foreground text-sm">{description}</p>
+            <div className="grid gap-2">
+                {metrics.map((metric) => (
+                    <label
+                        key={metric.id}
+                        className="hover:bg-muted/40 flex items-start gap-3 rounded-lg border p-3"
+                    >
+                        <input
+                            type="checkbox"
+                            className="mt-1"
+                            checked={selected.includes(metric.id)}
+                            onChange={(event) =>
+                                onToggle(metric.id, event.target.checked)
+                            }
+                        />
+                        <span className="min-w-0 flex-1">
+                            <span className="flex flex-wrap items-center gap-2 font-medium">
+                                {metric.label}
+                                <Badge variant="outline">{metric.unit}</Badge>
+                                <Badge variant="outline">{metric.domain}</Badge>
+                            </span>
+                            <span className="text-muted-foreground block text-sm">
+                                {metric.description}
+                            </span>
+                            <span className="text-muted-foreground block truncate font-mono text-xs">
+                                {metric.id}
+                            </span>
+                        </span>
+                    </label>
+                ))}
+            </div>
+        </fieldset>
+    );
+}
+
+function VersionMetricList({
+    title,
+    metrics,
+}: {
+    title: string;
+    metrics: SelectedMetric[];
+}) {
+    return (
+        <div>
+            <h3 className="text-sm font-semibold">{title}</h3>
+            {metrics.length === 0 ? (
+                <p className="text-muted-foreground text-sm">None selected</p>
+            ) : (
+                <ul className="mt-1 grid gap-1 text-sm">
+                    {metrics.map((metric) => (
+                        <li
+                            key={metric.id}
+                            className="flex flex-wrap items-center gap-2"
+                        >
+                            {metric.label}
+                            {metric.available ? null : (
+                                <Badge variant="destructive">
+                                    Retired or unavailable
+                                </Badge>
+                            )}
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}
+
+export default function ReportingPublicationIndex({
+    metrics,
+    versions,
+}: {
+    metrics: Metric[];
+    versions: ReportingVersion[];
+}) {
+    const organisation = usePage().props.currentOrganisation!;
+    const [query, setQuery] = useState('');
+    const editor = useForm({
+        public_metric_ids: [] as string[],
+        pack_metric_ids: [] as string[],
+    });
+    const normalizedQuery = query.trim().toLowerCase();
+    const filteredMetrics = metrics.filter((metric) =>
+        [
+            metric.label,
+            metric.id,
+            metric.description,
+            metric.domain,
+            metric.category,
+        ].some((value) => value.toLowerCase().includes(normalizedQuery)),
+    );
+
+    const toggle = (
+        field: 'public_metric_ids' | 'pack_metric_ids',
+        id: string,
+        checked: boolean,
+    ) => {
+        editor.setData(
+            field,
+            checked
+                ? [...editor.data[field], id]
+                : editor.data[field].filter((candidate) => candidate !== id),
+        );
+    };
+
+    const useAsStartingPoint = (version: ReportingVersion) => {
+        editor.setData({
+            public_metric_ids: version.publicMetrics
+                .filter((metric) => metric.available)
+                .map((metric) => metric.id),
+            pack_metric_ids: version.packMetrics
+                .filter((metric) => metric.available)
+                .map((metric) => metric.id),
+        });
+        editor.clearErrors();
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    };
+
+    const submit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        editor.post(store.url(organisation.slug), { preserveScroll: true });
+    };
+
+    const selectedMetric = (id: string) =>
+        metrics.find((metric) => metric.id === id);
+
+    return (
+        <div className="space-y-6 p-4">
+            <Head title="Reporting publication" />
+            <Heading
+                title="Reporting publication"
+                description="Approve registered metrics for public impact pages and controlled reporting packs without handling internal identifiers or JSON."
+            />
+
+            <Card>
+                <CardHeader>
+                    <CardTitle>Create a reporting publication draft</CardTitle>
+                </CardHeader>
+                <CardContent>
+                    <form className="space-y-6" onSubmit={submit}>
+                        <label className="relative block">
+                            <span className="sr-only">Search metrics</span>
+                            <Search className="text-muted-foreground absolute top-2.5 left-3 size-4" />
+                            <Input
+                                value={query}
+                                onChange={(event) =>
+                                    setQuery(event.target.value)
+                                }
+                                placeholder="Search by name, domain, or description"
+                                className="pl-9"
+                            />
+                        </label>
+
+                        {filteredMetrics.length === 0 ? (
+                            <p className="text-muted-foreground rounded-lg border p-4 text-sm">
+                                No registered metrics match that search.
+                            </p>
+                        ) : (
+                            <div className="grid gap-8 xl:grid-cols-2">
+                                <MetricSelection
+                                    title="Public impact page"
+                                    description="Select at least one aggregated metric appropriate for unrestricted publication."
+                                    metrics={filteredMetrics}
+                                    selected={editor.data.public_metric_ids}
+                                    onToggle={(id, checked) =>
+                                        toggle('public_metric_ids', id, checked)
+                                    }
+                                />
+                                <MetricSelection
+                                    title="Approved reporting packs"
+                                    description="Select at least one metric for board, funder, or other approved exports."
+                                    metrics={filteredMetrics}
+                                    selected={editor.data.pack_metric_ids}
+                                    onToggle={(id, checked) =>
+                                        toggle('pack_metric_ids', id, checked)
+                                    }
+                                />
+                            </div>
+                        )}
+                        <InputError message={editor.errors.public_metric_ids} />
+                        <InputError message={editor.errors.pack_metric_ids} />
+
+                        <div className="bg-muted/40 grid gap-4 rounded-xl border p-5 lg:grid-cols-2">
+                            <div>
+                                <strong>Public preview</strong>
+                                <div className="mt-2 grid gap-2 sm:grid-cols-2">
+                                    {editor.data.public_metric_ids.map((id) => {
+                                        const metric = selectedMetric(id);
+                                        return (
+                                            <div
+                                                key={id}
+                                                className="bg-background rounded-lg border p-3"
+                                            >
+                                                <div className="text-muted-foreground text-xs uppercase">
+                                                    {metric?.domain}
+                                                </div>
+                                                <div className="font-semibold">
+                                                    {metric?.label}
+                                                </div>
+                                                <div className="text-muted-foreground text-sm">
+                                                    — {metric?.unit}
+                                                </div>
+                                            </div>
+                                        );
+                                    })}
+                                    {editor.data.public_metric_ids.length ===
+                                    0 ? (
+                                        <p className="text-muted-foreground text-sm">
+                                            Select at least one public metric.
+                                        </p>
+                                    ) : null}
+                                </div>
+                            </div>
+                            <div>
+                                <strong>Reporting pack preview</strong>
+                                <ol className="mt-2 grid gap-1 text-sm">
+                                    {editor.data.pack_metric_ids.map(
+                                        (id, metricIndex) => (
+                                            <li key={id}>
+                                                {metricIndex + 1}.{' '}
+                                                {selectedMetric(id)?.label}
+                                            </li>
+                                        ),
+                                    )}
+                                </ol>
+                            </div>
+                        </div>
+
+                        <Button disabled={editor.processing}>
+                            {editor.processing
+                                ? 'Creating draft…'
+                                : 'Create reporting draft'}
+                        </Button>
+                    </form>
+                </CardContent>
+            </Card>
+
+            <section className="space-y-3">
+                <h2 className="text-xl font-semibold">Version history</h2>
+                {versions.length === 0 ? (
+                    <p className="text-muted-foreground text-sm">
+                        No reporting publication versions yet.
+                    </p>
+                ) : null}
+                {versions.map((version) => (
+                    <Card key={version.id}>
+                        <CardContent className="grid gap-4 pt-6 lg:grid-cols-[1fr_auto]">
+                            <div className="space-y-3">
+                                <div className="flex items-center gap-2">
+                                    <strong>
+                                        Reporting publication · v
+                                        {version.version}
+                                    </strong>
+                                    <Badge>{version.status}</Badge>
+                                </div>
+                                <div className="grid gap-4 md:grid-cols-2">
+                                    <VersionMetricList
+                                        title="Public impact page"
+                                        metrics={version.publicMetrics}
+                                    />
+                                    <VersionMetricList
+                                        title="Approved reporting packs"
+                                        metrics={version.packMetrics}
+                                    />
+                                </div>
+                                {version.hasUnavailableMetrics ? (
+                                    <p className="text-muted-foreground text-sm">
+                                        Create a new version to replace retired
+                                        metrics before activation.
+                                    </p>
+                                ) : null}
+                            </div>
+                            <div className="flex flex-wrap items-start gap-2">
+                                <Button
+                                    type="button"
+                                    variant="outline"
+                                    onClick={() => useAsStartingPoint(version)}
+                                >
+                                    New version
+                                </Button>
+                                {version.canActivate ? (
+                                    <Form
+                                        {...activate.form([
+                                            organisation.slug,
+                                            version.id,
+                                        ])}
+                                    >
+                                        <Button>Activate</Button>
+                                    </Form>
+                                ) : null}
+                            </div>
+                        </CardContent>
+                    </Card>
+                ))}
+            </section>
+        </div>
+    );
+}
+
+ReportingPublicationIndex.layout = (props: {
+    currentOrganisation: { slug: string };
+}) => ({
+    breadcrumbs: [
+        {
+            title: 'Reporting publication',
+            href: index(props.currentOrganisation.slug),
+        },
+    ],
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -32,6 +32,7 @@ use App\Http\Controllers\Organisations\PortalAccessGrantController as Organisati
 use App\Http\Controllers\Organisations\ProgramController;
 use App\Http\Controllers\Organisations\PublicFormController;
 use App\Http\Controllers\Organisations\PublishedImpactSnapshotController;
+use App\Http\Controllers\Organisations\ReportingPublicationController;
 use App\Http\Controllers\Organisations\ServiceCaseController;
 use App\Http\Controllers\Organisations\ServiceOperationsExportController;
 use App\Http\Controllers\Organisations\SupporterJourneyController;
@@ -178,6 +179,9 @@ Route::prefix('{current_organisation}')
         Route::get('public-forms', [PublicFormController::class, 'index'])->name('public-forms.index');
         Route::post('public-forms', [PublicFormController::class, 'store'])->name('public-forms.store');
         Route::post('public-forms/{publicForm}/activate', [PublicFormController::class, 'activate'])->name('public-forms.activate');
+        Route::get('reporting-publication', [ReportingPublicationController::class, 'index'])->name('reporting-publication.index');
+        Route::post('reporting-publication', [ReportingPublicationController::class, 'store'])->name('reporting-publication.store');
+        Route::post('reporting-publication/{reportingPublication}/activate', [ReportingPublicationController::class, 'activate'])->name('reporting-publication.activate');
         Route::get('impact-snapshots', [PublishedImpactSnapshotController::class, 'index'])->name('impact-snapshots.index');
         Route::post('impact-snapshots', [PublishedImpactSnapshotController::class, 'store'])->name('impact-snapshots.store');
         Route::get('impact-snapshots/{snapshot}/download', [PublishedImpactSnapshotController::class, 'download'])->name('impact-snapshots.download');

--- a/tests/Feature/ReportingPublicationEditorTest.php
+++ b/tests/Feature/ReportingPublicationEditorTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use App\Models\User;
+use App\OrganisationContext;
+use App\Reporting\MetricRegistry;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/** @return array{organisation: Organisation, administrator: User, officer: User} */
+function reportingPublicationEditorFixture(): array
+{
+    $organisation = Organisation::factory()->active()->create();
+    $administrator = User::factory()->create();
+    $officer = User::factory()->create();
+    $organisation->memberships()->create(['user_id' => $administrator->id, 'role' => OrganisationRole::OrganisationAdministrator]);
+    $organisation->memberships()->create(['user_id' => $officer->id, 'role' => OrganisationRole::EngagementOfficer]);
+
+    return compact('organisation', 'administrator', 'officer');
+}
+
+it('creates previews and activates reporting selections from the metric catalogue', function () {
+    extract(reportingPublicationEditorFixture());
+
+    $this->actingAs($administrator)
+        ->post(route('reporting-publication.store', $organisation), [
+            'public_metric_ids' => ['engagement.event_attendance'],
+            'pack_metric_ids' => ['service.requests_received', 'engagement.event_attendance'],
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    $version = app(OrganisationContext::class)->run($organisation, fn (): OrganisationConfiguration => OrganisationConfiguration::query()
+        ->where('area', OrganisationConfigurationArea::Reporting)
+        ->where('configuration_key', 'impact')
+        ->sole());
+    expect($version->definition)->toBe([
+        'public_metric_ids' => ['engagement.event_attendance'],
+        'pack_metric_ids' => ['service.requests_received', 'engagement.event_attendance'],
+    ])->and($version->status)->toBe(OrganisationConfigurationStatus::Draft);
+
+    $this->actingAs($administrator)
+        ->get(route('reporting-publication.index', $organisation))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('reporting-publication/index')
+            ->where('metrics', fn ($metrics) => collect($metrics)->contains('id', 'engagement.event_attendance'))
+            ->where('versions.0.publicMetrics.0.label', 'Event attendance')
+            ->where('versions.0.packMetrics.0.label', 'Requests received')
+            ->where('versions.0.canActivate', true));
+
+    $this->actingAs($administrator)
+        ->post(route('reporting-publication.activate', [$organisation, $version]))
+        ->assertRedirect();
+    expect($version->refresh()->status)->toBe(OrganisationConfigurationStatus::Active);
+});
+
+it('shows retired metrics in immutable legacy versions without making them selectable', function () {
+    extract(reportingPublicationEditorFixture());
+
+    $legacy = app(OrganisationContext::class)->run($organisation, fn (): OrganisationConfiguration => OrganisationConfiguration::factory()->create([
+        'area' => OrganisationConfigurationArea::Reporting,
+        'configuration_key' => 'impact',
+        'status' => OrganisationConfigurationStatus::Draft,
+        'definition' => [
+            'public_metric_ids' => ['legacy.people_reached', 'engagement.event_attendance'],
+            'pack_metric_ids' => ['legacy.people_reached'],
+        ],
+    ]));
+
+    $this->actingAs($administrator)
+        ->get(route('reporting-publication.index', $organisation))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('metrics', fn ($metrics) => collect($metrics)->doesntContain('id', 'legacy.people_reached'))
+            ->where('versions.0.publicMetrics.0', [
+                'id' => 'legacy.people_reached',
+                'label' => 'legacy.people_reached',
+                'domain' => null,
+                'unit' => null,
+                'available' => false,
+            ])
+            ->where('versions.0.publicMetrics.1.available', true)
+            ->where('versions.0.hasUnavailableMetrics', true)
+            ->where('versions.0.canActivate', false));
+
+    $this->actingAs($administrator)
+        ->post(route('reporting-publication.activate', [$organisation, $legacy]))
+        ->assertStatus(409);
+
+    expect($legacy->refresh()->definition)->toBe([
+        'public_metric_ids' => ['legacy.people_reached', 'engagement.event_attendance'],
+        'pack_metric_ids' => ['legacy.people_reached'],
+    ]);
+});
+
+it('rejects unavailable metrics and removes reporting from the generic JSON workflow', function () {
+    extract(reportingPublicationEditorFixture());
+
+    $this->actingAs($administrator)
+        ->post(route('reporting-publication.store', $organisation), [
+            'public_metric_ids' => ['legacy.people_reached'],
+            'pack_metric_ids' => [],
+        ])
+        ->assertSessionHasErrors(['public_metric_ids.0', 'pack_metric_ids']);
+    $this->actingAs($administrator)
+        ->post(route('organisation-configurations.store', $organisation), [
+            'area' => 'reporting',
+            'configuration_key' => 'impact',
+            'definition_json' => '{}',
+        ])
+        ->assertSessionHasErrors('area');
+    $this->actingAs($officer)
+        ->get(route('reporting-publication.index', $organisation))
+        ->assertForbidden();
+});
+
+it('only permits activation of the latest reporting draft', function () {
+    extract(reportingPublicationEditorFixture());
+    $metricIds = app(MetricRegistry::class)->ids();
+
+    foreach ([$metricIds[0], $metricIds[1]] as $metricId) {
+        $this->actingAs($administrator)
+            ->post(route('reporting-publication.store', $organisation), [
+                'public_metric_ids' => [$metricId],
+                'pack_metric_ids' => [$metricId],
+            ])
+            ->assertSessionHasNoErrors();
+    }
+    $drafts = app(OrganisationContext::class)->run($organisation, fn () => OrganisationConfiguration::query()
+        ->where('area', OrganisationConfigurationArea::Reporting)
+        ->where('configuration_key', 'impact')
+        ->orderBy('version')
+        ->get());
+
+    $this->actingAs($administrator)
+        ->post(route('organisation-configurations.activate', [$organisation, $drafts->last()]))
+        ->assertNotFound();
+    $this->actingAs($administrator)
+        ->post(route('reporting-publication.activate', [$organisation, $drafts->first()]))
+        ->assertStatus(409);
+});


### PR DESCRIPTION
Closes #88

## Summary
- add a searchable registered-metric catalogue for public impact and approved reporting-pack selections
- preserve immutable versions and clearly mark retired metrics without allowing them into new or activated drafts
- add preview and latest-draft activation while removing Reporting from the generic JSON workflow
- cover authorization, validation, retired-metric compatibility, history, and activation behavior

## Verification
- `php artisan test --compact` (395 tests, 2,849 assertions)
- `composer run types:check`
- `npm run check`
- `npm run types:check`
- `npm test`
- `npm run build:ssr`

## Stack
Base: #97