### PR TITLE
Put the records first on the impact packs page

### DIFF
--- a/resources/js/pages/impact-snapshots/index.tsx
+++ b/resources/js/pages/impact-snapshots/index.tsx
@@ -1,8 +1,10 @@
 import { Form, Head, usePage } from '@inertiajs/react';
+import { useEffect, useRef, useState } from 'react';
 import Heading from '@/components/heading';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
 import { download, index, store } from '@/routes/impact-snapshots';
 
 type Snapshot = {
@@ -14,91 +16,196 @@ type Snapshot = {
     publishedAt: string | null;
 };
 
+const fieldClass = 'h-9 rounded-md border bg-transparent px-3';
+
+function ApprovalPanel({ onDismiss }: { onDismiss: () => void }) {
+    const organisation = usePage().props.currentOrganisation!;
+    const firstField = useRef<HTMLSelectElement>(null);
+
+    /*
+     * The panel is not on the page until it is asked for, so opening it has to
+     * take the caret with it. Without this the keyboard user is left at the
+     * button and has to tab back into a region that appeared behind them.
+     */
+    useEffect(() => firstField.current?.focus(), []);
+
+    return (
+        <section
+            aria-labelledby="approve-snapshot-heading"
+            className="bg-muted/30 space-y-4 rounded-xl border p-5"
+        >
+            <h2 id="approve-snapshot-heading" className="font-medium">
+                Approve a snapshot
+            </h2>
+            <Form
+                {...store.form(organisation.slug)}
+                onSuccess={onDismiss}
+                className="grid items-end gap-4 md:grid-cols-3"
+            >
+                <div className="grid gap-1.5">
+                    <Label htmlFor="audience">Audience</Label>
+                    <select
+                        id="audience"
+                        name="audience"
+                        ref={firstField}
+                        className={fieldClass}
+                    >
+                        <option value="board">Board pack</option>
+                        <option value="funder">Funder pack</option>
+                        <option value="public">Public impact</option>
+                    </select>
+                </div>
+                <div className="grid gap-1.5">
+                    <Label htmlFor="period-start">Period start</Label>
+                    <input
+                        id="period-start"
+                        name="period_start"
+                        type="date"
+                        className={fieldClass}
+                    />
+                </div>
+                <div className="grid gap-1.5">
+                    <Label htmlFor="period-end">Period end</Label>
+                    <input
+                        id="period-end"
+                        name="period_end"
+                        type="date"
+                        className={fieldClass}
+                    />
+                </div>
+                <div className="flex gap-2 md:col-span-3">
+                    <Button>Approve reconciled snapshot</Button>
+                    <Button type="button" variant="ghost" onClick={onDismiss}>
+                        Cancel
+                    </Button>
+                </div>
+            </Form>
+            <p className="text-muted-foreground text-sm">
+                An approved snapshot is immutable. The active reporting
+                configuration decides which aggregate metrics may leave the
+                dashboard.
+            </p>
+        </section>
+    );
+}
+
 export default function ImpactSnapshotsIndex({
     snapshots,
 }: {
     snapshots: Snapshot[];
 }) {
     const organisation = usePage().props.currentOrganisation!;
+    const [approving, setApproving] = useState(false);
+    const approveButton = useRef<HTMLButtonElement>(null);
+    const returnFocus = useRef(false);
+
+    /*
+     * The button is disabled while the panel is open, so it cannot take focus
+     * until the panel has gone and this render has landed. Restoring focus
+     * inside the dismiss handler silently does nothing.
+     */
+    useEffect(() => {
+        if (approving || !returnFocus.current) return;
+        returnFocus.current = false;
+        approveButton.current?.focus();
+    }, [approving]);
+
+    const dismiss = () => {
+        returnFocus.current = true;
+        setApproving(false);
+    };
+
     return (
         <div className="space-y-6 p-4">
             <Head title="Impact packs" />
-            <Heading
-                title="Impact packs"
-                description="Approve an immutable board, funder, or public snapshot from the reconciled metric registry. Active reporting configuration controls which aggregate metrics can leave the dashboard."
-            />
-            <Card>
-                <CardHeader>
-                    <CardTitle>Approve snapshot</CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <Form
-                        {...store.form(organisation.slug)}
-                        className="grid gap-3 md:grid-cols-3"
-                    >
-                        <select
-                            name="audience"
-                            className="h-9 rounded border bg-transparent px-3"
-                        >
-                            <option value="board">Board pack</option>
-                            <option value="funder">Funder pack</option>
-                            <option value="public">Public impact</option>
-                        </select>
-                        <input
-                            name="period_start"
-                            type="date"
-                            className="h-9 rounded border bg-transparent px-3"
-                        />
-                        <input
-                            name="period_end"
-                            type="date"
-                            className="h-9 rounded border bg-transparent px-3"
-                        />
-                        <Button className="md:col-span-3">
-                            Approve reconciled snapshot
-                        </Button>
-                    </Form>
-                </CardContent>
-            </Card>
-            <section className="space-y-3">
-                <h2 className="text-xl font-semibold">Approved snapshots</h2>
-                {snapshots.map((snapshot) => (
-                    <Card key={snapshot.id}>
-                        <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-6">
-                            <div>
-                                <strong>{snapshot.audience} impact</strong>
-                                <p className="text-muted-foreground text-sm">
-                                    Registry {snapshot.registryVersion} ·{' '}
-                                    {snapshot.metricCount} metrics ·{' '}
-                                    {new Date(
-                                        snapshot.approvedAt,
-                                    ).toLocaleString()}
-                                </p>
-                            </div>
-                            <div className="flex gap-2">
-                                <Badge>
-                                    {snapshot.publishedAt
-                                        ? 'published'
-                                        : 'approved'}
-                                </Badge>
-                                {snapshot.audience !== 'public' ? (
-                                    <Button variant="outline" asChild>
-                                        <a
-                                            href={
-                                                download([
-                                                    organisation.slug,
-                                                    snapshot.id,
-                                                ]).url
-                                            }
-                                        >
-                                            Download CSV pack
-                                        </a>
-                                    </Button>
-                                ) : null}
-                            </div>
-                        </CardContent>
-                    </Card>
-                ))}
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <Heading
+                    title="Impact packs"
+                    description="Immutable board, funder, and public snapshots approved from the reconciled metric registry."
+                />
+                <Button
+                    ref={approveButton}
+                    type="button"
+                    onClick={() => setApproving(true)}
+                    disabled={approving}
+                >
+                    Approve snapshot
+                </Button>
+            </div>
+
+            {approving ? <ApprovalPanel onDismiss={dismiss} /> : null}
+
+            <section aria-labelledby="approved-snapshots-heading">
+                <h2
+                    id="approved-snapshots-heading"
+                    className="mb-3 text-xl font-semibold"
+                >
+                    Approved snapshots
+                </h2>
+                {snapshots.length === 0 ? (
+                    <div className="bg-muted/30 rounded-xl border border-dashed p-6">
+                        <p className="font-medium">No snapshots approved yet</p>
+                        <p className="text-muted-foreground mt-1 text-sm">
+                            Approving a snapshot freezes the reconciled metrics
+                            for a period so a board or funder can be given a
+                            figure that will not move under them.
+                        </p>
+                    </div>
+                ) : (
+                    <ul className="space-y-3">
+                        {snapshots.map((snapshot) => (
+                            <li key={snapshot.id}>
+                                <Card>
+                                    <CardContent className="flex flex-wrap items-center justify-between gap-3 pt-6">
+                                        <div>
+                                            <strong>
+                                                {snapshot.audience} impact
+                                            </strong>
+                                            <p className="text-muted-foreground text-sm">
+                                                Registry{' '}
+                                                {snapshot.registryVersion} ·{' '}
+                                                {snapshot.metricCount} metrics ·{' '}
+                                                <time
+                                                    dateTime={
+                                                        snapshot.approvedAt
+                                                    }
+                                                >
+                                                    {new Date(
+                                                        snapshot.approvedAt,
+                                                    ).toLocaleString()}
+                                                </time>
+                                            </p>
+                                        </div>
+                                        <div className="flex gap-2">
+                                            <Badge>
+                                                {snapshot.publishedAt
+                                                    ? 'published'
+                                                    : 'approved'}
+                                            </Badge>
+                                            {snapshot.audience !== 'public' ? (
+                                                <Button
+                                                    variant="outline"
+                                                    asChild
+                                                >
+                                                    <a
+                                                        href={
+                                                            download([
+                                                                organisation.slug,
+                                                                snapshot.id,
+                                                            ]).url
+                                                        }
+                                                    >
+                                                        Download CSV pack
+                                                    </a>
+                                                </Button>
+                                            ) : null}
+                                        </div>
+                                    </CardContent>
+                                </Card>
+                            </li>
+                        ))}
+                    </ul>
+                )}
             </section>
         </div>
     );

--- a/resources/js/tests/pages/impact-snapshots-index.test.tsx
+++ b/resources/js/tests/pages/impact-snapshots-index.test.tsx
@@ -1,0 +1,77 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import ImpactSnapshotsIndex from '@/pages/impact-snapshots/index';
+
+vi.mock('@inertiajs/react', () => ({
+    Form: ({ children, ...props }: ComponentProps<'form'>) => (
+        <form {...props}>{children}</form>
+    ),
+    Head: () => null,
+    usePage: () => ({
+        props: { currentOrganisation: { slug: 'harbour-kind' } },
+    }),
+}));
+
+vi.mock('@/routes/impact-snapshots', () => ({
+    download: () => ({ url: '/harbour-kind/impact-snapshots/1/download' }),
+    index: vi.fn(),
+    store: { form: () => ({ action: '/harbour-kind/impact-snapshots' }) },
+}));
+
+const snapshot = {
+    id: 'snapshot-1',
+    audience: 'board',
+    registryVersion: '2026.1',
+    metricCount: 6,
+    approvedAt: '2026-08-01T09:00:00Z',
+    publishedAt: null,
+};
+
+describe('Impact packs index', () => {
+    afterEach(cleanup);
+
+    /*
+     * The records are what the page is for. The approval form used to sit
+     * permanently above them, so reading the list always meant scrolling past
+     * a form nobody had asked for.
+     */
+    it('shows the records first and the approval form only when asked for', () => {
+        render(<ImpactSnapshotsIndex snapshots={[snapshot]} />);
+
+        expect(
+            screen.getByRole('heading', { name: 'Approved snapshots' }),
+        ).toBeVisible();
+        expect(screen.queryByLabelText('Audience')).not.toBeInTheDocument();
+
+        fireEvent.click(
+            screen.getByRole('button', { name: 'Approve snapshot' }),
+        );
+
+        expect(screen.getByLabelText('Audience')).toBeVisible();
+        expect(screen.getByLabelText('Period start')).toBeVisible();
+        expect(screen.getByLabelText('Period end')).toBeVisible();
+    });
+
+    it('moves focus into the panel and back out again on cancel', () => {
+        render(<ImpactSnapshotsIndex snapshots={[snapshot]} />);
+
+        const open = screen.getByRole('button', { name: 'Approve snapshot' });
+        fireEvent.click(open);
+        expect(screen.getByLabelText('Audience')).toHaveFocus();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+        expect(screen.queryByLabelText('Audience')).not.toBeInTheDocument();
+        expect(open).toHaveFocus();
+    });
+
+    it('teaches the interface when nothing has been approved', () => {
+        render(<ImpactSnapshotsIndex snapshots={[]} />);
+
+        expect(screen.getByText('No snapshots approved yet')).toBeVisible();
+        expect(
+            screen.getByRole('button', { name: 'Approve snapshot' }),
+        ).toBeVisible();
+    });
+});


### PR DESCRIPTION
This is the pattern you objected to — a form sitting permanently above an index of records — fixed on one page, so there is something concrete to react to before the other eleven follow.

## The change

The approval form used to occupy the top of the page. Reading the snapshot list, which is what the page is for, always meant scrolling past a form nobody had asked for.

Now:

- the primary action (**Approve snapshot**) sits beside the page title
- the form appears **in place, above the list**, only when asked for
- it is a panel, not a modal — the list stays readable behind it, and dismissing it does not lose the page
- opening it moves focus to the first field; dismissing returns focus to the button that opened it

## Three things the old page was missing

Found while rebuilding the form, fixed here:

1. **The audience select and both date inputs had no accessible name at all** — no label, no `aria-label`, nothing. A screen reader announced three unnamed controls. That was a WCAG 2.2 AA failure on the page's only form.
2. **No empty state.** A new organisation saw a heading over nothing. It now explains what approving a snapshot is for.
3. The approval date was not machine readable; it is now a `<time dateTime=…>`.

## One implementation note

Focus restoration runs in an effect, not in the dismiss handler. The button is disabled while the panel is open, so it cannot take focus until the panel has gone and that render has landed — calling `focus()` in the handler silently did nothing. The test caught it.

## Verification

All three new tests were verified failing against the old page.

- `npm test` — 64 passing
- `npm run check`, `npm run types:check` — clean
- `vendor/bin/pest` — 397 passing

## If you like this shape

The eleven remaining pages carrying the same pattern:

| Page | Form card | Index below |
| --- | --- | --- |
| `intakes` | Record intake | Intake queue |
| `parties` | Add party | Party list |
| `volunteers` | New opportunity | Opportunity cards |
| `message-templates` | Draft a template | All templates |
| `public-forms` | Create a public form draft | All forms |
| `intake-rules` | Rule editor | Rule versions |
| `audience-segments` | New segment | Segments |
| `supporter-journeys` | New journey | Journeys |
| `supporter-journey-policy` | Policy editor | Policy versions |
| `community-engagement` | Log engagement | Engagements |
| `reporting-publication` | Publication editor | Publications |

`intakes` is the one where it costs staff the most — it has the longest form and the longest list. (`donations` looks similar at a glance but has no create form on its index, so it is not on this list.)

## AI-assisted contribution

Drafted with Claude Code (Opus 5) under my direction and review, as required by CONTRIBUTING.md.