### PR TITLE
Let message templates be retired, and name their list correctly

### DIFF
--- a/app/Actions/Auditing/BuildTenantAuditView.php
+++ b/app/Actions/Auditing/BuildTenantAuditView.php
@@ -134,6 +134,7 @@ class BuildTenantAuditView
             TenantAuditEventType::PartnerCommitmentRecorded,
             TenantAuditEventType::OrganisationConfigurationCreated,
             TenantAuditEventType::OrganisationConfigurationActivated,
+            TenantAuditEventType::OrganisationConfigurationRetired,
             TenantAuditEventType::ImpactSnapshotPublished,
             TenantAuditEventType::SupporterJourneyTransitioned => 'engagement',
             default => 'service',

--- a/app/Actions/Configuration/RetireOrganisationConfiguration.php
+++ b/app/Actions/Configuration/RetireOrganisationConfiguration.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace App\Actions\Configuration;
+
+use App\Actions\Auditing\RecordTenantAuditEvent;
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Enums\TenantAuditEventType;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+/**
+ * Takes a whole configuration key out of service.
+ *
+ * Configuration history is immutable and the model forbids deletion, so a key
+ * that should no longer be used is retired rather than removed. Every version
+ * still in play (draft or active) moves to retired, leaving no version of the
+ * key active. Superseded versions are left alone: they are already history.
+ *
+ * Retirement is terminal per version. A retired key is reinstated by creating
+ * a new version of it, which makes the key's latest version a draft again.
+ */
+final class RetireOrganisationConfiguration
+{
+    public function __construct(
+        private readonly OrganisationContext $context,
+        private readonly RecordTenantAuditEvent $recordAudit,
+    ) {}
+
+    /** @return Collection<int, OrganisationConfiguration> */
+    public function handle(Organisation $organisation, OrganisationConfigurationArea $area, string $key, User $actor): Collection
+    {
+        $this->context->ensureOwns($organisation->id);
+
+        return DB::transaction(function () use ($actor, $area, $key, $organisation): Collection {
+            /** @var Collection<int, OrganisationConfiguration> $versions */
+            $versions = OrganisationConfiguration::query()
+                ->where('area', $area)
+                ->where('configuration_key', $key)
+                ->lockForUpdate()
+                ->orderBy('version')
+                ->get();
+
+            if ($versions->isEmpty()) {
+                throw new LogicException("No {$area->value} configuration exists for key {$key}.");
+            }
+
+            $retirable = $versions->whereIn('status', [
+                OrganisationConfigurationStatus::Draft,
+                OrganisationConfigurationStatus::Active,
+            ]);
+
+            if ($retirable->isEmpty()) {
+                throw new LogicException("Configuration key {$key} is already retired.");
+            }
+
+            /*
+             * Saved one at a time rather than as a mass update so the model's
+             * status transition guard actually runs; a query-builder update
+             * would bypass it.
+             */
+            foreach ($retirable as $version) {
+                $version->update(['status' => OrganisationConfigurationStatus::Retired]);
+
+                $this->recordAudit->handle(
+                    $organisation,
+                    TenantAuditEventType::OrganisationConfigurationRetired,
+                    'organisation_configuration',
+                    $version->id,
+                    [
+                        'configuration_id' => $version->id,
+                        'area' => $area->value,
+                        'configuration_key' => $key,
+                        'version' => $version->version,
+                    ],
+                    $actor,
+                );
+            }
+
+            return $retirable->values();
+        });
+    }
+}

--- a/app/Enums/OrganisationConfigurationStatus.php
+++ b/app/Enums/OrganisationConfigurationStatus.php
@@ -7,4 +7,5 @@ enum OrganisationConfigurationStatus: string
     case Draft = 'draft';
     case Active = 'active';
     case Superseded = 'superseded';
+    case Retired = 'retired';
 }

--- a/app/Enums/TenantAuditEventType.php
+++ b/app/Enums/TenantAuditEventType.php
@@ -49,6 +49,7 @@ enum TenantAuditEventType: string
     case PartnerCommitmentRecorded = 'partner_commitment_recorded';
     case OrganisationConfigurationCreated = 'organisation_configuration_created';
     case OrganisationConfigurationActivated = 'organisation_configuration_activated';
+    case OrganisationConfigurationRetired = 'organisation_configuration_retired';
     case ImpactSnapshotPublished = 'impact_snapshot_published';
     case SupporterJourneyTransitioned = 'supporter_journey_transitioned';
 
@@ -199,6 +200,7 @@ enum TenantAuditEventType: string
             self::PartnerCommitmentRecorded => ['commitment_id' => 'string', 'partner_profile_id' => 'string', 'status' => 'string'],
             self::OrganisationConfigurationCreated => ['configuration_id' => 'string', 'area' => 'string', 'configuration_key' => 'string', 'version' => 'integer'],
             self::OrganisationConfigurationActivated => ['configuration_id' => 'string', 'area' => 'string', 'configuration_key' => 'string', 'version' => 'integer'],
