### PR TITLE
Give every page exactly one h1 and one main landmark

### DIFF
--- a/resources/js/components/heading.test.tsx
+++ b/resources/js/components/heading.test.tsx
@@ -1,0 +1,42 @@
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import Heading from '@/components/heading';
+
+/*
+ * page-layout.test.ts treats a default-variant <Heading> as a page's h1. That
+ * assumption only holds while this component renders one, so assert it here.
+ */
+describe('Heading', () => {
+    it('renders the page title as an h1', () => {
+        render(<Heading title="Reporting publication" />);
+
+        expect(
+            screen.getByRole('heading', {
+                level: 1,
+                name: 'Reporting publication',
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it('renders a section title one level below the page title', () => {
+        render(<Heading title="Profile information" variant="small" />);
+
+        expect(
+            screen.getByRole('heading', {
+                level: 2,
+                name: 'Profile information',
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it('renders the optional description', () => {
+        render(
+            <Heading title="Programs" description="Define service programs." />,
+        );
+
+        expect(
+            screen.getByText('Define service programs.'),
+        ).toBeInTheDocument();
+    });
+});

--- a/resources/js/components/heading.tsx
+++ b/resources/js/components/heading.tsx
@@ -7,9 +7,16 @@ export default function Heading({
     description?: string;
     variant?: 'default' | 'small';
 }) {
+    /*
+     * The default variant is the page title, so it is the document's h1. The
+     * small variant labels a section within a page and sits a level below.
+     * Rendering both as h2 left most staff pages with no h1 at all.
+     */
+    const Title = variant === 'small' ? 'h2' : 'h1';
+
     return (
         <header className={variant === 'small' ? '' : 'mb-8 space-y-0.5'}>
-            <h2
+            <Title
                 className={
                     variant === 'small'
                         ? 'mb-0.5 text-base font-medium'
@@ -17,7 +24,7 @@ export default function Heading({
                 }
             >
                 {title}
-            </h2>
+            </Title>
             {description && (
                 <p className="text-muted-foreground text-sm">{description}</p>
             )}

--- a/resources/js/page-layout.test.ts
+++ b/resources/js/page-layout.test.ts
@@ -4,6 +4,8 @@ vi.mock('@/layouts/app-layout', () => ({ default: () => null }));
 vi.mock('@/layouts/auth-layout', () => ({ default: () => null }));
 vi.mock('@/layouts/settings/layout', () => ({ default: () => null }));
 
+import AuthLayout from '@/layouts/auth-layout';
+import SettingsLayout from '@/layouts/settings/layout';
 import { resolvePageLayout } from './page-layout';
 
 describe('resolvePageLayout', () => {
@@ -39,6 +41,28 @@ describe('page layout ownership', () => {
      * renders the whole shell twice: two sidebars, two headers, two demo
      * banners, and a <main> nested inside the shell's own <main>.
      */
+    /*
+     * AppContent renders SidebarInset, which is a <main>. A page that opens its
+     * own <main> therefore nests one landmark inside another: invalid HTML, and
+     * a duplicate landmark for anyone navigating by landmark. Pages the resolver
+     * gives no layout (welcome, demo, portal) own their <main> legitimately.
+     */
+    it.each(files)(
+        'does not open a <main> the shell already owns: %s',
+        (file) => {
+            const name = file.replace('./pages/', '').replace(/\.tsx$/, '');
+
+            if (resolvePageLayout(name) === null) {
+                return;
+            }
+
+            expect(
+                sources[file],
+                `${name} opens its own <main>, but its resolved layout already renders one`,
+            ).not.toContain('<main');
+        },
+    );
+
     it.each(files)('does not re-wrap its resolved layout: %s', (file) => {
         const name = file.replace('./pages/', '').replace(/\.tsx$/, '');
 
@@ -52,5 +76,49 @@ describe('page layout ownership', () => {
                 `${name} renders <${layout}> itself, but resolvePageLayout already provides a layout for it`,
             ).not.toContain(`<${layout}`);
         }
+    });
+});
+
+describe('page title structure', () => {
+    const sources = import.meta.glob('./pages/**/*.tsx', {
+        query: '?raw',
+        import: 'default',
+        eager: true,
+    }) as Record<string, string>;
+
+    const files = Object.keys(sources).sort();
+
+    const occurrences = (source: string, needle: string) =>
+        source.split(needle).length - 1;
+
+    /*
+     * Every page needs exactly one h1, from exactly one source: a literal <h1>,
+     * a default-variant <Heading> (the page title), or a layout that supplies
+     * one. AuthLayout renders the h1 for auth pages; SettingsLayout renders a
+     * default <Heading> above the settings sub-nav. Counting them together
+     * catches both a missing h1 and two competing ones.
+     */
+    it.each(files)('has exactly one source of an h1: %s', (file) => {
+        const name = file.replace('./pages/', '').replace(/\.tsx$/, '');
+        const source = sources[file]!;
+        const layout = resolvePageLayout(name);
+
+        const layoutProvides =
+            layout === AuthLayout ||
+            (Array.isArray(layout) && layout.includes(SettingsLayout))
+                ? 1
+                : 0;
+
+        // A <Heading> is the page title unless it is the small section variant.
+        const headings =
+            occurrences(source, '<Heading') -
+            occurrences(source, 'variant="small"');
+
+        const literal = occurrences(source, '<h1');
+
+        expect(
+            literal + headings + layoutProvides,
+            `${name}: expected one h1 source, found ${literal} literal <h1>, ${headings} page-title <Heading>, ${layoutProvides} from its layout`,
+        ).toBe(1);
     });
 });

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -101,13 +101,20 @@ export default function Dashboard({
                 open={pendingInvitations.length > 0 && showInvitations}
                 onOpenChange={setShowInvitations}
             />
-            <main className="flex h-full flex-1 flex-col gap-6 overflow-x-auto rounded-xl p-4 sm:p-6">
+            <div className="flex h-full flex-1 flex-col gap-6 overflow-x-auto rounded-xl p-4 sm:p-6">
+                {/*
+                 * Both visible headings below name a section rather than the
+                 * page, and the impact section renders first, so the page
+                 * title is carried non-visually to avoid restating the
+                 * breadcrumb.
+                 */}
+                <h1 className="sr-only">Dashboard</h1>
                 {impact ? <ImpactMetrics impact={impact} /> : null}
                 <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
                     <div>
-                        <h1 className="font-display text-3xl font-semibold tracking-[-0.015em]">
+                        <h2 className="font-display text-3xl font-semibold tracking-[-0.015em]">
                             Service operations
-                        </h1>
+                        </h2>
                         <p className="text-muted-foreground mt-1 text-sm">
                             Work requiring attention within your current scope.
                         </p>
@@ -273,7 +280,7 @@ export default function Dashboard({
                         );
                     })}
                 </div>
-            </main>
+            </div>
         </>
     );
 }
@@ -290,12 +297,12 @@ function ImpactMetrics({ impact }: { impact: ImpactDashboard }) {
             <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
                 <div>
                     <div className="flex items-center gap-2">
-                        <h1
+                        <h2
                             id="impact-heading"
                             className="font-display text-2xl font-semibold"
                         >
                             Reconciled impact
-                        </h1>
+                        </h2>
                         <Badge variant="outline">Fictional data</Badge>
                     </div>
                     <p className="text-muted-foreground mt-1 text-sm">
@@ -395,9 +402,9 @@ function ImpactMetrics({ impact }: { impact: ImpactDashboard }) {
 
                 return (
                     <div key={category} className="space-y-2">
-                        <h2 className="text-sm font-semibold tracking-wide uppercase">
+                        <h3 className="text-sm font-semibold tracking-wide uppercase">
                             {category}s
-                        </h2>
+                        </h3>
                         <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
                             {metrics.map((metric) => (
                                 <Card key={metric.definition.id}>
@@ -475,9 +482,9 @@ function MetricChart({
             aria-describedby="impact-chart-description"
         >
             <figcaption>
-                <h2 id="impact-chart-title" className="font-semibold">
+                <h3 id="impact-chart-title" className="font-semibold">
                     Presentation chart
-                </h2>
+                </h3>
                 <p
                     id="impact-chart-description"
                     className="text-muted-foreground text-sm"

--- a/resources/js/pages/demo/bootstrap.tsx
+++ b/resources/js/pages/demo/bootstrap.tsx
@@ -32,7 +32,12 @@ export default function DemoBootstrap({
                     />
                     <div className="space-y-2">
                         <CardTitle className="text-2xl">
-                            Explore a synthetic CommunityKind workspace
+                            {/*
+                             * CardTitle is a div. Tailwind's preflight unstyles
+                             * headings, so the h1 inherits its appearance and
+                             * only adds the semantics this page was missing.
+                             */}
+                            <h1>Explore a synthetic CommunityKind workspace</h1>
                         </CardTitle>
                         <CardDescription className="text-base">
                             Choose from several staff perspectives and explore

--- a/resources/js/pages/organisations/edit.tsx
+++ b/resources/js/pages/organisations/edit.tsx
@@ -113,8 +113,6 @@ export default function OrganisationEdit({
         <>
             <Head title={pageTitle} />
 
-            <h1 className="sr-only">{pageTitle}</h1>
-
             <div className="flex flex-col space-y-10">
                 <div className="space-y-6">
                     <div className="flex items-center gap-3">

--- a/resources/js/pages/organisations/index.tsx
+++ b/resources/js/pages/organisations/index.tsx
@@ -35,8 +35,6 @@ export default function OrganisationsIndex({ organisations }: Props) {
         <>
             <Head title="Organisations" />
 
-            <h1 className="sr-only">Organisations</h1>
-
             <div className="flex flex-col space-y-6">
                 <div className="flex items-center justify-between">
                     <Heading

--- a/resources/js/pages/settings/appearance.tsx
+++ b/resources/js/pages/settings/appearance.tsx
@@ -8,8 +8,6 @@ export default function Appearance() {
         <>
             <Head title="Appearance settings" />
 
-            <h1 className="sr-only">Appearance settings</h1>
-
             <div className="space-y-6">
                 <Heading
                     variant="small"

--- a/resources/js/pages/settings/profile.tsx
+++ b/resources/js/pages/settings/profile.tsx
@@ -28,8 +28,6 @@ export default function Profile({
         <>
             <Head title="Profile settings" />
 
-            <h1 className="sr-only">Profile settings</h1>
-
             <div className="space-y-6">
                 <Heading
                     variant="small"

--- a/resources/js/pages/settings/security.tsx
+++ b/resources/js/pages/settings/security.tsx
@@ -28,8 +28,6 @@ export default function Security(props: Props) {
         <>
             <Head title="Security settings" />
 
-            <h1 className="sr-only">Security settings</h1>
-
             <div className="space-y-6">
                 <Heading
                     variant="small"


### PR DESCRIPTION
## What was wrong

Three heading conventions had grown up side by side:

| Convention | Pages |
|---|---|
| visible `<h1>` | `audit`, `dashboard` |
| `sr-only` `<h1>` + the settings layout's h2 | `settings/*`, `organisations/*` (5) |
| **no `<h1>` at all** | the remaining ~22 |

`components/heading.tsx` rendered an `<h2>`, and 29 pages use it as their page title — so those pages' document outline started at h2 with no h1. `dashboard.tsx` had two visible `<h1>`. `demo/bootstrap.tsx` had no heading of any kind: its title is a `CardTitle`, which renders a `<div>`.

Separately, `dashboard.tsx:104` opened its own `<main>` while `AppContent` renders `SidebarInset`, which *is* a `<main>` — one landmark nested inside another. That is the same defect fixed on the audit page in #102, and the guard added there did not catch it, because it tests for self-wrapped layout *components* rather than for `<main>`.

## What changed

- `Heading` renders the page title as `<h1>` and the `small` section variant as `<h2>`. **Styling is untouched, so nothing moves visually.**
- The five `sr-only` h1 elements are now duplicates, so they are removed. On those pages the settings layout supplies the h1; the specific page is named by its document title and the active sub-nav item.
- `dashboard` needed more than a demotion: both visible headings name a *section*, and the impact section renders before the one that reads like a title, so demoting either would leave an h2 ahead of the h1. The page title is carried non-visually, both headings drop to h2, and the impact subsections drop to h3. A visible "Dashboard" title would only restate the breadcrumb.
- `dashboard`'s `<main>` becomes a `<div>`.
- `demo/bootstrap` gets an `<h1>` inside its `CardTitle`. Tailwind's preflight unstyles headings, so it inherits the existing appearance and adds only the missing semantics.

## Guards

Both gaps that let this through are now closed:

1. A page whose resolved layout is not `null` must not open a `<main>` — the check #102 should have had.
2. Every page must have exactly one source of an h1: a literal element, a page-title `Heading`, or a layout that supplies one (`AuthLayout`, or `SettingsLayout` via its own `Heading`). This catches both a missing h1 and two competing ones.

Guard 2 trusts `Heading` to render an h1, so `components/heading.test.tsx` asserts that directly. Without it the guard would silently pass if `Heading` regressed to an h2 — which is exactly how the original problem hid.

All five checks were confirmed failing against the previous code before being committed:

```
dashboard opens its own <main>, but its resolved layout already renders one
dashboard: expected one h1 source, found 2 literal <h1>, 0 page-title <Heading>, 0 from its layout
demo/bootstrap: expected one h1 source, found 0 literal <h1>, 0 page-title <Heading>, 0 from its layout
settings/profile: expected one h1 source, found 1 literal <h1>, 0 page-title <Heading>, 1 from its layout
Unable to find an accessible element with the role "heading" and name "Reporting publication"
```

## Test plan

- [x] `npm run check` — 142 files formatted, 118 linted, zero warnings
- [x] `npm run types:check` — clean
- [x] `npm test` — 9 files, **152 tests** passed (up from 61; the two new page guards contribute one case per page)
- [x] All heading open/close tags verified balanced across pages, components and layouts
- [x] `php artisan test --compact` — see note below

## Note: a pre-existing flaky test, not from this PR

`OrganisationTest::test_deleting_current_organisation_switches_to_alphabetically_first_remaining_organisation` fails intermittently. This PR touches no PHP, factories or tests.

Cause: `User::factory()->create()` creates its own organisation named from `fake()->company()` and makes it current. The test then adds Zulu/Alpha/Beta and asserts deletion of Zulu switches to "Alpha Organisation" — but the factory's organisation is also a membership, so whenever faker yields a name sorting before "Alpha", that one wins. The observed failure returned id `1`, the factory's organisation.

Measured at **1 failure in 25 isolated runs (~4%)**. Fixed separately so it does not ride along in a frontend accessibility change.

## AI-assisted contribution disclosure

Material AI assistance: found and authored with Claude Code (Opus 5) during a deliberate structural pass over all pages. Verification commands above were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)