### PR TITLE
Remove the two banned side-stripe accents

### DIFF
--- a/resources/js/design-bans.test.ts
+++ b/resources/js/design-bans.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+/*
+ * Two CSS patterns are ruled out by `.impeccable.md`, both because they read as
+ * templated rather than designed. They are easy to reintroduce by habit, so they
+ * are checked here rather than left to review.
+ */
+
+const sources = {
+    ...import.meta.glob('./pages/**/*.tsx', {
+        query: '?raw',
+        import: 'default',
+        eager: true,
+    }),
+    ...import.meta.glob('./components/**/*.tsx', {
+        query: '?raw',
+        import: 'default',
+        eager: true,
+    }),
+    ...import.meta.glob('./layouts/**/*.tsx', {
+        query: '?raw',
+        import: 'default',
+        eager: true,
+    }),
+} as Record<string, string>;
+
+const files = Object.keys(sources).sort();
+
+/*
+ * A left or right border wider than 1px is banned as a card, list-item, callout
+ * or alert accent. These two are neither: each is load-bearing structure, so
+ * they are allowed by name with the reason recorded.
+ */
+const SIDE_BORDER_ALLOWED: Record<string, string> = {
+    './pages/welcome.tsx':
+        'the vertical spine of the operating-model timeline, which the node dots are positioned against',
+    './components/nav-main.tsx':
+        'the active-item indicator in the sidebar, a selection state rather than decoration',
+};
+
+// border-l-2, border-r-8, border-l-[3px], and so on. 1px sides are fine.
+const SIDE_BORDER = /border-[lr]-(?:[2-9]|\d\d|\[)/;
+
+describe('banned visual patterns', () => {
+    it('finds the source files', () => {
+        expect(files.length).toBeGreaterThan(0);
+    });
+
+    it.each(files)('uses no side-stripe accent: %s', (file) => {
+        const matched = SIDE_BORDER.test(sources[file]!);
+
+        if (file in SIDE_BORDER_ALLOWED) {
+            expect(
+                matched,
+                `${file} is allowlisted for ${SIDE_BORDER_ALLOWED[file]}, but no longer uses a side border. Remove it from SIDE_BORDER_ALLOWED.`,
+            ).toBe(true);
+
+            return;
+        }
+
+        expect(
+            matched,
+            `${file} uses a left or right border wider than 1px as an accent. Use a full border, a background tint, a leading icon, or nothing.`,
+        ).toBe(false);
+    });
+
+    it.each(files)('fills no text with a gradient: %s', (file) => {
+        expect(
+            sources[file]!,
+            `${file} fills text from a gradient. Use a solid colour, and weight or size for emphasis.`,
+        ).not.toMatch(/background-clip:\s*text|\bbg-clip-text\b/);
+    });
+});

--- a/resources/js/pages/demo/personas.tsx
+++ b/resources/js/pages/demo/personas.tsx
@@ -59,7 +59,7 @@ export default function DemoPersonas({ personas }: { personas: Persona[] }) {
                                 </p>
                             </CardHeader>
                             <CardContent className="space-y-5">
-                                <div className="border-saffron bg-saffron/10 rounded-lg border-l-4 p-3 text-sm leading-6">
+                                <div className="border-saffron/40 bg-saffron/10 rounded-lg border p-3 text-sm leading-6">
                                     <div className="mb-1 flex items-center gap-2 font-semibold">
                                         <ShieldCheck
                                             className="size-4"

--- a/resources/js/pages/parties/show.tsx
+++ b/resources/js/pages/parties/show.tsx
@@ -384,19 +384,26 @@ export default function PartyShow({
                         <CardHeader>
                             <CardTitle>Timeline</CardTitle>
                         </CardHeader>
-                        <CardContent className="space-y-3">
-                            {party.timeline.map((event: any) => (
-                                <div key={event.id} className="border-l-2 pl-3">
-                                    <p className="text-sm font-medium">
-                                        {event.summary}
-                                    </p>
-                                    <p className="text-muted-foreground text-xs">
-                                        {new Date(
-                                            event.occurredAt,
-                                        ).toLocaleString()}
-                                    </p>
-                                </div>
-                            ))}
+                        <CardContent>
+                            <ul className="divide-y">
+                                {party.timeline.map((event: any) => (
+                                    <li
+                                        key={event.id}
+                                        className="py-3 first:pt-0 last:pb-0"
+                                    >
+                                        <p className="text-sm font-medium">
+                                            {event.summary}
+                                        </p>
+                                        <p className="text-muted-foreground text-xs">
+                                            <time dateTime={event.occurredAt}>
+                                                {new Date(
+                                                    event.occurredAt,
+                                                ).toLocaleString()}
+                                            </time>
+                                        </p>
+                                    </li>
+                                ))}
+                            </ul>
                         </CardContent>
                     </Card>
                 </div>


### PR DESCRIPTION
## What

`.impeccable.md` bans coloured side stripes on cards, list items, callouts and alerts. Two places still used them.

- **`demo/personas.tsx`** — the persona callout's `border-l-4` becomes a full 1px border at lower chroma, so the background tint carries the emphasis instead of the stripe.
- **`parties/show.tsx`** — the event timeline was a stack of `div`s each carrying its own `border-l-2`. It is a list, so it is now a `ul` with `divide-y` separators. Each event's date became a `<time dateTime=…>` while I was in there.

## The guard

`resources/js/design-bans.test.ts` scans every page, component and layout source for the two absolute bans — side borders wider than 1px, and gradient-filled text. The allowlist is asserted in both directions, so an entry that stops being needed fails the test rather than quietly widening the ban. It currently holds two entries, both selection/structure rather than decoration:

- `welcome.tsx` — the vertical spine of the operating-model timeline, which the node dots are positioned against
- `nav-main.tsx` — the active-item indicator in the sidebar

Both guards were verified failing against the original markup before being committed.

## Verification

- `npm test` — 294 passing
- `npm run check` — clean, zero warnings
- `npm run types:check` — clean

## AI-assisted contribution

Drafted with Claude Code (Opus 5) under my direction and review, as required by CONTRIBUTING.md.