### PR TITLE
Group public forms by purpose instead of listing every revision

### DIFF
--- a/app/Http/Controllers/Organisations/PublicFormController.php
+++ b/app/Http/Controllers/Organisations/PublicFormController.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Controller;
 use App\Http\Requests\Organisations\StorePublicFormRequest;
 use App\Models\Organisation;
 use App\Models\OrganisationConfiguration;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
@@ -21,10 +22,21 @@ class PublicFormController extends Controller
     public function index(Organisation $currentOrganisation): Response
     {
         Gate::authorize('viewAny', [OrganisationConfiguration::class, $currentOrganisation]);
+
+        /*
+         * Each purpose is one form; version is a revision of it. Group by
+         * purpose so the page reads as an index of forms rather than a flat
+         * list of every revision of every form.
+         */
         $forms = OrganisationConfiguration::query()
             ->where('area', OrganisationConfigurationArea::PublicForm)
-            ->latest('version')
-            ->get();
+            ->orderByDesc('version')
+            ->get()
+            ->groupBy(fn (OrganisationConfiguration $form): string => $this->purpose($form))
+            ->map(fn (Collection $versions, string $purpose): array => $this->presentForm($purpose, $versions))
+            ->sortBy('purposeLabel')
+            ->values()
+            ->all();
 
         return Inertia::render('public-forms/index', [
             'purposes' => collect(PublicFormDefinition::catalogue())->map(fn (array $purpose, string $value): array => [
@@ -39,18 +51,37 @@ class PublicFormController extends Controller
                     'fixedRequired' => $field['fixed_required'],
                 ])->all(),
             ])->values(),
-            'forms' => $forms->map(fn (OrganisationConfiguration $form): array => [
+            'forms' => $forms,
+        ]);
+    }
+
+    /**
+     * @param  Collection<int, OrganisationConfiguration>  $versions  Newest first.
+     * @return array<string, mixed>
+     */
+    private function presentForm(string $purpose, Collection $versions): array
+    {
+        $highestVersion = $versions->max('version');
+
+        return [
+            'purpose' => $purpose,
+            /*
+             * A row whose stored purpose is no longer in the catalogue falls
+             * back to its configuration key, which has no catalogue entry.
+             * Indexing the catalogue directly used to fail the whole page.
+             */
+            'purposeLabel' => PublicFormDefinition::catalogue()[$purpose]['label'] ?? $purpose,
+            'activeVersion' => $versions->firstWhere('status', OrganisationConfigurationStatus::Active)?->version,
+            'versions' => $versions->map(fn (OrganisationConfiguration $form): array => [
                 'id' => $form->id,
-                'purpose' => $this->purpose($form),
-                'purposeLabel' => PublicFormDefinition::catalogue()[$this->purpose($form)]['label'],
                 'version' => $form->version,
                 'status' => $form->status->value,
-                'fields' => PublicFormDefinition::displayFields($this->purpose($form), $form->definition),
+                'fields' => PublicFormDefinition::displayFields($purpose, $form->definition),
                 'activatedAt' => $form->activated_at?->toAtomString(),
                 'canActivate' => $form->status === OrganisationConfigurationStatus::Draft
-                    && $forms->firstWhere('configuration_key', $form->configuration_key)?->id === $form->id,
-            ]),
-        ]);
+                    && $highestVersion === $form->version,
+            ])->values()->all(),
+        ];
     }
 
     public function store(StorePublicFormRequest $request, Organisation $currentOrganisation, CreateOrganisationConfiguration $create): RedirectResponse

