### PR TITLE
Route configuration supersession through the model

### DIFF
--- a/app/Actions/Configuration/ActivateOrganisationConfiguration.php
+++ b/app/Actions/Configuration/ActivateOrganisationConfiguration.php
@@ -29,11 +29,23 @@ final class ActivateOrganisationConfiguration
                 throw new LogicException('Only the latest configuration version can be activated. Create a new version to roll back.');
             }
             $this->validate->handle($locked->area, $locked->definition);
-            OrganisationConfiguration::query()
+            /*
+             * Superseded one row at a time rather than as a query-builder
+             * update. A mass update fires no model events, so the status
+             * transition guard on the model never ran for this path: it looked
+             * protected but was not. Only versions that are actually active are
+             * touched; every other status is left as it is.
+             */
+            $superseding = OrganisationConfiguration::query()
                 ->where('area', $locked->area)
                 ->where('configuration_key', $locked->configuration_key)
                 ->where('status', OrganisationConfigurationStatus::Active)
-                ->update(['status' => OrganisationConfigurationStatus::Superseded]);
+                ->lockForUpdate()
+                ->get();
+
+            foreach ($superseding as $active) {
+                $active->update(['status' => OrganisationConfigurationStatus::Superseded]);
+            }
             $locked->update(['status' => OrganisationConfigurationStatus::Active, 'activated_by_user_id' => $actor->id, 'activated_at' => now()]);
             $this->recordAudit->handle($locked->organisation, TenantAuditEventType::OrganisationConfigurationActivated, 'organisation_configuration', $locked->id, ['configuration_id' => $locked->id, 'area' => $locked->area->value, 'configuration_key' => $locked->configuration_key, 'version' => $locked->version], $actor);
 

--- a/tests/Feature/ConfigurationActivationTest.php
+++ b/tests/Feature/ConfigurationActivationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+use App\Actions\Configuration\ActivateOrganisationConfiguration;
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use App\Models\User;
+use App\OrganisationContext;
+
+/**
+ * Activation supersedes the version currently in use. It must touch nothing
+ * else: versions already superseded are settled history, and any other status
+ * is not activation's business.
+ */
+it('supersedes only the active version and leaves other statuses alone', function () {
+    $organisation = Organisation::factory()->active()->create();
+    $administrator = User::factory()->create();
+    $organisation->memberships()->create([
+        'user_id' => $administrator->id,
+        'role' => OrganisationRole::OrganisationAdministrator,
+    ]);
+
+    app(OrganisationContext::class)->run($organisation, function () use ($administrator): void {
+        $superseded = OrganisationConfiguration::factory()->create([
+            'area' => OrganisationConfigurationArea::Reporting,
+            'configuration_key' => 'impact',
+            'version' => 1,
+            'status' => OrganisationConfigurationStatus::Superseded,
+        ]);
+        $active = OrganisationConfiguration::factory()->create([
+            'area' => OrganisationConfigurationArea::Reporting,
+            'configuration_key' => 'impact',
+            'version' => 2,
+            'status' => OrganisationConfigurationStatus::Active,
+        ]);
+        $draft = OrganisationConfiguration::factory()->create([
+            'area' => OrganisationConfigurationArea::Reporting,
+            'configuration_key' => 'impact',
+            'version' => 3,
+            'status' => OrganisationConfigurationStatus::Draft,
+            'activated_at' => null,
+        ]);
+
+        app(ActivateOrganisationConfiguration::class)->handle($draft, $administrator);
+
+        expect($draft->fresh()->status)->toBe(OrganisationConfigurationStatus::Active)
+            ->and($active->fresh()->status)->toBe(OrganisationConfigurationStatus::Superseded)
+            ->and($superseded->fresh()->status)->toBe(OrganisationConfigurationStatus::Superseded);
+    });
+});
+
+it('does not touch another configuration key while superseding', function () {
+    $organisation = Organisation::factory()->active()->create();
+    $administrator = User::factory()->create();
+    $organisation->memberships()->create([
+        'user_id' => $administrator->id,
+        'role' => OrganisationRole::OrganisationAdministrator,
+    ]);
+
+    app(OrganisationContext::class)->run($organisation, function () use ($administrator): void {
+        $otherKeyActive = OrganisationConfiguration::factory()->create([
+            'area' => OrganisationConfigurationArea::Reporting,
+            'configuration_key' => 'other-impact',
+            'version' => 1,
+            'status' => OrganisationConfigurationStatus::Active,
+        ]);
+        $draft = OrganisationConfiguration::factory()->create([
+            'area' => OrganisationConfigurationArea::Reporting,
+            'configuration_key' => 'impact',
+            'version' => 1,
+            'status' => OrganisationConfigurationStatus::Draft,
+            'activated_at' => null,
+        ]);
+
+        app(ActivateOrganisationConfiguration::class)->handle($draft, $administrator);
+
+        expect($draft->fresh()->status)->toBe(OrganisationConfigurationStatus::Active)
+            ->and($otherKeyActive->fresh()->status)->toBe(OrganisationConfigurationStatus::Active);
+    });
+});


### PR DESCRIPTION
## The problem

`OrganisationConfiguration::booted()` defines a status state machine:

```php
$allowed = match ($from) {
    Draft => [Active],
    Active => [Superseded],
    Superseded => [],
};
```

But `ActivateOrganisationConfiguration` superseded the outgoing version with a query-builder update:

```php
OrganisationConfiguration::query()
    ->where('status', Active)
    ->update(['status' => Superseded]);
```

Query-builder updates fire **no model events**, so the `updating` hook never ran for this path. The guard looked like it governed every status change; in fact it governed none made here.

## Honest scope: this changes no behaviour today

The transition performed — `Active → Superseded` — is one the guard permits, and the `WHERE` clause already limited it to active rows. So there is no bug being fixed and no test that fails before and passes after.

The value is that the path is now genuinely covered. A future change to the state machine will be enforced here instead of silently skipped — which matters more now that the enum is growing (a fourth status arrives in #105).

I'd rather state that plainly than manufacture a regression test that pretends otherwise.

## The change

Fetch the active versions under the same `lockForUpdate()` and save them one at a time, so the guard runs. The lock is preserved, so the atomicity the mass update provided is unchanged.

Added tests for the invariant the path must hold regardless of implementation:

- activating a version supersedes the version in use, and leaves an already-superseded version alone
- superseding does not touch a different `configuration_key`

Both pass before and after; they document the contract rather than the fix.

## Test plan

- [x] `vendor/bin/pint` — passed
- [x] `vendor/bin/phpstan analyse` — 0 errors
- [x] `php artisan test --compact` — 399 passed, 2819 assertions

## AI-assisted contribution disclosure

Material AI assistance: found and authored with Claude Code (Opus 5), noticed while reading the activate path to model a new retire action on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)