### PR TITLE
Stop the organisation fallback tests depending on faker ordering

### DIFF
--- a/tests/Feature/Organisations/OrganisationTest.php
+++ b/tests/Feature/Organisations/OrganisationTest.php
@@ -236,6 +236,12 @@ class OrganisationTest extends TestCase
     public function test_deleting_current_organisation_switches_to_alphabetically_first_remaining_organisation()
     {
         $user = User::factory()->create(['name' => 'Mike']);
+        /*
+         * The user factory also creates an organisation for its user, named from
+         * faker. Name it explicitly, or a generated name sorting before "Alpha
+         * Organisation" silently becomes the expected fallback.
+         */
+        $user->currentOrganisation->update(['name' => 'Original Organisation']);
 
         $zuluOrganisation = Organisation::factory()->create(['name' => 'Zulu Organisation']);
         $zuluOrganisation->members()->attach($user, ['is_owner' => true]);
@@ -331,6 +337,12 @@ class OrganisationTest extends TestCase
     {
         $owner = User::factory()->create();
         $member = User::factory()->create(['name' => 'Mike']);
+        /*
+         * The user factory also creates an organisation for its user, named from
+         * faker. Name it explicitly, or a generated name sorting before "Alpha
+         * Organisation" silently becomes the expected fallback.
+         */
+        $member->currentOrganisation->update(['name' => 'Original Organisation']);
 
         $zuluOrganisation = Organisation::factory()->create(['name' => 'Zulu Organisation']);
         $zuluOrganisation->members()->attach($owner, ['is_owner' => true]);


### PR DESCRIPTION
## The flake

Both `test_deleting_current_organisation_switches_to_alphabetically_first_remaining_organisation` and `test_leaving_current_organisation_switches_to_alphabetically_first_remaining_organisation` assert that removing "Zulu Organisation" switches the user to "Alpha Organisation".

But `UserFactory::configure()` also creates an organisation for its user and attaches it:

```php
$organisation = Organisation::factory()->active()->create();   // name from fake()->company()
$organisation->memberships()->create([...]);
$user->switchOrganisation($organisation);
```

and `HasOrganisations::fallbackOrganisation()` orders across **all** of the user's organisations:

```php
->orderByRaw('LOWER(organisations.name)')
```

So whenever faker produced a company name sorting before `alpha organisation` — "Abbott Inc", "Adams LLC" and so on — that organisation became the fallback and the assertion failed against an id the test never named. The failure I saw returned id `1`, the factory's organisation.

## Measurement

| | Failures |
|---|---|
| before | 1 in 25 isolated runs (~4%) |
| after | 0 in 40 runs × 2 tests = **80 executions** |

## The fix

Name the factory's organisation explicitly in both tests, rather than weakening the expectation:

```php
$user->currentOrganisation->update(['name' => 'Original Organisation']);
```

Every organisation the user belongs to is now known to the test, so the ordering is unambiguous and the assertion means what it says. The tests keep their realistic multi-organisation state.

## Test plan

- [x] `vendor/bin/pint` — passed
- [x] Target tests run 40× with zero failures (80 executions)
- [x] Full suite verified green on this branch

## AI-assisted contribution disclosure

Material AI assistance: found and authored with Claude Code (Opus 5). Encountered while verifying an unrelated frontend change; root cause traced to the factory/ordering interaction and confirmed by repeated runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)