+            self::OrganisationConfigurationRetired => ['configuration_id' => 'string', 'area' => 'string', 'configuration_key' => 'string', 'version' => 'integer'],
             self::ImpactSnapshotPublished => ['snapshot_id' => 'string', 'audience' => 'string', 'registry_version' => 'string', 'metric_count' => 'integer'],
             self::SupporterJourneyTransitioned => ['journey_id' => 'string', 'from_status' => 'string', 'to_status' => 'string', 'scheduled_for' => 'nullable_string'],
         };

--- a/app/Http/Controllers/Organisations/MessageTemplateController.php
+++ b/app/Http/Controllers/Organisations/MessageTemplateController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Organisations;
 
 use App\Actions\Configuration\ActivateOrganisationConfiguration;
 use App\Actions\Configuration\CreateOrganisationConfiguration;
+use App\Actions\Configuration\RetireOrganisationConfiguration;
 use App\Enums\OrganisationConfigurationArea;
 use App\Enums\OrganisationConfigurationStatus;
 use App\Enums\SupporterJourneyKind;
@@ -11,6 +12,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Organisations\StoreMessageTemplateRequest;
 use App\Models\Organisation;
 use App\Models\OrganisationConfiguration;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Str;
@@ -22,32 +24,65 @@ class MessageTemplateController extends Controller
     public function index(Organisation $currentOrganisation): Response
     {
         Gate::authorize('viewAny', [OrganisationConfiguration::class, $currentOrganisation]);
+        $showRetired = request()->boolean('retired');
+
+        /*
+         * Each configuration_key is one template; version is a revision of it.
+         * Group by key so the page reads as an index of templates rather than a
+         * flat list of every revision of every template.
+         */
         $templates = OrganisationConfiguration::query()
             ->where('area', OrganisationConfigurationArea::MessageTemplate)
             ->orderBy('configuration_key')
             ->orderByDesc('version')
-            ->get();
+            ->get()
+            ->groupBy('configuration_key')
+            ->map(fn (Collection $versions, string $key): array => $this->presentTemplate($key, $versions))
+            ->values();
+
+        $retiredCount = $templates->where('retired', true)->count();
 
         return Inertia::render('message-templates/index', [
-            'templates' => $templates->map(fn (OrganisationConfiguration $template): array => [
-                'id' => $template->id,
-                'key' => $template->configuration_key,
-                'name' => Str::of($template->configuration_key)->replace(['-', '_'], ' ')->title()->toString(),
-                'version' => $template->version,
-                'status' => $template->status->value,
-                'channel' => $template->definition['channel'],
-                'subject' => $template->definition['subject'] ?? '',
-                'body' => $template->definition['body'],
-                'journeyKind' => $template->definition['journey_kind'],
-                'activatedAt' => $template->activated_at?->toAtomString(),
-                'canActivate' => $template->status === OrganisationConfigurationStatus::Draft
-                    && $templates->where('configuration_key', $template->configuration_key)->max('version') === $template->version,
-            ]),
+            'templates' => $showRetired
+                ? $templates->all()
+                : $templates->where('retired', false)->values()->all(),
+            'retiredCount' => $retiredCount,
+            'showRetired' => $showRetired,
             'journeyKinds' => collect(SupporterJourneyKind::cases())->map(fn (SupporterJourneyKind $kind): array => [
                 'value' => $kind->value,
                 'label' => $kind->label(),
             ]),
         ]);
+    }
+
+    /**
+     * @param  Collection<int, OrganisationConfiguration>  $versions  Newest first.
+     * @return array<string, mixed>
+     */
+    private function presentTemplate(string $key, Collection $versions): array
+    {
+        $latest = $versions->firstOrFail();
+        $highestVersion = $versions->max('version');
+
+        return [
+            'key' => $key,
+            'name' => Str::of($key)->replace(['-', '_'], ' ')->title()->toString(),
+            'channel' => $latest->definition['channel'],
+            'journeyKind' => $latest->definition['journey_kind'],
+            'retired' => $latest->status === OrganisationConfigurationStatus::Retired,
+            'activeVersion' => $versions->firstWhere('status', OrganisationConfigurationStatus::Active)?->version,
+            'versions' => $versions->map(fn (OrganisationConfiguration $template): array => [
+                'id' => $template->id,
+                'version' => $template->version,
+                'status' => $template->status->value,
+                'channel' => $template->definition['channel'],
+                'subject' => $template->definition['subject'] ?? '',
+                'body' => $template->definition['body'],
+                'activatedAt' => $template->activated_at?->toAtomString(),
+                'canActivate' => $template->status === OrganisationConfigurationStatus::Draft
+                    && $highestVersion === $template->version,
+            ])->values()->all(),
+        ];
     }
 
     public function store(StoreMessageTemplateRequest $request, Organisation $currentOrganisation, CreateOrganisationConfiguration $create): RedirectResponse
@@ -80,6 +115,20 @@ class MessageTemplateController extends Controller
             ->value('id');
         abort_unless($template->status === OrganisationConfigurationStatus::Draft && $template->id === $latestId, 409);
         $activate->handle($template, request()->user());