--- a/resources/js/pages/public-forms/index.tsx
+++ b/resources/js/pages/public-forms/index.tsx
@@ -26,13 +26,18 @@ type Purpose = {
 
 type PublicFormVersion = {
     id: string;
-    purpose: string;
-    purposeLabel: string;
     version: number;
     status: string;
     fields: FormField[];
     activatedAt: string | null;
     canActivate: boolean;
+};
+
+type PublicForm = {
+    purpose: string;
+    purposeLabel: string;
+    activeVersion: number | null;
+    versions: PublicFormVersion[];
 };
 
 function FieldPreview({ field }: { field: FormField }) {
@@ -79,12 +84,60 @@ function FieldPreview({ field }: { field: FormField }) {
     );
 }
 
+function VersionDetail({
+    version,
+    organisationSlug,
+    onNewVersion,
+}: {
+    version: PublicFormVersion;
+    organisationSlug: string;
+    onNewVersion: () => void;
+}) {
+    return (
+        <div className="grid gap-3 lg:grid-cols-[1fr_auto]">
+            <div className="space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                    <strong>v{version.version}</strong>
+                    <Badge>{version.status}</Badge>
+                    {version.activatedAt ? (
+                        <time
+                            className="text-muted-foreground text-sm"
+                            dateTime={version.activatedAt}
+                        >
+                            activated{' '}
+                            {new Date(version.activatedAt).toLocaleDateString()}
+                        </time>
+                    ) : null}
+                </div>
+                <ol className="grid gap-1 text-sm sm:grid-cols-2">
+                    {version.fields.map((field, fieldIndex) => (
+                        <li key={field.key}>
+                            {fieldIndex + 1}. {field.label}
+                            {field.required ? ' · required' : ' · optional'}
+                        </li>
+                    ))}
+                </ol>
+            </div>
+            <div className="flex flex-wrap items-start gap-2">
+                <Button type="button" variant="outline" onClick={onNewVersion}>
+                    New version
+                </Button>
+                {version.canActivate ? (
+                    <Form {...activate.form([organisationSlug, version.id])}>
+                        <Button>Activate</Button>
+                    </Form>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
 export default function PublicFormsIndex({
     purposes,
     forms,
 }: {
     purposes: Purpose[];
-    forms: PublicFormVersion[];
+    forms: PublicForm[];
 }) {
     const organisation = usePage().props.currentOrganisation!;
     const initialPurpose = purposes[0];
@@ -154,11 +207,14 @@ export default function PublicFormsIndex({
         );
     };
 
-    const useAsStartingPoint = (form: PublicFormVersion) => {
+    const useAsStartingPoint = (
+        purpose: string,
+        version: PublicFormVersion,
+    ) => {
         editor.setData({
-            form: form.purpose,
-            ordered_fields: form.fields.map((field) => field.key),
-            required_fields: form.fields
+            form: purpose,
+            ordered_fields: version.fields.map((field) => field.key),
+            required_fields: version.fields
                 .filter((field) => field.required)
                 .map((field) => field.key),
         });
@@ -334,56 +390,70 @@ export default function PublicFormsIndex({
             </Card>
 
             <section className="space-y-3">
-                <h2 className="text-xl font-semibold">Version history</h2>
+                <h2 className="text-xl font-semibold">All forms</h2>
                 {forms.length === 0 ? (
                     <p className="text-muted-foreground text-sm">
-                        No public form versions yet. Built-in form behavior
-                        remains in place until a draft is activated.
+                        No public forms yet. Built-in form behavior remains in
+                        place until a draft is activated.
                     </p>
                 ) : null}
-                {forms.map((form) => (
-                    <Card key={form.id}>
-                        <CardContent className="grid gap-4 pt-6 lg:grid-cols-[1fr_auto]">
-                            <div className="space-y-3">
-                                <div className="flex flex-wrap items-center gap-2">
-                                    <strong>
-                                        {form.purposeLabel} · v{form.version}
-                                    </strong>
-                                    <Badge>{form.status}</Badge>
-                                </div>
-                                <ol className="grid gap-1 text-sm sm:grid-cols-2">
-                                    {form.fields.map((field, fieldIndex) => (
-                                        <li key={field.key}>
-                                            {fieldIndex + 1}. {field.label}
-                                            {field.required
-                                                ? ' · required'
-                                                : ' · optional'}
-                                        </li>
-                                    ))}
-                                </ol>
-                            </div>
-                            <div className="flex flex-wrap items-start gap-2">
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    onClick={() => useAsStartingPoint(form)}
-                                >
-                                    New version
-                                </Button>
-                                {form.canActivate ? (
-                                    <Form
-                                        {...activate.form([
-                                            organisation.slug,
-                                            form.id,
-                                        ])}
-                                    >
-                                        <Button>Activate</Button>
-                                    </Form>
+                {forms.map((form) => {
+                    const [current, ...superseded] = form.versions;
+
+                    return (
+                        <Card key={form.purpose}>
+                            <CardHeader className="flex-row items-baseline justify-between gap-3 space-y-0">
+                                <CardTitle>{form.purposeLabel}</CardTitle>
+                                <p className="text-muted-foreground text-sm">
+                                    {form.activeVersion === null
+                                        ? 'Not published'
+                                        : `Live: v${form.activeVersion}`}
+                                </p>
+                            </CardHeader>
+                            <CardContent className="space-y-4">
+                                {current ? (
+                                    <VersionDetail
+                                        version={current}
+                                        organisationSlug={organisation.slug}
+                                        onNewVersion={() =>
+                                            useAsStartingPoint(
+                                                form.purpose,
+                                                current,
+                                            )
+                                        }
+                                    />
                                 ) : null}
-                            </div>
-                        </CardContent>
-                    </Card>
-                ))}
+                                {superseded.length > 0 ? (
+                                    <details className="border-t pt-4">
+                                        <summary className="cursor-pointer text-sm font-medium">
+                                            {superseded.length} earlier{' '}
+                                            {superseded.length === 1
+                                                ? 'version'
+                                                : 'versions'}
+                                        </summary>
+                                        <div className="mt-4 space-y-4">
+                                            {superseded.map((version) => (
+                                                <VersionDetail
+                                                    key={version.id}
+                                                    version={version}
+                                                    organisationSlug={
+                                                        organisation.slug
+                                                    }
+                                                    onNewVersion={() =>
+                                                        useAsStartingPoint(
+                                                            form.purpose,
+                                                            version,
+                                                        )
+                                                    }
+                                                />
+                                            ))}
+                                        </div>
+                                    </details>
+                                ) : null}
+                            </CardContent>
+                        </Card>
+                    );
+                })}
             </section>
         </div>
     );

--- a/tests/Feature/PublicFormEditorTest.php
+++ b/tests/Feature/PublicFormEditorTest.php
@@ -55,9 +55,11 @@ it('creates previews and activates an ordered purpose-built public form', functi
         ->assertInertia(fn (Assert $page) => $page
             ->component('public-forms/index')
             ->where('forms.0.purpose', 'volunteer_registration')
-            ->where('forms.0.fields.0.key', 'email')
-            ->where('forms.0.fields.3.required', true)
-            ->where('forms.0.canActivate', true));
+            ->where('forms.0.activeVersion', null)
+            ->count('forms.0.versions', 1)
+            ->where('forms.0.versions.0.fields.0.key', 'email')
+            ->where('forms.0.versions.0.fields.3.required', true)
+            ->where('forms.0.versions.0.canActivate', true));
 
     $this->actingAs($administrator)
         ->post(route('public-forms.activate', [$organisation, $form]))
@@ -80,16 +82,39 @@ it('derives the structured editor state from legacy public form definitions', fu
     $this->actingAs($administrator)
         ->get(route('public-forms.index', $organisation))
         ->assertInertia(fn (Assert $page) => $page
-            ->where('forms.0.id', $legacy->id)
             ->where('forms.0.purpose', 'supporter_profile')
             ->where('forms.0.purposeLabel', 'Supporter profile')
-            ->where('forms.0.fields', [
+            ->where('forms.0.versions.0.id', $legacy->id)
+            ->where('forms.0.versions.0.fields', [
                 ['key' => 'name', 'label' => 'Name', 'type' => 'text', 'required' => true, 'fixedRequired' => true],
                 ['key' => 'email', 'label' => 'Email address', 'type' => 'email', 'required' => true, 'fixedRequired' => true],
                 ['key' => 'telephone', 'label' => 'Telephone number', 'type' => 'tel', 'required' => true, 'fixedRequired' => false],
             ]));
 
     expect($legacy->refresh()->definition)->not->toHaveKey('fields');
+});
+
+it('lists a form whose purpose has left the catalogue', function () {
+    extract(publicFormEditorFixture());
+
+    /*
+     * `purpose()` falls back to the configuration key when the stored purpose
+     * is no longer one the catalogue knows. Indexing the catalogue with that
+     * key used to fail the whole index.
+     */
+    app(OrganisationContext::class)->run($organisation, fn (): OrganisationConfiguration => OrganisationConfiguration::factory()->create([
+        'area' => OrganisationConfigurationArea::PublicForm,
+        'configuration_key' => 'retired_pledge_form',
+        'definition' => ['form' => 'a_purpose_that_no_longer_exists', 'required_fields' => []],
+    ]));
+
+    $this->actingAs($administrator)
+        ->get(route('public-forms.index', $organisation))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->where('forms.0.purpose', 'retired_pledge_form')
+            ->where('forms.0.purposeLabel', 'retired_pledge_form')
+            ->where('forms.0.versions.0.fields', []));
 });
 
 it('rejects malformed form definitions and the generic JSON workflow', function () {
@@ -134,6 +159,22 @@ it('only permits activation of the latest draft for each public form purpose', f
         ->where('configuration_key', 'event_registration')
         ->orderBy('version')
         ->get());
+
+    /*
+     * Both revisions belong to one purpose, so the index must list one form
+     * holding two versions rather than two entries competing for the same
+     * name.
+     */
+    $this->actingAs($administrator)
+        ->get(route('public-forms.index', $organisation))
+        ->assertInertia(fn (Assert $page) => $page
+            ->count('forms', 1)
+            ->where('forms.0.purpose', 'event_registration')
+            ->count('forms.0.versions', 2)
+            ->where('forms.0.versions.0.version', 2)
+            ->where('forms.0.versions.0.canActivate', true)
+            ->where('forms.0.versions.1.version', 1)
+            ->where('forms.0.versions.1.canActivate', false));
 
     $this->actingAs($administrator)
         ->post("/{$organisation->slug}/organisation-configurations/{$drafts->last()->id}/activate")


### PR DESCRIPTION
Companion to #105, which did the same for message templates.

## The mislabelling

The section beneath the editor was titled **Version history** and rendered one card per `organisation_configurations` row. Every revision of every form appeared as a peer, so three revisions of the volunteer form read as three separate forms — and the heading claimed to be the history of *one* thing while listing many.

The controller now groups by purpose. Each form is one card:

- the purpose label as the card title, with `Live: v3` or `Not published` beside it
- the newest revision shown in full
- earlier revisions behind a `<details>` disclosure, so they are reachable without competing with the current one

The section is now **All forms**.

## A 500 fixed along the way

`purpose()` falls back to the row's `configuration_key` when the stored `definition['form']` is no longer a purpose the catalogue knows. The old code then did `PublicFormDefinition::catalogue()[$purpose]['label']` — an undefined array key, so **a single such row failed the entire page** with a 500. It now falls back to the key as the label.

Verified: the new test fails against the old controller with `Undefined array key "retired_pledge_form"`, HTTP 500.

## Also

`canActivate` is now decided within a purpose's own versions instead of scanning a globally `latest('version')`-ordered list for the first row with a matching key.

## Verification

Both new assertions were verified failing against the old controller.

- `vendor/bin/pest` — 398 passing
- `vendor/bin/phpstan` — 0 errors
- `vendor/bin/pint --dirty` — clean
- `npm run check`, `npm run types:check`, `npm test` — clean

## AI-assisted contribution

Drafted with Claude Code (Opus 5) under my direction and review, as required by CONTRIBUTING.md.