### PR TITLE
Stop the audit page rendering the app shell twice

### DIFF
--- a/resources/js/page-layout.test.ts
+++ b/resources/js/page-layout.test.ts
@@ -15,3 +15,42 @@ describe('resolvePageLayout', () => {
         expect(resolvePageLayout('portal/show')).toBeNull();
     });
 });
+
+describe('page layout ownership', () => {
+    /*
+     * Page sources as raw text, keyed by path relative to this file. Read
+     * through Vite rather than node:fs so the test needs no Node typings.
+     */
+    const sources = import.meta.glob('./pages/**/*.tsx', {
+        query: '?raw',
+        import: 'default',
+        eager: true,
+    }) as Record<string, string>;
+
+    const files = Object.keys(sources).sort();
+
+    it('finds the page components', () => {
+        expect(files.length).toBeGreaterThan(0);
+    });
+
+    /*
+     * `createInertiaApp` resolves a layout for every page through
+     * resolvePageLayout, so a page that also wraps itself in that layout
+     * renders the whole shell twice: two sidebars, two headers, two demo
+     * banners, and a <main> nested inside the shell's own <main>.
+     */
+    it.each(files)('does not re-wrap its resolved layout: %s', (file) => {
+        const name = file.replace('./pages/', '').replace(/\.tsx$/, '');
+
+        if (resolvePageLayout(name) === null) {
+            return;
+        }
+
+        for (const layout of ['AppLayout', 'AuthLayout', 'SettingsLayout']) {
+            expect(
+                sources[file],
+                `${name} renders <${layout}> itself, but resolvePageLayout already provides a layout for it`,
+            ).not.toContain(`<${layout}`);
+        }
+    });
+});

--- a/resources/js/pages/audit/index.tsx
+++ b/resources/js/pages/audit/index.tsx
@@ -1,5 +1,4 @@
 import { Head } from '@inertiajs/react';