+
+        return back();
+    }
+
+    public function retire(Organisation $currentOrganisation, string $templateKey, RetireOrganisationConfiguration $retire): RedirectResponse
+    {
+        $latest = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::MessageTemplate)
+            ->where('configuration_key', $templateKey)
+            ->latest('version')
+            ->firstOrFail();
+        Gate::authorize('retire', $latest);
+        abort_if($latest->status === OrganisationConfigurationStatus::Retired, 409);
+        $retire->handle($currentOrganisation, OrganisationConfigurationArea::MessageTemplate, $templateKey, request()->user());
 
         return back();
     }

--- a/app/Models/OrganisationConfiguration.php
+++ b/app/Models/OrganisationConfiguration.php
@@ -41,9 +41,10 @@ class OrganisationConfiguration extends Model
             if ($configuration->isDirty('status')) {
                 $from = OrganisationConfigurationStatus::from((string) $configuration->getRawOriginal('status'));
                 $allowed = match ($from) {
-                    OrganisationConfigurationStatus::Draft => [OrganisationConfigurationStatus::Active],
-                    OrganisationConfigurationStatus::Active => [OrganisationConfigurationStatus::Superseded],
+                    OrganisationConfigurationStatus::Draft => [OrganisationConfigurationStatus::Active, OrganisationConfigurationStatus::Retired],
+                    OrganisationConfigurationStatus::Active => [OrganisationConfigurationStatus::Superseded, OrganisationConfigurationStatus::Retired],
                     OrganisationConfigurationStatus::Superseded => [],
+                    OrganisationConfigurationStatus::Retired => [],
                 };
                 if (! in_array($configuration->status, $allowed, true)) {
                     throw new LogicException("Cannot transition configuration from {$from->value} to {$configuration->status->value}.");

--- a/app/Policies/OrganisationConfigurationPolicy.php
+++ b/app/Policies/OrganisationConfigurationPolicy.php
@@ -29,6 +29,11 @@ class OrganisationConfigurationPolicy
         return $this->view($user, $configuration);
     }
 
+    public function retire(User $user, OrganisationConfiguration $configuration): bool
+    {
+        return $this->update($user, $configuration);
+    }
+
     public function delete(User $user, OrganisationConfiguration $configuration): bool
     {
         return false;

--- a/resources/js/pages/message-templates/index.tsx
+++ b/resources/js/pages/message-templates/index.tsx
@@ -1,4 +1,4 @@
-import { Form, Head, useForm, usePage } from '@inertiajs/react';
+import { Form, Head, Link, useForm, usePage } from '@inertiajs/react';
 import type { FormEvent } from 'react';
 import Heading from '@/components/heading';
 import InputError from '@/components/input-error';
@@ -8,20 +8,31 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { activate, index, store } from '@/routes/message-templates';
+import { activate, index, retire, store } from '@/routes/message-templates';
 
-type MessageTemplate = {
+type TemplateVersion = {
     id: string;
-    key: string;
-    name: string;
     version: number;
     status: string;
     channel: 'email' | 'sms';
     subject: string;
     body: string;
-    journeyKind: string;
     activatedAt: string | null;
     canActivate: boolean;
+};
+
+/*
+ * One template, newest revision first. configuration_key identifies the
+ * template; version is a revision of it.
+ */
+type MessageTemplate = {
+    key: string;
+    name: string;
+    channel: 'email' | 'sms';
+    journeyKind: string;
+    retired: boolean;
+    activeVersion: number | null;
+    versions: TemplateVersion[];
 };
 
 type JourneyKind = { value: string; label: string };
@@ -43,9 +54,13 @@ function preview(template: string) {
 
 export default function MessageTemplatesIndex({
     templates,
+    retiredCount,
+    showRetired,
     journeyKinds,
 }: {
     templates: MessageTemplate[];
+    retiredCount: number;
+    showRetired: boolean;
     journeyKinds: JourneyKind[];
 }) {
     const organisation = usePage().props.currentOrganisation!;
@@ -66,13 +81,16 @@ export default function MessageTemplatesIndex({
         });
     };
 
-    const useAsStartingPoint = (template: MessageTemplate) => {
+    const useAsStartingPoint = (
+        template: MessageTemplate,
+        version: TemplateVersion,
+    ) => {
         form.setData({
             template_key: template.key,
             name: template.name,
-            channel: template.channel,
-            subject: template.subject,
-            body: template.body,
+            channel: version.channel,
+            subject: version.subject,
+            body: version.body,
             journey_kind: template.journeyKind,
         });
         window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -246,57 +264,157 @@ export default function MessageTemplatesIndex({
             </Card>
 
             <section className="space-y-3">
-                <h2 className="text-xl font-semibold">Version history</h2>
-                {templates.map((template) => (
-                    <Card key={template.id}>
-                        <CardContent className="grid gap-4 pt-6 lg:grid-cols-[1fr_auto]">
-                            <div className="space-y-3">
-                                <div className="flex flex-wrap items-center gap-2">
-                                    <strong>
-                                        {template.name} · v{template.version}
-                                    </strong>
-                                    <Badge>{template.status}</Badge>
-                                    <Badge variant="outline">
-                                        {template.channel.toUpperCase()}
-                                    </Badge>
-                                    <Badge variant="secondary">
-                                        {template.journeyKind.replaceAll(
-                                            '_',
-                                            ' ',
-                                        )}
-                                    </Badge>
-                                </div>
-                                {template.channel === 'email' ? (
-                                    <p className="font-semibold">
-                                        {preview(template.subject)}
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                    <h2 className="text-xl font-semibold">
+                        {showRetired
+                            ? 'All templates, including retired'
+                            : 'All templates'}
+                    </h2>
+                    {retiredCount > 0 || showRetired ? (
+                        <Button asChild variant="ghost" size="sm">
+                            <Link
+                                href={
+                                    showRetired
+                                        ? index(organisation.slug)
+                                        : index(organisation.slug, {
+                                              query: { retired: 1 },
+                                          })
+                                }
+                            >
+                                {showRetired
+                                    ? 'Hide retired'
+                                    : `Show ${retiredCount} retired`}
+                            </Link>
+                        </Button>
+                    ) : null}
+                </div>
+
+                {templates.length === 0 ? (
+                    <p className="text-muted-foreground rounded-lg border border-dashed p-6 text-sm">
+                        No message templates yet. Create one above and it will
+                        appear here with every revision you make to it.
+                    </p>
+                ) : null}
+
+                {templates.map((template) => {
+                    const latest = template.versions[0]!;
+
+                    return (
+                        <Card key={template.key}>
+                            <CardContent className="grid gap-4 pt-6 lg:grid-cols-[1fr_auto]">
+                                <div className="space-y-3">
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        <strong>{template.name}</strong>
+                                        {template.retired ? (
+                                            <Badge variant="outline">
+                                                Retired
+                                            </Badge>
+                                        ) : null}
+                                        <Badge variant="outline">
+                                            {template.channel.toUpperCase()}
+                                        </Badge>
+                                        <Badge variant="secondary">
+                                            {template.journeyKind.replaceAll(
+                                                '_',
+                                                ' ',
+                                            )}
+                                        </Badge>
+                                    </div>
+
+                                    <p className="text-muted-foreground text-sm">
+                                        {template.retired
+                                            ? 'Retired, so no version is in use. Create a new version to put it back into service.'
+                                            : template.activeVersion !== null
+                                              ? `Journeys use v${template.activeVersion}.`
+                                              : 'No version is active yet, so journeys will not use this template.'}
                                     </p>
-                                ) : null}
-                                <p className="text-muted-foreground text-sm whitespace-pre-wrap">
-                                    {preview(template.body)}
-                                </p>
-                            </div>
-                            <div className="flex flex-wrap items-start gap-2">
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    onClick={() => useAsStartingPoint(template)}
-                                >
-                                    New version
-                                </Button>
-                                {template.canActivate ? (
-                                    <Form
-                                        {...activate.form([
-                                            organisation.slug,
-                                            template.id,
-                                        ])}
+
+                                    {latest.channel === 'email' ? (
+                                        <p className="font-semibold">
+                                            {preview(latest.subject)}
+                                        </p>
+                                    ) : null}
+                                    <p className="text-muted-foreground text-sm whitespace-pre-wrap">
+                                        {preview(latest.body)}
+                                    </p>
+
+                                    <details className="text-sm">
+                                        <summary className="cursor-pointer font-medium">
+                                            {template.versions.length}{' '}
+                                            {template.versions.length === 1
+                                                ? 'version'
+                                                : 'versions'}
+                                        </summary>
+                                        <ul className="mt-2 divide-y border-t">
+                                            {template.versions.map(
+                                                (version) => (
+                                                    <li
+                                                        key={version.id}
+                                                        className="flex flex-wrap items-center gap-2 py-2"
+                                                    >
+                                                        <span className="font-medium">
+                                                            v{version.version}
+                                                        </span>
+                                                        <Badge>
+                                                            {version.status}
+                                                        </Badge>
+                                                        {version.activatedAt ? (
+                                                            <span className="text-muted-foreground">
+                                                                activated{' '}
+                                                                {new Date(
+                                                                    version.activatedAt,
+                                                                ).toLocaleDateString()}
+                                                            </span>
+                                                        ) : null}
+                                                        {version.canActivate ? (
+                                                            <Form
+                                                                {...activate.form(
+                                                                    [
+                                                                        organisation.slug,
+                                                                        version.id,
+                                                                    ],
+                                                                )}
+                                                                className="ml-auto"
+                                                            >
+                                                                <Button size="sm">
+                                                                    Activate
+                                                                </Button>
+                                                            </Form>
+                                                        ) : null}
+                                                    </li>
+                                                ),
+                                            )}
+                                        </ul>
+                                    </details>
+                                </div>
+
+                                <div className="flex flex-wrap items-start gap-2">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={() =>
+                                            useAsStartingPoint(template, latest)
+                                        }
                                     >
-                                        <Button>Activate</Button>
-                                    </Form>
-                                ) : null}
-                            </div>
-                        </CardContent>
-                    </Card>
-                ))}
+                                        New version
+                                    </Button>
+                                    {template.retired ? null : (
+                                        <Form
+                                            {...retire.form([
+                                                organisation.slug,
+                                                template.key,
+                                            ])}
+                                        >
+                                            <Button variant="ghost">
+                                                Retire
+                                            </Button>
+                                        </Form>
+                                    )}
+                                </div>
+                            </CardContent>
+                        </Card>
+                    );
+                })}
             </section>
         </div>
     );

--- a/resources/js/tests/pages/message-templates-index.test.tsx
+++ b/resources/js/tests/pages/message-templates-index.test.tsx
@@ -1,0 +1,213 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import MessageTemplatesIndex from '@/pages/message-templates/index';
+
+vi.mock('@inertiajs/react', () => ({
+    Form: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+    Head: () => null,
+    Link: ({ children, href }: { children?: ReactNode; href?: unknown }) => (
+        <a href={typeof href === 'string' ? href : '#'}>{children}</a>
+    ),
+    useForm: () => ({
+        data: {
+            template_key: '',
+            name: '',
+            channel: 'email',
+            subject: '',
+            body: '',
+            journey_kind: 'general',
+        },
+        errors: {},
+        post: vi.fn(),
+        processing: false,
+        reset: vi.fn(),
+        setData: vi.fn(),
+    }),
+    usePage: () => ({
+        props: { currentOrganisation: { slug: 'harbour-kind' } },
+    }),
+}));
+
+vi.mock('@/routes/message-templates', () => ({
+    activate: { form: () => ({}) },
+    index: () => '/message-templates',
+    retire: { form: () => ({}) },
+    store: { url: () => '/message-templates' },
+}));
+
+const version = (v: number, status: string, body: string) => ({
+    id: `v${v}`,
+    version: v,
+    status,
+    channel: 'email' as const,
+    subject: 'Welcome',
+    body,
+    activatedAt: status === 'active' ? '2026-09-01T00:00:00Z' : null,
+    canActivate: status === 'draft' && v === 3,
+});
+
+const welcome = {
+    key: 'welcome-email',
+    name: 'Welcome Email',
+    channel: 'email' as const,
+    journeyKind: 'general',
+    retired: false,
+    activeVersion: 2,
+    versions: [
+        version(3, 'draft', 'Third body'),
+        version(2, 'active', 'Second body'),
+        version(1, 'superseded', 'First body'),
+    ],
+};
+
+const journeyKinds = [{ value: 'general', label: 'General' }];
+
+afterEach(cleanup);
+
+describe('message templates index', () => {
+    it('names the list for what it contains, not "Version history"', () => {
+        render(
+            <MessageTemplatesIndex
+                templates={[welcome]}
+                retiredCount={0}
+                showRetired={false}
+                journeyKinds={journeyKinds}
+            />,
+        );
+
+        expect(
+            screen.getByRole('heading', { name: 'All templates' }),
+        ).toBeInTheDocument();
+        expect(screen.queryByText('Version history')).not.toBeInTheDocument();
+
+        /*
+         * The page title already says "Message templates", so the section
+         * heading must name the list without restating it.
+         */
+        expect(screen.getAllByText('Message templates')).toHaveLength(1);
+    });
+
+    it('groups revisions under one template rather than listing each as a record', () => {
+        render(
+            <MessageTemplatesIndex
+                templates={[welcome]}
+                retiredCount={0}
+                showRetired={false}
+                journeyKinds={journeyKinds}
+            />,
+        );
+
+        // One heading for the template, not one per revision.
+        expect(screen.getAllByText('Welcome Email')).toHaveLength(1);
+
+        const versions = screen.getByText('3 versions');
+        expect(versions).toBeInTheDocument();
+
+        const list = versions.closest('details')!;
+        expect(within(list).getByText('v1')).toBeInTheDocument();
+        expect(within(list).getByText('v2')).toBeInTheDocument();
+        expect(within(list).getByText('v3')).toBeInTheDocument();
+    });
+
+    it('says which version journeys actually use', () => {
+        render(
+            <MessageTemplatesIndex
+                templates={[welcome]}
+                retiredCount={0}
+                showRetired={false}
+                journeyKinds={journeyKinds}
+            />,
+        );
+
+        expect(screen.getByText('Journeys use v2.')).toBeInTheDocument();
+    });
+
+    it('warns when no version is active', () => {
+        render(
+            <MessageTemplatesIndex
+                templates={[
+                    {
+                        ...welcome,
+                        activeVersion: null,
+                        versions: [version(1, 'draft', 'Only body')],
+                    },
+                ]}
+                retiredCount={0}
+                showRetired={false}
+                journeyKinds={journeyKinds}
+            />,
+        );
+
+        expect(
+            screen.getByText(/No version is active yet/),
+        ).toBeInTheDocument();
+    });
+
+    it('offers retirement for a live template', () => {
+        render(
+            <MessageTemplatesIndex
+                templates={[welcome]}
+                retiredCount={0}
+                showRetired={false}
+                journeyKinds={journeyKinds}
+            />,
+        );
+
+        expect(
+            screen.getByRole('button', { name: 'Retire' }),
+        ).toBeInTheDocument();
+    });
+
+    it('does not offer retirement twice, and explains reinstatement', () => {
+        render(
+            <MessageTemplatesIndex
+                templates={[{ ...welcome, retired: true, activeVersion: null }]}
+                retiredCount={1}
+                showRetired
+                journeyKinds={journeyKinds}
+            />,
+        );
+
+        expect(
+            screen.queryByRole('button', { name: 'Retire' }),
+        ).not.toBeInTheDocument();
+        expect(screen.getByText('Retired')).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                /Create a new version to put it back into service/,
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it('links to the retired templates when some are hidden', () => {
+        render(
+            <MessageTemplatesIndex
+                templates={[welcome]}
+                retiredCount={2}
+                showRetired={false}
+                journeyKinds={journeyKinds}
+            />,
+        );
+
+        expect(
+            screen.getByRole('link', { name: 'Show 2 retired' }),
+        ).toBeInTheDocument();
+    });
+
+    it('teaches the empty state rather than just reporting it', () => {
+        render(
+            <MessageTemplatesIndex
+                templates={[]}
+                retiredCount={0}
+                showRetired={false}
+                journeyKinds={journeyKinds}
+            />,
+        );
+
+        expect(
+            screen.getByText(/Create one above and it will appear here/),
+        ).toBeInTheDocument();
+    });
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -166,6 +166,7 @@ Route::prefix('{current_organisation}')
         Route::get('message-templates', [MessageTemplateController::class, 'index'])->name('message-templates.index');
         Route::post('message-templates', [MessageTemplateController::class, 'store'])->name('message-templates.store');
         Route::post('message-templates/{messageTemplate}/activate', [MessageTemplateController::class, 'activate'])->name('message-templates.activate');
+        Route::post('message-templates/{templateKey}/retire', [MessageTemplateController::class, 'retire'])->name('message-templates.retire');
         Route::get('supporter-journey-policy', [SupporterJourneyPolicyController::class, 'index'])->name('supporter-journey-policy.index');
         Route::post('supporter-journey-policy', [SupporterJourneyPolicyController::class, 'store'])->name('supporter-journey-policy.store');
         Route::post('supporter-journey-policy/{supporterJourneyPolicy}/activate', [SupporterJourneyPolicyController::class, 'activate'])->name('supporter-journey-policy.activate');

--- a/tests/Feature/MessageTemplateEditorTest.php
+++ b/tests/Feature/MessageTemplateEditorTest.php
@@ -54,9 +54,10 @@ it('creates previews activates and versions message templates without JSON', fun
         ->assertInertia(fn (Assert $page) => $page
             ->component('message-templates/index')
             ->where('templates.0.name', 'Donor Re Engagement')
-            ->where('templates.0.version', 1)
-            ->where('templates.0.body', 'Hello {{ supporter_name }}, thank you for your {{ donation_count }} gifts.')
-            ->where('templates.0.status', 'draft'));
+            ->where('templates.0.retired', false)
+            ->where('templates.0.versions.0.version', 1)
+            ->where('templates.0.versions.0.body', 'Hello {{ supporter_name }}, thank you for your {{ donation_count }} gifts.')
+            ->where('templates.0.versions.0.status', 'draft'));
 
     $this->actingAs($administrator)
         ->post(route('message-templates.activate', [$organisation, $first]))
@@ -133,8 +134,8 @@ it('only offers activation for the latest template draft', function () {
     $this->actingAs($administrator)
         ->get(route('message-templates.index', $organisation))
         ->assertInertia(fn (Assert $page) => $page
-            ->where('templates.0.canActivate', true)
-            ->where('templates.1.canActivate', false));
+            ->where('templates.0.versions.0.canActivate', true)
+            ->where('templates.0.versions.1.canActivate', false));
     $this->actingAs($administrator)
         ->post(route('message-templates.activate', [$organisation, $drafts->first()]))
         ->assertStatus(409);

--- a/tests/Feature/MessageTemplateRetirementTest.php
+++ b/tests/Feature/MessageTemplateRetirementTest.php
@@ -1,0 +1,182 @@
+<?php
+
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Enums\OrganisationRole;
+use App\Enums\TenantAuditEventType;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use App\Models\TenantAuditEvent;
+use App\Models\User;
+use App\OrganisationContext;
+use Illuminate\Database\Eloquent\Collection;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/** @return array{organisation: Organisation, administrator: User, officer: User} */
+function messageTemplateRetirementFixture(): array
+{
+    $organisation = Organisation::factory()->active()->create();
+    $administrator = User::factory()->create();
+    $officer = User::factory()->create();
+    $organisation->memberships()->create(['user_id' => $administrator->id, 'role' => OrganisationRole::OrganisationAdministrator]);
+    $organisation->memberships()->create(['user_id' => $officer->id, 'role' => OrganisationRole::EngagementOfficer]);
+
+    return compact('organisation', 'administrator', 'officer');
+}
+
+function storeMessageTemplate(User $actor, Organisation $organisation, string $body): void
+{
+    test()->actingAs($actor)
+        ->post(route('message-templates.store', $organisation), [
+            'name' => 'Welcome email',
+            'channel' => 'email',
+            'subject' => 'Welcome',
+            'body' => $body,
+            'journey_kind' => 'general',
+        ])
+        ->assertSessionHasNoErrors();
+}
+
+/** @return Collection<int, OrganisationConfiguration> */
+function welcomeEmailVersions(Organisation $organisation)
+{
+    return app(OrganisationContext::class)->run($organisation, fn () => OrganisationConfiguration::query()
+        ->where('area', OrganisationConfigurationArea::MessageTemplate)
+        ->where('configuration_key', 'welcome-email')
+        ->orderBy('version')
+        ->get());
+}
+
+it('retires every version still in play and leaves superseded history alone', function () {
+    extract(messageTemplateRetirementFixture());
+
+    storeMessageTemplate($administrator, $organisation, 'First body');
+    $first = welcomeEmailVersions($organisation)->sole();
+    $this->actingAs($administrator)->post(route('message-templates.activate', [$organisation, $first]))->assertRedirect();
+
+    storeMessageTemplate($administrator, $organisation, 'Second body');
+    $second = welcomeEmailVersions($organisation)->last();
+    $this->actingAs($administrator)->post(route('message-templates.activate', [$organisation, $second]))->assertRedirect();
+
+    // v1 superseded, v2 active. A third draft is left unactivated.
+    storeMessageTemplate($administrator, $organisation, 'Third body');
+
+    $this->actingAs($administrator)
+        ->post(route('message-templates.retire', [$organisation, 'welcome-email']))
+        ->assertRedirect();
+
+    $versions = welcomeEmailVersions($organisation);
+
+    expect($versions->pluck('status')->all())->toBe([
+        OrganisationConfigurationStatus::Superseded,
+        OrganisationConfigurationStatus::Retired,
+        OrganisationConfigurationStatus::Retired,
+    ]);
+});
+
+it('hides retired templates from the index until they are asked for', function () {
+    extract(messageTemplateRetirementFixture());
+
+    storeMessageTemplate($administrator, $organisation, 'First body');
+    $this->actingAs($administrator)
+        ->post(route('message-templates.retire', [$organisation, 'welcome-email']))
+        ->assertRedirect();
+
+    $this->actingAs($administrator)
+        ->get(route('message-templates.index', $organisation))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('templates', [])
+            ->where('retiredCount', 1)
+            ->where('showRetired', false)
+            ->etc());
+
+    $this->actingAs($administrator)
+        ->get(route('message-templates.index', [$organisation, 'retired' => 1]))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('templates.0.key', 'welcome-email')
+            ->where('templates.0.retired', true)
+            ->where('showRetired', true)
+            ->etc());
+});
+
+it('records a tenant audit event for each retired version', function () {
+    extract(messageTemplateRetirementFixture());
+
+    storeMessageTemplate($administrator, $organisation, 'First body');
+    $this->actingAs($administrator)
+        ->post(route('message-templates.retire', [$organisation, 'welcome-email']))
+        ->assertRedirect();
+
+    app(OrganisationContext::class)->run($organisation, function (): void {
+        $events = TenantAuditEvent::query()
+            ->where('type', TenantAuditEventType::OrganisationConfigurationRetired)
+            ->get();
+
+        expect($events)->toHaveCount(1)
+            ->and($events->first()->payload['configuration_key'])->toBe('welcome-email')
+            ->and($events->first()->payload['version'])->toBe(1);
+    });
+});
+
+it('refuses to retire a template twice', function () {
+    extract(messageTemplateRetirementFixture());
+
+    storeMessageTemplate($administrator, $organisation, 'First body');
+    $this->actingAs($administrator)
+        ->post(route('message-templates.retire', [$organisation, 'welcome-email']))
+        ->assertRedirect();
+    $this->actingAs($administrator)
+        ->post(route('message-templates.retire', [$organisation, 'welcome-email']))
+        ->assertStatus(409);
+});
+
+it('reinstates a retired template through a new version rather than a status change', function () {
+    extract(messageTemplateRetirementFixture());
+
+    storeMessageTemplate($administrator, $organisation, 'First body');
+    $this->actingAs($administrator)
+        ->post(route('message-templates.retire', [$organisation, 'welcome-email']))
+        ->assertRedirect();
+
+    // Retirement is terminal per version: the row itself cannot come back.
+    app(OrganisationContext::class)->run($organisation, function () use ($organisation): void {
+        $retired = welcomeEmailVersions($organisation)->sole();
+        expect(fn () => $retired->update(['status' => OrganisationConfigurationStatus::Active]))
+            ->toThrow(LogicException::class);
+    });
+
+    storeMessageTemplate($administrator, $organisation, 'Reinstated body');
+
+    $this->actingAs($administrator)
+        ->get(route('message-templates.index', $organisation))
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('templates.0.key', 'welcome-email')
+            ->where('templates.0.retired', false)
+            ->where('templates.0.versions.0.status', 'draft')
+            ->where('templates.0.versions.0.version', 2)
+            ->etc());
+});
+
+it('does not let a non-administrator retire a template', function () {
+    extract(messageTemplateRetirementFixture());
+
+    storeMessageTemplate($administrator, $organisation, 'First body');
+
+    $this->actingAs($officer)
+        ->post(route('message-templates.retire', [$organisation, 'welcome-email']))
+        ->assertForbidden();
+
+    expect(welcomeEmailVersions($organisation)->sole()->status)
+        ->toBe(OrganisationConfigurationStatus::Draft);
+});
+
+it('still refuses to delete configuration history', function () {
+    extract(messageTemplateRetirementFixture());
+
+    storeMessageTemplate($administrator, $organisation, 'First body');
+
+    app(OrganisationContext::class)->run($organisation, function () use ($organisation): void {
+        expect(fn () => welcomeEmailVersions($organisation)->sole()->delete())
+            ->toThrow(LogicException::class);
+    });
+});


### PR DESCRIPTION
Two problems reported from the same page: a message template could not be deleted, and the list of templates was titled "Version history".

## Why delete was missing — and why this is not a delete

All five configuration areas share one immutable versioned table. None has a `destroy` route, the model's `deleting` hook **throws**, and the status enum offered only `draft | active | superseded`. That is correct for the three areas that hold a *single* configuration under a fixed key:

| Page | `configuration_key` | Shape |
|---|---|---|
| `supporter-journey-policy` | `'default'` | one config, many versions |
| `intake-rules` | `'default'` | one config, many versions |
| `reporting-publication` | `'impact'` | one config, many versions |
| `public-forms` | form purpose (bounded set) | N configs × versions |
| `message-templates` | **slug of a user-supplied name** | N user-created records × versions |

Message templates are the only area where the key is user-generated, so it is the only one where arbitrary named records accumulate — and the one with no way to withdraw one. The immutability rule was designed for single-config areas and applied to a collection area where it does not fit.

So this adds retirement, not deletion:

- A terminal `Retired` status, reachable from `Draft` and `Active`.
- Retirement is **by key, not by version**: every version still in play moves to retired, leaving nothing active. Superseded versions are untouched — they are already history.
- Reinstatement is a **new version** of the same key, not a status change. No version ever returns from retired, so the immutable model holds and the audit lineage stays intact.
- Versions are saved one at a time so the model's transition guard actually runs. A query-builder `update()` would bypass model events — as the existing `activate` path does today, which is worth knowing separately.
- Each retired version records a tenant audit event.

## Why the list was called "Version history"

The same heading was copy-pasted to all five pages, but only three of them list versions of one thing. On message templates the key distinguishes *separate templates*, so that list was the record index — which is why a newly created template appeared under something that reads as an audit trail, and why the index seemed to be missing.

It is now grouped: one card per template, revisions collapsed behind a version count, the active version stated plainly (`Journeys use v2.`, or a warning when none is active), and retired templates hidden behind a `Show N retired` link.

The section heading is **"All templates"**, not "Message templates", because the page title already says the latter. The test suite caught that: my first attempt reused the page title and produced two identical headings — the exact duplication this PR set out to remove. There is now an assertion that the phrase appears once.

## Deliberate omissions, for review

- **No confirmation step on Retire.** It is reversible via a new version and fully audited, and the project's design guidance treats modals as a last resort. If you would rather it be confirmed, say so — it is a small change.
- **`public-forms` has the same mislabelling** and needs its own controller change to group by purpose. Left as a follow-up rather than enlarged into this PR.
- `CONTEXT.md` has no entry for Organisation Configuration or Message Template, and `AGENTS.md` points at a `docs/adr/` directory that does not exist — so there was no recorded decision on configuration immutability to check this against. Worth documenting the invariant now that a fourth status exists.

## Test plan

- [x] `vendor/bin/pint` — passed
- [x] `vendor/bin/phpstan analyse` — 0 errors
- [x] `php artisan test --compact` — **404 passed**, 2880 assertions (up from 397)
- [x] `npm run check` — 118 files linted, zero warnings
- [x] `npm run types:check` — clean
- [x] `npm test` — 9 files, **69 tests** passed

New `MessageTemplateRetirementTest` covers: draft and active both retired while superseded is left alone; the index hiding retired templates until asked; one audit event per retired version; a second retire returning 409; reinstatement via a new version *and* that a retired row cannot transition back; a non-administrator being forbidden; and that deletion is still refused.

New `message-templates-index.test.tsx` covers the heading, revisions grouped under one template, the active-version statement, the no-active-version warning, retire offered only for live templates, the retired filter link, and the empty state.

Two existing assertions in `MessageTemplateEditorTest` moved from `templates.0.version` to `templates.0.versions.0.version` — the payload shape intentionally changed; the assertions' intent is preserved.

## Note

`resources/js/routes` is gitignored and regenerated by the Vite plugin, so the new `retire` helper is not in the diff. Regenerate with `php artisan wayfinder:generate --with-form` if you generate manually — without `--with-form` the `.form` variants other pages rely on are dropped.

## AI-assisted contribution disclosure

Material AI assistance: diagnosed and authored with Claude Code (Opus 5). The retire-versus-delete analysis, the retire-by-key semantics, and the heading diagnosis were proposed by the model and approved before implementation. Verification commands above were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)