### PR TITLE
Add Program pathway selector

### DIFF
--- a/resources/js/components/program-definition-list.tsx
+++ b/resources/js/components/program-definition-list.tsx
@@ -118,10 +118,6 @@ export default function ProgramDefinitionList<T extends ProgramDefinition>({
                                 disabled={!canUpdate || definition.retired}
                             />
                             <div className="flex flex-wrap items-center gap-3">
-                                <span className="text-muted-foreground font-mono text-xs">
-                                    {definition.key ??
-                                        'Stable reference created on save'}
-                                </span>
                                 {supportsFieldType ? (
                                     <select
                                         aria-label={`${singular} ${index + 1} type`}

--- a/resources/js/pages/programs/index.tsx
+++ b/resources/js/pages/programs/index.tsx
@@ -7,7 +7,7 @@ import {
     Plus,
     RotateCcw,
 } from 'lucide-react';
-import type { FormEvent } from 'react';
+import { type FormEvent, useEffect, useState } from 'react';
 import Heading from '@/components/heading';
 import InputError from '@/components/input-error';
 import ProgramDefinitionList, {
@@ -18,6 +18,13 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
 import { index } from '@/routes/programs';
 import { update } from '@/routes/organisations/programs';
 
@@ -79,9 +86,11 @@ type Program = {
 function ProgramEditor({
     program,
     organisation,
+    onDirtyChange,
 }: {
     program: Program;
     organisation: string;
+    onDirtyChange: (isDirty: boolean) => void;
 }) {
     const form = useForm({
         name: program.name,
@@ -100,6 +109,10 @@ function ProgramEditor({
         risk_flags: program.risk_flags,
     });
     const errors = form.errors as Record<string, string>;
+
+    useEffect(() => {
+        onDirtyChange(form.isDirty);
+    }, [form.isDirty, onDirtyChange]);
 
     const updateStage = (
         stageIndex: number,
@@ -248,6 +261,7 @@ function ProgramEditor({
         event.preventDefault();
         form.patch(update.url([organisation, program.slug]), {
             preserveScroll: true,
+            onSuccess: () => form.setDefaults(),
         });
     };
 
@@ -1058,6 +1072,26 @@ function ProgramEditor({
 
 export default function ProgramsIndex({ programs }: { programs: Program[] }) {
     const organisation = usePage().props.currentOrganisation!;
+    const [selectedProgramId, setSelectedProgramId] = useState(
+        programs[0]?.id.toString() ?? '',
+    );
+    const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
+    const selectedProgram = programs.find(
+        (program) => program.id.toString() === selectedProgramId,
+    );
+    const selectProgram = (programId: string) => {
+        if (
+            programId !== selectedProgramId &&
+            hasUnsavedChanges &&
+            !window.confirm(
+                'Discard your unsaved changes and open another Program?',
+            )
+        ) {
+            return;
+        }
+
+        setSelectedProgramId(programId);
+    };
 
     return (
         <>
@@ -1067,15 +1101,51 @@ export default function ProgramsIndex({ programs }: { programs: Program[] }) {
                     title="Program pathways"
                     description="Use familiar language and a clear service pathway so staff can recognise how work progresses."
                 />
-                <div className="grid gap-6">
-                    {programs.map((program) => (
-                        <ProgramEditor
-                            key={program.id}
-                            program={program}
-                            organisation={organisation.slug}
-                        />
-                    ))}
-                </div>
+                {programs.length > 0 ? (
+                    <div className="grid max-w-xl gap-2">
+                        <Label htmlFor="program-pathway-selector">
+                            Program
+                        </Label>
+                        <Select
+                            value={selectedProgramId}
+                            onValueChange={selectProgram}
+                        >
+                            <SelectTrigger
+                                id="program-pathway-selector"
+                                className="w-full"
+                            >
+                                <SelectValue placeholder="Choose a Program" />
+                            </SelectTrigger>
+                            <SelectContent align="start">
+                                {programs.map((program) => (
+                                    <SelectItem
+                                        key={program.id}
+                                        value={program.id.toString()}
+                                    >
+                                        {program.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                        <p className="text-muted-foreground text-sm">
+                            Choose one Program to review or update its pathway.
+                        </p>
+                    </div>
+                ) : null}
+                {selectedProgram ? (
+                    <ProgramEditor
+                        key={selectedProgram.id}
+                        program={selectedProgram}
+                        organisation={organisation.slug}
+                        onDirtyChange={setHasUnsavedChanges}
+                    />
+                ) : (
+                    <Card>
+                        <CardContent className="text-muted-foreground py-8 text-sm">
+                            No Programs are available for this Organisation.
+                        </CardContent>
+                    </Card>
+                )}
             </div>
         </>
     );

--- a/resources/js/pages/programs/index.tsx
+++ b/resources/js/pages/programs/index.tsx
@@ -468,23 +468,13 @@ function ProgramEditor({
                                                 stage.retired
                                             }
                                         />
-                                        <div className="flex flex-wrap items-center gap-2">
-                                            {stage.key ? (
-                                                <span className="text-muted-foreground font-mono text-xs">
-                                                    {stage.key}
-                                                </span>
-                                            ) : (
-                                                <span className="text-muted-foreground text-xs">
-                                                    A stable reference will be
-                                                    created when saved.
-                                                </span>
-                                            )}
-                                            {stage.retired ? (
+                                        {stage.retired ? (
+                                            <div>
                                                 <Badge variant="outline">
                                                     Retired
                                                 </Badge>
-                                            ) : null}
-                                        </div>
+                                            </div>
+                                        ) : null}
                                         <InputError
                                             message={
                                                 errors[
@@ -607,10 +597,6 @@ function ProgramEditor({
                                                     measure.retired
                                                 }
                                             />
-                                            <span className="text-muted-foreground font-mono text-xs">
-                                                {measure.key ??
-                                                    'Stable reference created on save'}
-                                            </span>
                                             <InputError
                                                 message={
                                                     errors[
@@ -771,10 +757,6 @@ function ProgramEditor({
                                                         taxonomy.retired
                                                     }
                                                 />
-                                                <span className="text-muted-foreground font-mono text-xs">
-                                                    {taxonomy.key ??
-                                                        'Stable reference created on save'}
-                                                </span>
                                                 <InputError
                                                     message={
                                                         errors[
@@ -906,10 +888,6 @@ function ProgramEditor({
                                                                     value.retired
                                                                 }
                                                             />
-                                                            <span className="text-muted-foreground font-mono text-xs">
-                                                                {value.key ??
-                                                                    'Reference created on save'}
-                                                            </span>
                                                             <InputError
                                                                 message={
                                                                     errors[

--- a/resources/js/pages/programs/index.tsx
+++ b/resources/js/pages/programs/index.tsx
@@ -722,8 +722,7 @@ function ProgramEditor({
                                 <h3 className="font-semibold">Taxonomies</h3>
                                 <p className="text-muted-foreground text-sm">
                                     Maintain the shared classifications staff
-                                    use, with clear allowed values instead of
-                                    free-form JSON.
+                                    use across this Program.
                                 </p>
                             </div>
                             {program.canUpdate ? (

--- a/resources/js/pages/public-forms/index.tsx
+++ b/resources/js/pages/public-forms/index.tsx
@@ -178,7 +178,7 @@ export default function PublicFormsIndex({
             <Head title="Public forms" />
             <Heading
                 title="Public forms"
-                description="Arrange supported fields, choose optional requirements, preview the result, and publish an immutable version—without editing JSON."
+                description="Arrange fields, choose requirements, preview the result, and publish a version for public use."
             />
 
             <Card>

--- a/resources/js/pages/reporting-publication/index.tsx
+++ b/resources/js/pages/reporting-publication/index.tsx
@@ -81,9 +81,6 @@ function MetricSelection({
                             <span className="text-muted-foreground block text-sm">
                                 {metric.description}
                             </span>
-                            <span className="text-muted-foreground block truncate font-mono text-xs">
-                                {metric.id}
-                            </span>
                         </span>
                     </label>
                 ))}

--- a/resources/js/pages/reporting-publication/index.tsx
+++ b/resources/js/pages/reporting-publication/index.tsx
@@ -188,7 +188,7 @@ export default function ReportingPublicationIndex({
             <Head title="Reporting publication" />
             <Heading
                 title="Reporting publication"
-                description="Approve registered metrics for public impact pages and controlled reporting packs without handling internal identifiers or JSON."
+                description="Approve metrics for public impact pages and controlled reporting packs."
             />
 
             <Card>

--- a/resources/js/tests/pages/programs-index.test.tsx
+++ b/resources/js/tests/pages/programs-index.test.tsx
@@ -68,10 +68,49 @@ const program = (id: number, name: string) => ({
     request_label: 'Request',
     case_label: 'Case',
     case_default_classification: 'confidential' as const,
-    stages: [],
-    outcome_measures: [],
-    taxonomies: [],
-    intake_fields: [],
+    stages: [
+        {
+            id: 1,
+            key: 'internal_received_key',
+            label: 'Received',
+            retired: false,
+        },
+    ],
+    outcome_measures: [
+        {
+            id: 2,
+            key: 'internal_outcome_key',
+            label: 'Progress',
+            unit: 'score',
+            retired: false,
+        },
+    ],
+    taxonomies: [
+        {
+            id: 3,
+            key: 'internal_taxonomy_key',
+            label: 'Need',
+            retired: false,
+            values: [
+                {
+                    id: 4,
+                    key: 'internal_value_key',
+                    label: 'Housing',
+                    retired: false,
+                },
+            ],
+        },
+    ],
+    intake_fields: [
+        {
+            id: 5,
+            key: 'internal_field_key',
+            label: 'Contact preference',
+            field_type: 'text' as const,
+            is_required: false,
+            retired: false,
+        },
+    ],
     eligibility_questions: [],
     risk_flags: [],
     canUpdate: true,
@@ -103,6 +142,7 @@ describe('Program pathways', () => {
         expect(
             screen.queryByDisplayValue('Youth Development'),
         ).not.toBeInTheDocument();
+        expect(screen.queryByText(/internal_.*_key/)).not.toBeInTheDocument();
 
         fireEvent.change(screen.getByRole('combobox', { name: 'Program' }), {
             target: { value: '20' },

--- a/resources/js/tests/pages/programs-index.test.tsx
+++ b/resources/js/tests/pages/programs-index.test.tsx
@@ -1,0 +1,143 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import ProgramsIndex from '@/pages/programs/index';
+
+let formIsDirty = false;
+
+vi.mock('@inertiajs/react', () => ({
+    Head: () => null,
+    useForm: <T,>(data: T) => ({
+        data,
+        errors: {},
+        isDirty: formIsDirty,
+        patch: vi.fn(),
+        processing: false,
+        recentlySuccessful: false,
+        setData: vi.fn(),
+        setDefaults: vi.fn(),
+    }),
+    usePage: () => ({
+        props: { currentOrganisation: { slug: 'harbour-kind' } },
+    }),
+}));
+
+vi.mock('@/components/ui/select', () => ({
+    Select: ({
+        children,
+        onValueChange,
+        value,
+    }: {
+        children: ReactNode;
+        onValueChange: (value: string) => void;
+        value: string;
+    }) => (
+        <select
+            aria-label="Program"
+            value={value}
+            onChange={(event) => onValueChange(event.target.value)}
+        >
+            {children}
+        </select>
+    ),
+    SelectContent: ({ children }: { children: ReactNode }) => children,
+    SelectItem: ({
+        children,
+        value,
+    }: {
+        children: ReactNode;
+        value: string;
+    }) => <option value={value}>{children}</option>,
+    SelectTrigger: () => null,
+    SelectValue: () => null,
+}));
+
+vi.mock('@/routes/programs', () => ({
+    index: vi.fn(),
+}));
+
+vi.mock('@/routes/organisations/programs', () => ({
+    update: { url: vi.fn() },
+}));
+
+const program = (id: number, name: string) => ({
+    id,
+    name,
+    slug: name.toLowerCase().replaceAll(' ', '-'),
+    request_label: 'Request',
+    case_label: 'Case',
+    case_default_classification: 'confidential' as const,
+    stages: [],
+    outcome_measures: [],
+    taxonomies: [],
+    intake_fields: [],
+    eligibility_questions: [],
+    risk_flags: [],
+    canUpdate: true,
+});
+
+describe('Program pathways', () => {
+    beforeEach(() => {
+        formIsDirty = false;
+    });
+
+    afterEach(() => {
+        cleanup();
+        vi.restoreAllMocks();
+    });
+
+    it('shows one selected Program editor at a time', () => {
+        render(
+            <ProgramsIndex
+                programs={[
+                    program(10, 'Family Support'),
+                    program(20, 'Youth Development'),
+                ]}
+            />,
+        );
+
+        expect(screen.getByLabelText('Program name')).toHaveValue(
+            'Family Support',
+        );
+        expect(
+            screen.queryByDisplayValue('Youth Development'),
+        ).not.toBeInTheDocument();
+
+        fireEvent.change(screen.getByRole('combobox', { name: 'Program' }), {
+            target: { value: '20' },
+        });
+
+        expect(screen.getByLabelText('Program name')).toHaveValue(
+            'Youth Development',
+        );
+        expect(
+            screen.queryByDisplayValue('Family Support'),
+        ).not.toBeInTheDocument();
+    });
+
+    it('keeps the selected Program when unsaved changes are not discarded', () => {
+        formIsDirty = true;
+        vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+        render(
+            <ProgramsIndex
+                programs={[
+                    program(10, 'Family Support'),
+                    program(20, 'Youth Development'),
+                ]}
+            />,
+        );
+
+        fireEvent.change(screen.getByRole('combobox', { name: 'Program' }), {
+            target: { value: '20' },
+        });
+
+        expect(window.confirm).toHaveBeenCalledWith(
+            'Discard your unsaved changes and open another Program?',
+        );
+        expect(screen.getByLabelText('Program name')).toHaveValue(
+            'Family Support',
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- show one Program pathway editor at a time
- add an accessible Program selector and empty state
- protect unsaved edits when switching Programs
- remove implementation-history language from user-facing configuration copy
- add frontend regression coverage for selection and discard cancellation

## Verification
- `php artisan test --compact tests/Feature/ProgramConfigurationTest.php`
- `npm test -- --maxWorkers=1`
- `npm run check`
- `npm run types:check`
- `npm run build:ssr`

Signed-off-by: Marlin F <marlinf@users.noreply.github.com>