-import AppLayout from '@/layouts/app-layout';
 
 type AuditEvent = {
     id: string;
@@ -18,81 +17,80 @@ export default function AuditIndex({
     role: string;
 }) {
     return (
-        <AppLayout breadcrumbs={[{ title: 'Audit history', href: '#' }]}>
+        <div className="space-y-6 p-4 md:p-6">
             <Head title="Audit history" />
-            <main className="space-y-6 p-4 md:p-6">
-                <header className="space-y-1">
-                    <h1 className="font-display text-2xl font-semibold">
-                        Audit history
-                    </h1>
-                    <p className="text-muted-foreground text-sm">
-                        A policy-filtered projection for {role}. Event payloads
-                        and identifiers are intentionally excluded.
-                    </p>
-                </header>
+            <header className="space-y-1">
+                <h1 className="font-display text-2xl font-semibold">
+                    Audit history
+                </h1>
+                <p className="text-muted-foreground text-sm">
+                    A policy-filtered projection for {role}. Event payloads and
+                    identifiers are intentionally excluded.
+                </p>
+            </header>
 
-                <div className="overflow-x-auto rounded-lg border">
-                    <table className="w-full text-left text-sm">
-                        <caption className="sr-only">
-                            Audit events permitted for your current role and
-                            scope
-                        </caption>
-                        <thead className="bg-muted/50">
-                            <tr>
-                                <th scope="col" className="px-4 py-3">
-                                    Time
-                                </th>
-                                <th scope="col" className="px-4 py-3">
-                                    Event
-                                </th>
-                                <th scope="col" className="px-4 py-3">
-                                    Domain
-                                </th>
-                                <th scope="col" className="px-4 py-3">
-                                    Actor
-                                </th>
-                                <th scope="col" className="px-4 py-3">
-                                    Subject type
-                                </th>
+            <div className="overflow-x-auto rounded-lg border">
+                <table className="w-full text-left text-sm">
+                    <caption className="sr-only">
+                        Audit events permitted for your current role and scope
+                    </caption>
+                    <thead className="bg-muted/50">
+                        <tr>
+                            <th scope="col" className="px-4 py-3">
+                                Time
+                            </th>
+                            <th scope="col" className="px-4 py-3">
+                                Event
+                            </th>
+                            <th scope="col" className="px-4 py-3">
+                                Domain
+                            </th>
+                            <th scope="col" className="px-4 py-3">
+                                Actor
+                            </th>
+                            <th scope="col" className="px-4 py-3">
+                                Subject type
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody className="divide-y">
+                        {events.map((event) => (
+                            <tr key={event.id}>
+                                <td className="px-4 py-3 whitespace-nowrap">
+                                    <time dateTime={event.occurredAt}>
+                                        {new Date(
+                                            event.occurredAt,
+                                        ).toLocaleString()}
+                                    </time>
+                                </td>
+                                <td className="px-4 py-3 font-medium">
+                                    {event.event}
+                                </td>
+                                <td className="px-4 py-3 capitalize">
+                                    {event.domain}
+                                </td>
+                                <td className="px-4 py-3">{event.actor}</td>
+                                <td className="px-4 py-3">{event.subject}</td>
                             </tr>
-                        </thead>
-                        <tbody className="divide-y">
-                            {events.map((event) => (
-                                <tr key={event.id}>
-                                    <td className="px-4 py-3 whitespace-nowrap">
-                                        <time dateTime={event.occurredAt}>
-                                            {new Date(
-                                                event.occurredAt,
-                                            ).toLocaleString()}
-                                        </time>
-                                    </td>
-                                    <td className="px-4 py-3 font-medium">
-                                        {event.event}
-                                    </td>
-                                    <td className="px-4 py-3 capitalize">
-                                        {event.domain}
-                                    </td>
-                                    <td className="px-4 py-3">{event.actor}</td>
-                                    <td className="px-4 py-3">
-                                        {event.subject}
-                                    </td>
-                                </tr>
-                            ))}
-                            {events.length === 0 && (
-                                <tr>
-                                    <td
-                                        colSpan={5}
-                                        className="text-muted-foreground px-4 py-8 text-center"
-                                    >
-                                        No audit events are visible within your
-                                        current policy scope.
-                                    </td>
-                                </tr>
-                            )}
-                        </tbody>
-                    </table>
-                </div>
-            </main>
-        </AppLayout>
+                        ))}
+                        {events.length === 0 && (
+                            <tr>
+                                <td
+                                    colSpan={5}
+                                    className="text-muted-foreground px-4 py-8 text-center"
+                                >
+                                    No audit events are visible within your
+                                    current policy scope.
+                                </td>
+                            </tr>
+                        )}
+                    </tbody>
+                </table>
+            </div>
+        </div>
     );
 }
+
+AuditIndex.layout = () => ({
+    breadcrumbs: [{ title: 'Audit history', href: '#' }],
+});


### PR DESCRIPTION
## The bug

`app.tsx` passes a global `layout: resolvePageLayout` to `createInertiaApp`. That resolver returns `AppLayout` for anything not matched earlier, which includes `audit/index`. But `pages/audit/index.tsx` **also** wrapped its own content in `<AppLayout>`, so the entire staff shell rendered nested inside itself.

Visible result: two sidebars, two sidebar headers each with their own collapse toggle, two demo sandbox banners, and the page content squeezed into a narrow inner card next to a dead column of empty sidebar.

There is a second defect underneath it. `AppContent` renders `SidebarInset`, which is a `<main>`. The page's own `<main>` was therefore a second `main` landmark nested inside the first — invalid HTML (`<main>` must not descend from `<main>`) and a duplicate landmark for screen-reader users navigating by landmark.

This predates the typography work in #101; both the resolver and the self-wrap are present on `main`.

## The fix

- Drop the self-wrap and the now-unused `AppLayout` import.
- Move the breadcrumb to `AuditIndex.layout = () => ({ breadcrumbs })`, the convention the other ~20 pages already use.
- Demote the page's `<main>` to a `<div>`, matching the other pages, since the shell owns the landmark.

## The guard

`audit/index.tsx` was the only page with this mistake, but the failure mode is quiet — the page still renders, just wrong — and easy to reintroduce, because wrapping your own layout is the more obvious thing to write. So the test is repo-wide rather than single-page: every page component is resolved through `resolvePageLayout`, and any page that renders a layout the resolver already supplies fails with a message naming the page and the layout.

It reads page sources through Vite's `import.meta.glob` with `?raw` rather than `node:fs`, because `tsconfig.json` is browser-scoped and does not include Node typings.

Verified in both directions: it fails against the previous audit page with
`audit/index renders <AppLayout> itself, but resolvePageLayout already provides a layout for it`,
and passes across every other page. A guard that has never been observed to fail is not a guard.

## Test plan

- [x] `npm run check` — formatted and linted, zero warnings
- [x] `npm run types:check` — clean
- [x] `npm test` — 7 files, 56 tests passed (was 11; the new guard contributes one case per page)
- [x] Guard confirmed failing against the buggy version, then restored
- [x] `scripts/check-dco.sh` — sign-off present

Worth loading the audit page to confirm the shell renders once and the breadcrumb still reads "Audit history".

## AI-assisted contribution disclosure

Material AI assistance: diagnosed and authored with Claude Code (Opus 5). The root cause was traced from a screenshot through `app.tsx` → `page-layout.ts` → `app-sidebar-layout.tsx` → `SidebarInset`. Verification commands above were run and passed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)