### PR TITLE
Add Petrona display face and design context

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -1,0 +1,134 @@
+# Impeccable
+
+Design context for CommunityKind. Read this before any UI work.
+
+## Design Context
+
+### Users
+
+**Staff (primary, desktop, all day).** Case workers, program managers, engagement and
+fundraising officers, Organisation administrators, and executive viewers at locally focused
+nonprofits of roughly 10–75 staff running two to six service programs. They have no
+dedicated CRM engineering team. Case workers in particular sit in this product through
+emotionally heavy work — intake, confidential case notes, outcomes that do not always
+improve. The interface must not add friction or noise to a day that is already hard.
+
+**Supporters (public tenant surfaces, mostly phones).** Donors, volunteers, goods donors,
+and business partners meeting the Organisation through public forms, receipts, unsubscribe
+links, and `/account` self-service. Short, single-purpose visits. Low tolerance for
+ambiguity about who they are giving to or what happens next.
+
+**Technical evaluators (demo sandbox).** People assessing CommunityKind as an adaptable
+Laravel reference implementation, working through the guided 15-minute demo. Their
+impression forms in the first screen.
+
+The job to be done: connect service delivery, supporter engagement, and impact reporting in
+one place, while keeping sensitive client information deliberately separate from fundraising
+workflows.
+
+### Brand Personality
+
+**Quiet · dignified · unhurried.**
+
+The interface should feel like a well-designed public-health or civic service, not a SaaS
+dashboard. Confident enough not to decorate. Nothing shouts, nothing celebrates. When a
+screen holds sensitive client information, the design itself should communicate that the
+information is being handled with care.
+
+Emotional goals: **composure** for staff, **trust** for supporters, **credibility** for
+evaluators. Explicitly not: excitement, urgency, playfulness, or triumph. Impact reporting
+is where the product earns its keep — treat outcomes seriously rather than gamifying them.
+
+### Aesthetic Direction
+
+**Calm institutional care.** Generous space, restrained accents, strong typographic
+hierarchy carrying the load that colour and ornament would carry elsewhere.
+
+**Theme.** Light is the designed default on every surface — staff app and public tenant
+pages alike. Daytime casework, anxious supporters on phones, and the dignity of the subject
+matter all point the same way. Dark mode stays fully supported and correct (tokens, contrast,
+focus rings) but is not where design effort goes. Never make dark mode the showcase.
+
+**Typography.**
+
+- Body, UI, forms, tables, labels: **Instrument Sans** (existing, retained). This is a
+  deliberate exception to the usual ban on default-feeling faces — it is already tuned
+  against shadcn/ui, and churning it would touch every screen for little gain. Do not
+  swap it out without an explicit decision.
+- Display: **Petrona**, exposed as the `--font-display` token and the `font-display`
+  utility. Low-contrast serif, economical widths, faintly hand-drawn terminals —
+  a printed social-services report rather than a magazine. Loaded via `bunny('Petrona')`
+  in `vite.config.ts` at weights 500 and 600, normal and italic, with weight 600
+  preloaded. Alternate if Petrona fails in practice: **Literata**. Never substitute
+  Fraunces, Newsreader, Instrument Serif, Playfair, Cormorant, or Syne.
+- **Where `font-display` goes.** Page-level titles (`h1`), marketing and report headlines,
+  and impact figures. The serif marks arrival at a place, not every subdivision.
+- **Where it does not.** Section headings _inside_ a page, form-group labels, table
+  headers, card titles, badges, buttons, and all body copy stay on `--font-sans`, so
+  dense operational screens read as one system. When in doubt, it stays sans.
+- **Optical tuning when you apply it.** Tracking values in this codebase were tuned for
+  Instrument Sans and are too tight for a serif. At display sizes use roughly `-0.02em`
+  (5xl and above) or `-0.015em` (4xl), not `-0.035em`/`-0.055em`, and give a serif hero
+  at least `1.04` leading. Below `text-2xl`, drop negative tracking entirely. Impact
+  figures also take `tabular-nums` so columns align.
+- Fixed `rem` scales for the staff app and dashboards. Fluid `clamp()` only on public
+  marketing and content pages. At least a 1.25 ratio between steps; few sizes, high
+  contrast. Body copy capped at 65–75ch.
+
+**Colour.** The existing palette is settled and not up for redesign: `civic` `#173b57`,
+`service` `#1e7a70`, `service-bright` `#71c6bc`, `leaf` `#5e8f4e`, `saffron` `#e5a23a`,
+`coral` `#d86a56`, `cloud` `#f4f7f5`. Neutrals are already tinted toward civic navy — keep
+them there. Work in OKLCH for anything new, reducing chroma as lightness approaches the
+extremes. Accents stay rare: roughly 60% surface / 30% secondary text and borders / 10%
+accent by visual weight. Saffron and coral carry meaning (attention, destructive/at-risk)
+and must never be used decoratively.
+
+**Anti-references.** Do not let this look like a generic admin template or an AI-generated
+dashboard. Specifically banned:
+
+- Coloured side-stripes on cards, list items, callouts, or alerts (`border-left`/
+  `border-right` wider than 1px, hard-coded or via token). Use a full border, a background
+  tint, a leading label, or nothing.
+- Gradient text (`background-clip: text` over any gradient).
+- Glassmorphism, decorative glow, purple-to-blue gradients, neon-on-dark.
+- Uniform card grids of icon + heading + text; cards nested in cards; wrapping every
+  region in a card.
+- The hero-metric template (giant number, small label, supporting stats, gradient accent)
+  on impact reporting.
+- Rounded rectangles with generic drop shadows. Sparklines as decoration.
+- Modals, unless there is genuinely no alternative.
+
+**Motion.** Sparing and functional — state changes, entrances, exits, feedback. `transform`
+and `opacity` only; exponential ease-out; no bounce or elastic. `prefers-reduced-motion` is
+honoured everywhere. Nothing animates on a screen showing confidential case data.
+
+### Accessibility
+
+**WCAG 2.2 AA, enforced.** Violations are bugs that block a change, not backlog items.
+AA contrast on all text and meaningful non-text, complete keyboard paths, visible focus
+indicators, semantic landmarks and headings, `prefers-reduced-motion` respected, and never
+colour alone to convey state. Verified as of this file: light `--muted-foreground`
+`#526b78` on `--background` `#f4f7f5` is 5.27:1; dark `#afc1c8` on `#0d1d29` is 9.10:1.
+Both pass — do not darken or lighten these tokens without recomputing.
+
+### Design Principles
+
+1. **Client dignity is a visual property.** Sensitive client information gets calmer
+   treatment than anything else on screen — more space, less colour, no motion, no
+   celebration. Confidentiality boundaries are shown plainly, never as a scary warning
+   banner.
+2. **Outcomes over activity.** Impact reporting is the centrepiece surface. Give it real
+   typographic hierarchy and honest presentation, including outcomes that did not improve.
+   Never inflate a number by making it large.
+3. **Hierarchy through type and space, not colour and ornament.** With a locked palette and
+   rare accents, size, weight, and rhythm do the work. Vary spacing deliberately; identical
+   padding everywhere reads as unfinished.
+4. **Separation must be legible.** A user should always be able to tell which Organisation
+   they are in, which surface they are on (staff app vs public tenant vs demo sandbox), and
+   whether what they are looking at is client data or supporter data — without reading the
+   URL.
+5. **Automation with human control, made visible.** Anywhere the system acts on its own,
+   the UI shows what it will do, offers preview/pause/override, and leaves an audit trail.
+   No silent magic.
+6. **Synthetic data must look synthetic.** Demo and seeded content is always visibly
+   fictional. Never design a screen that would read as a real client record.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,35 @@ The repository uses the five canonical triage labels without renaming. See `docs
 
 This is a single-context repository using root `CONTEXT.md` and `docs/adr/`. See `docs/agents/domain.md`.
 
+### Design context
+
+Full design context is in root `.impeccable.md`. Read it before any UI work. The
+non-negotiables:
+
+- **Aesthetic:** calm institutional care. Quiet, dignified, unhurried — a well-designed
+  civic service, not a SaaS dashboard. Hierarchy comes from type and space, not colour
+  and ornament.
+- **Theme:** light is the designed default on every surface, staff and public. Dark mode
+  stays correct and supported but is never the showcase.
+- **Type:** Instrument Sans (`--font-sans`) for body, UI, forms, tables, and section
+  headings inside a page — retained deliberately. Petrona (`--font-display`, utility
+  `font-display`) for page-level `h1` titles, marketing and report headlines, and impact
+  figures only; when in doubt it stays sans. Tracking in this codebase was tuned for a
+  sans — loosen it to about `-0.02em` when applying the serif at display sizes. Fixed
+  `rem` scales in the staff app, `clamp()` only on public content pages.
+- **Colour:** the `civic`/`service`/`leaf`/`saffron`/`coral`/`cloud` palette in
+  `resources/css/app.css` is settled. Accents stay rare; saffron and coral carry meaning
+  and are never decorative.
+- **Accessibility:** WCAG 2.2 AA, enforced. Contrast failures, missing keyboard paths,
+  invisible focus, and unhonoured `prefers-reduced-motion` block a change.
+- **Never ship:** coloured side-stripes on cards, list items, or alerts (`border-left`/
+  `border-right` over 1px); gradient text; glassmorphism or decorative glow; uniform
+  icon-heading-text card grids; nested cards; the hero-metric template on impact reporting;
+  modals where an alternative exists.
+- **Client dignity is a visual property.** Screens holding sensitive client information get
+  calmer treatment than anything else — more space, less colour, no motion. Demo and seeded
+  content must always read as visibly synthetic.
+
 ===
 
 <laravel-boost-guidelines>

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -13,6 +13,19 @@
         'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol',
         'Noto Color Emoji';
 
+    /*
+     * Display face. Page titles and impact headlines only; body, UI, forms,
+     * and in-page section headings stay on --font-sans. See `.impeccable.md`.
+     *
+     * --font-petrona is emitted by the `@fonts` directive and carries the
+     * fontaine metric-matched fallback, which keeps the hero from shifting
+     * while the webfont loads. The literal is the belt-and-braces path for a
+     * view that renders app.css without `@fonts`.
+     */
+    --font-display:
+        var(--font-petrona, 'Petrona'), ui-serif, Georgia, 'Times New Roman',
+        serif;
+
     --color-civic: #173b57;
     --color-service: #1e7a70;
     --color-service-bright: #71c6bc;

--- a/resources/js/components/heading.tsx
+++ b/resources/js/components/heading.tsx
@@ -13,7 +13,7 @@ export default function Heading({
                 className={
                     variant === 'small'
                         ? 'mb-0.5 text-base font-medium'
-                        : 'text-xl font-semibold tracking-tight'
+                        : 'font-display text-xl font-semibold'
                 }
             >
                 {title}

--- a/resources/js/layouts/auth/auth-simple-layout.tsx
+++ b/resources/js/layouts/auth/auth-simple-layout.tsx
@@ -25,7 +25,9 @@ export default function AuthSimpleLayout({
                         </Link>
 
                         <div className="space-y-2 text-center">
-                            <h1 className="text-xl font-medium">{title}</h1>
+                            <h1 className="font-display text-xl font-medium">
+                                {title}
+                            </h1>
                             <p className="text-muted-foreground text-center text-sm">
                                 {description}
                             </p>

--- a/resources/js/layouts/auth/auth-split-layout.tsx
+++ b/resources/js/layouts/auth/auth-split-layout.tsx
@@ -31,7 +31,9 @@ export default function AuthSplitLayout({
                         <AppLogoIcon className="h-10 fill-current text-black sm:h-12" />
                     </Link>
                     <div className="flex flex-col items-start gap-2 text-left sm:items-center sm:text-center">
-                        <h1 className="text-xl font-medium">{title}</h1>
+                        <h1 className="font-display text-xl font-medium">
+                            {title}
+                        </h1>
                         <p className="text-muted-foreground text-sm text-balance">
                             {description}
                         </p>

--- a/resources/js/pages/audit/index.tsx
+++ b/resources/js/pages/audit/index.tsx
@@ -22,7 +22,9 @@ export default function AuditIndex({
             <Head title="Audit history" />
             <main className="space-y-6 p-4 md:p-6">
                 <header className="space-y-1">
-                    <h1 className="text-2xl font-semibold">Audit history</h1>
+                    <h1 className="font-display text-2xl font-semibold">
+                        Audit history
+                    </h1>
                     <p className="text-muted-foreground text-sm">
                         A policy-filtered projection for {role}. Event payloads
                         and identifiers are intentionally excluded.

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -105,7 +105,7 @@ export default function Dashboard({
                 {impact ? <ImpactMetrics impact={impact} /> : null}
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
                     <div>
-                        <h1 className="text-3xl font-semibold tracking-tight">
+                        <h1 className="font-display text-3xl font-semibold tracking-[-0.015em]">
                             Service operations
                         </h1>
                         <p className="text-muted-foreground mt-1 text-sm">
@@ -292,7 +292,7 @@ function ImpactMetrics({ impact }: { impact: ImpactDashboard }) {
                     <div className="flex items-center gap-2">
                         <h1
                             id="impact-heading"
-                            className="text-2xl font-semibold"
+                            className="font-display text-2xl font-semibold"
                         >
                             Reconciled impact
                         </h1>
@@ -407,7 +407,7 @@ function ImpactMetrics({ impact }: { impact: ImpactDashboard }) {
                                         </CardTitle>
                                     </CardHeader>
                                     <CardContent className="space-y-2">
-                                        <p className="text-3xl font-semibold">
+                                        <p className="font-display text-3xl font-semibold tabular-nums">
                                             {metricValue(
                                                 metric,
                                                 impact.currency,

--- a/resources/js/pages/demo/personas.tsx
+++ b/resources/js/pages/demo/personas.tsx
@@ -32,7 +32,7 @@ export default function DemoPersonas({ personas }: { personas: Persona[] }) {
                         className="mx-auto size-10 text-amber-600"
                         aria-hidden="true"
                     />
-                    <h1 className="text-3xl font-semibold">
+                    <h1 className="font-display text-3xl font-semibold">
                         Choose a synthetic demo persona
                     </h1>
                     <p className="text-muted-foreground">

--- a/resources/js/pages/demo/start.tsx
+++ b/resources/js/pages/demo/start.tsx
@@ -32,7 +32,7 @@ export default function DemoStart({
                         </p>
                         <h1
                             id="demo-heading"
-                            className="text-4xl font-semibold tracking-tight text-balance sm:text-6xl"
+                            className="font-display text-4xl font-semibold tracking-[-0.015em] text-balance sm:text-6xl"
                         >
                             Follow the work from first contact to community
                             impact.
@@ -83,7 +83,7 @@ export default function DemoStart({
                                     aria-hidden="true"
                                 />
                             </div>
-                            <h2 className="text-2xl font-semibold tracking-tight">
+                            <h2 className="font-display text-2xl font-semibold">
                                 Your isolated evaluation space
                             </h2>
                             <p className="text-muted-foreground leading-7">

--- a/resources/js/pages/portal/show.tsx
+++ b/resources/js/pages/portal/show.tsx
@@ -95,7 +95,7 @@ export default function PortalShow({
                         <p className="text-sm font-medium text-emerald-700 dark:text-emerald-400">
                             {organisation.name}
                         </p>
-                        <h1 className="mt-1 text-3xl font-semibold tracking-tight">
+                        <h1 className="font-display mt-1 text-3xl font-semibold tracking-[-0.015em]">
                             My supporter profile
                         </h1>
                         <p className="mt-2 max-w-2xl text-sm text-slate-600 dark:text-slate-300">

--- a/resources/js/pages/welcome.tsx
+++ b/resources/js/pages/welcome.tsx
@@ -108,9 +108,9 @@ export default function Welcome() {
                                     />
                                     Community operations for human services
                                 </p>
-                                <h1 className="text-5xl leading-[0.98] font-semibold tracking-[-0.055em] text-balance sm:text-7xl lg:text-[4.6rem]">
+                                <h1 className="font-display text-5xl leading-[1.04] font-semibold tracking-[-0.02em] text-balance sm:text-7xl lg:text-[4.6rem]">
                                     One shared thread from first contact to{' '}
-                                    <span className="text-service font-serif font-normal italic dark:text-[#71C6BC]">
+                                    <span className="text-service font-medium italic dark:text-[#71C6BC]">
                                         visible impact.
                                     </span>
                                 </h1>
@@ -234,7 +234,7 @@ export default function Welcome() {
                                 </p>
                                 <h2
                                     id="operating-model-heading"
-                                    className="mt-4 text-4xl leading-tight font-semibold tracking-[-0.035em] text-balance sm:text-5xl"
+                                    className="font-display mt-4 text-4xl leading-tight font-semibold tracking-[-0.015em] text-balance sm:text-5xl"
                                 >
                                     The work makes more sense when the thread
                                     stays intact.
@@ -269,7 +269,7 @@ export default function Welcome() {
                                                 </p>
                                             </div>
                                             <div>
-                                                <h3 className="text-xl font-semibold tracking-tight">
+                                                <h3 className="font-display text-xl font-semibold">
                                                     {title}
                                                 </h3>
                                                 <p className="text-civic/70 dark:text-cloud/70 mt-2 leading-7">
@@ -290,7 +290,7 @@ export default function Welcome() {
                                     className="size-9 text-[#71C6BC]"
                                     aria-hidden="true"
                                 />
-                                <h2 className="mt-6 text-4xl leading-tight font-semibold tracking-[-0.035em] sm:text-5xl">
+                                <h2 className="font-display mt-6 text-4xl leading-tight font-semibold tracking-[-0.015em] sm:text-5xl">
                                     Privacy is part of the operating model.
                                 </h2>
                                 <p className="text-cloud/70 mt-6 max-w-xl text-lg leading-8">
@@ -328,7 +328,7 @@ export default function Welcome() {
                                 <p className="text-service text-sm font-semibold tracking-[0.14em] uppercase dark:text-[#71C6BC]">
                                     Open by design
                                 </p>
-                                <h2 className="mt-4 max-w-3xl text-4xl leading-tight font-semibold tracking-[-0.035em] sm:text-5xl">
+                                <h2 className="font-display mt-4 max-w-3xl text-4xl leading-tight font-semibold tracking-[-0.015em] sm:text-5xl">
                                     Inspect the decisions, not just the demo.
                                 </h2>
                                 <p className="text-civic/70 dark:text-cloud/70 mt-6 max-w-2xl text-lg leading-8">
@@ -367,7 +367,7 @@ export default function Welcome() {
                                 <p className="text-coral text-sm font-semibold tracking-[0.14em] uppercase dark:text-[#F29A88]">
                                     Honest about readiness
                                 </p>
-                                <h2 className="mt-4 max-w-3xl text-4xl leading-tight font-semibold tracking-[-0.035em] sm:text-5xl">
+                                <h2 className="font-display mt-4 max-w-3xl text-4xl leading-tight font-semibold tracking-[-0.015em] sm:text-5xl">
                                     Evaluate the shape of the work—safely.
                                 </h2>
                                 <p className="text-civic/70 dark:text-cloud/70 mt-6 max-w-3xl leading-7">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,13 @@ export default defineConfig({
                 bunny('Instrument Sans', {
                     weights: [400, 500, 600],
                 }),
+                // Display face for page titles and impact headlines. See
+                // `.impeccable.md`; body/UI type stays Instrument Sans.
+                bunny('Petrona', {
+                    weights: [500, 600],
+                    styles: ['normal', 'italic'],
+                    preload: [{ weight: 600 }],
+                }),
             ],
         }),
         inertia(),


### PR DESCRIPTION
## Summary

Establishes a documented design context for the project and introduces a display typeface. Headings previously relied entirely on the body sans, and the aesthetic direction was undocumented, so every session re-derived it.

Two parts:

**Design context.** `.impeccable.md` records users, brand personality, aesthetic direction, accessibility bar, and six design principles. `AGENTS.md` carries a short pointer to the non-negotiables — calm institutional care, light as the designed default on every surface, WCAG 2.2 AA enforced, the existing civic/service palette treated as settled, and an explicit list of visual patterns not to ship. The pointer sits in the hand-written top section, outside the Laravel Boost generated block, so regeneration will not clobber it.

**Display face.** Petrona, loaded through the existing `bunny()` provider.

## Typography decisions

- **Weights 500 and 600, normal and italic.** 700 is omitted because no display heading uses bold; the italic set is needed by the welcome hero. Build output: 4 subsetted woff2 files, 104KB total, with only the 24KB weight-600 normal preloaded. The rest load lazily under `font-display: swap`.
- **`--font-display` resolves through the plugin's `--font-petrona`**, which carries the fontaine metric-matched `"Petrona fallback"` face. That is what keeps the hero from reflowing while the webfont loads. A literal `'Petrona'` remains as the fallback for any view that renders `app.css` without `@fonts`.
- **Where the serif goes:** page-level `h1` titles, marketing and report headlines, and impact figures. **Where it does not:** section headings inside a page, form labels, card titles, table headers, and all body copy stay on Instrument Sans, so dense operational screens continue to read as one system. The rule is recorded in `.impeccable.md` so it does not have to be re-derived.
- **Optics retuned.** Existing tracking was tuned for Instrument Sans and is too tight for a serif. The welcome hero moves from `-0.055em` / `0.98` leading to `-0.02em` / `1.04`; section headlines from `-0.035em` to `-0.015em`; negative tracking is dropped entirely below `text-2xl`. Impact figures also take `tabular-nums` so metric columns align.
- **Instrument Sans is retained deliberately** for body, UI, and forms. It is already tuned against shadcn/ui and replacing it would touch every screen for little gain. The reasoning is recorded so a future change does not churn it by reflex.

The welcome hero's emphasis span was already reaching for a serif via Tailwind's default `font-serif`, which resolved to system Georgia. It now uses Petrona italic in the same family as its headline.

## Surfaces touched

Both auth layouts, the `Heading` component's default variant, dashboard (page title, impact section title, metric values), all five welcome-page headlines, both demo pages, the portal profile title, and audit history.

No behavioural, authorization, or tenant-isolation changes. Keyboard and screen-reader behaviour is unaffected — this changes `font-family`, tracking, and leading only, and adds no new markup.

## Test plan

- [x] `npm run check` — 140 files formatted, 116 linted, zero warnings
- [x] `npm run types:check` — clean
- [x] `npm test` — 7 files, 11 tests passed
- [x] `php artisan test --compact` — 397 passed, 2814 assertions
- [x] `npm run docs:check` — passed for 10 published pages
- [x] `npm run build` — clean; verified Petrona woff2 emitted, `--font-petrona` in the fonts manifest, one preload entry, and `.font-display{font-family:var(--font-display)}` in the compiled CSS
- [x] `scripts/check-dco.sh` — sign-off present

Worth a look in a browser at the welcome hero and the dashboard impact figures, since the retuned tracking and leading are judgement calls that only read properly at size.

## AI-assisted contribution disclosure

Material AI assistance: authored with Claude Code (Opus 5). The font selection, the display-versus-sans boundary, the weight/italic trade-off, and the optical retuning were proposed by the model and reviewed before commit. Verification commands above were run and passed locally.

## Known issue, not addressed here

`resources/js/pages/dashboard.tsx` renders two `<h1>` elements on one page — "Service operations" (line 108) and "Reconciled impact" (line 293). Valid HTML5 and not strictly an AA failure, but it muddles the document outline for screen-reader users navigating by heading level. Left out of scope for a typography change; worth a follow-up to demote the impact heading to `h2` and confirm its `aria-labelledby` wiring still reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)