### PR TITLE
Stop listing every dashboard queue twice

### DIFF
--- a/resources/js/dashboard.test.tsx
+++ b/resources/js/dashboard.test.tsx
@@ -54,9 +54,25 @@ describe('Service operations dashboard', () => {
             screen.getByRole('combobox', { name: 'Filter by program' }),
         ).toHaveAccessibleName('Filter by program');
         expect(
-            screen.getByRole('region', { name: 'Work queue counts' }),
+            screen.getByRole('region', { name: 'Work queues' }),
         ).toBeVisible();
         expect(screen.getAllByText('Queue clear')).toHaveLength(4);
+
+        /*
+         * Each queue was listed twice: once as a count card, then again as the
+         * card holding its rows. The count now sits in the row card's header,
+         * so every queue name must appear exactly once.
+         */
+        for (const label of [
+            'Active caseload',
+            'Waitlist',
+            'Overdue actions',
+            'Unresolved risks',
+            'External referrals',
+        ]) {
+            expect(screen.getAllByText(label)).toHaveLength(1);
+        }
+        expect(screen.getByText('1 open')).toBeVisible();
 
         const interactiveElements = [
             ...screen.getAllByRole('button'),

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -74,11 +74,11 @@ type ServiceOperations = {
 };
 
 const queueDefinitions = [
-    { key: 'caseload', label: 'Active caseload', accent: 'border-t-service' },
-    { key: 'waitlist', label: 'Waitlist', accent: 'border-t-saffron' },
-    { key: 'overdue', label: 'Overdue actions', accent: 'border-t-coral' },
-    { key: 'risks', label: 'Unresolved risks', accent: 'border-t-coral' },
-    { key: 'referrals', label: 'External referrals', accent: 'border-t-leaf' },
+    { key: 'caseload', label: 'Active caseload' },
+    { key: 'waitlist', label: 'Waitlist' },
+    { key: 'overdue', label: 'Overdue actions' },
+    { key: 'risks', label: 'Unresolved risks' },
+    { key: 'referrals', label: 'External referrals' },
 ] as const;
 
 type QueueKey = (typeof queueDefinitions)[number]['key'];
@@ -168,36 +168,22 @@ export default function Dashboard({
                 </div>
 
                 <section
-                    aria-label="Work queue counts"
-                    className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5"
+                    aria-label="Work queues"
+                    className="grid gap-5 xl:grid-cols-2"
                 >
-                    {queueDefinitions.map(({ key, label, accent }) => (
-                        <Card key={key} className={`border-t-4 ${accent}`}>
-                            <CardHeader className="pb-2">
-                                <CardTitle className="text-sm font-medium">
-                                    {label}
-                                </CardTitle>
-                            </CardHeader>
-                            <CardContent>
-                                <p
-                                    className="text-3xl font-semibold"
-                                    aria-live="polite"
-                                >
-                                    {serviceOperations.counts[key]}
-                                </p>
-                            </CardContent>
-                        </Card>
-                    ))}
-                </section>
-
-                <div className="grid gap-5 xl:grid-cols-2">
                     {queueDefinitions.map(({ key, label }) => {
                         const rows = serviceOperations[key] ?? [];
 
                         return (
                             <Card key={key}>
-                                <CardHeader>
+                                <CardHeader className="flex-row items-baseline justify-between gap-3 space-y-0">
                                     <CardTitle>{label}</CardTitle>
+                                    <p
+                                        className="text-muted-foreground text-sm tabular-nums"
+                                        aria-live="polite"
+                                    >
+                                        {serviceOperations.counts[key]} open
+                                    </p>
                                 </CardHeader>
                                 <CardContent>
                                     {rows.length === 0 ? (
@@ -279,7 +265,7 @@ export default function Dashboard({
                             </Card>
                         );
                     })}
-                </div>
+                </section>
             </div>
         </>
     );


### PR DESCRIPTION
Stacked on #104 — both touch `dashboard.tsx`. Review that one first; this diff is against its branch.

## What

The dashboard rendered the five work queues twice:

1. a strip of five count cards, each with a coloured `border-t-4` stripe
2. a grid of five cards holding each queue's rows

`serviceOperations.counts[key]` is exactly the length of the row list card 2 renders, so the strip was a second reading of the same figure — and it meant the page opened with five cards that said nothing a reader could not see immediately below.

The count now sits in the queue card's own header, subordinate to the title (`3 open`), and the strip is gone.

`counts` stays in the Inertia payload. It is the surface `ServiceOperationsDashboardTest` asserts tenant scoping against — that a member of one program cannot see another's caseload — and it is the authoritative figure, so the header reads it rather than `rows.length`.

## The stripes

Removing the strip also removes the `border-t-4 border-t-service` / `-saffron` / `-coral` / `-leaf` accents. That was the hero-metric template `.impeccable.md` bans, and the colours carried no meaning the labels did not already carry — two queues shared `coral` with nothing in common.

## Verification

- `npm test` — passing; the new assertion (each queue name appears exactly once) was verified failing against the old markup
- `npm run check`, `npm run types:check` — clean

## AI-assisted contribution

Drafted with Claude Code (Opus 5) under my direction and review, as required by CONTRIBUTING.md.