### PR TITLE
Give Organisation Configuration a name and a documented lifecycle

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -172,6 +172,18 @@ _Avoid_: Organisation status, Hosted Access
 The effective level of access the official hosted service permits after considering Organisation Status, Subscription Status, and Access Holds: full, read-only, recovery-only, or denied. Restriction leaves Memberships and Roles intact and follows a defined recovery policy rather than deleting the Organisation; Hosted Access has no meaning for a self-hosted Organisation.
 _Avoid_: Organisation status, Subscription
 
+**Organisation Configuration**:
+An Organisation-owned, versioned definition of how one configurable area behaves for that tenant: Public Forms, Message Templates, Supporter Journeys, Intake Rules, and Reporting. It is tenant data inside the Organisation boundary and is never Installation or deployment configuration.
+_Avoid_: Setting, preference, environment configuration, feature flag
+
+**Configuration Version**:
+One immutable revision of an Organisation Configuration, numbered within its configuration key. A version is never edited after it is written; changing behaviour means adding the next version. Earlier versions stay readable so a decision recorded under them can still be explained.
+_Avoid_: Draft record, edit, revision history entry
+
+**Configuration Status**:
+The lifecycle state of a single Configuration Version: draft, active, superseded, or retired. At most one version of a configuration key is active. Activating a version supersedes the one it replaces; retiring withdraws the configuration itself so it stops being offered, without deleting what it governed.
+_Avoid_: Deleted configuration, archived, disabled
+
 ## Example dialogue
 
 > **Domain expert:** Sam belongs to both HarbourKind and NeighbourLink.
@@ -201,3 +213,7 @@ _Avoid_: Organisation status, Subscription
 > **Domain expert:** HarbourKind's invoice is overdue, but the nonprofit is still operating.
 >
 > **Developer:** HarbourKind remains an active Organisation. Its Subscription is past due, and Hosted Access applies the agreed grace-period policy.
+>
+> **Domain expert:** HarbourKind has stopped sending the re-engagement message and wants it gone.
+>
+> **Developer:** That Message Template is an Organisation Configuration. Its versions stay as written, so the messages already sent can still be explained; the configuration moves to retired and stops being offered.

--- a/docs/explanation/domain-and-tenancy.md
+++ b/docs/explanation/domain-and-tenancy.md
@@ -14,6 +14,25 @@ Parties are organisation-owned people, households, or external organisations. Th
 
 Programs organise service delivery. Cases belong to exactly one Program; assignment and role scope determine confidential access. Supporter-safe engagement remains distinct from service-client context even when aggregate signals contribute to impact reporting.
 
+## Tenant configuration is immutable and versioned
+
+Five areas of behaviour are configurable per Organisation: Public Forms, Message Templates, Supporter Journeys, Intake Rules, and Reporting. Each is an Organisation Configuration, held as a numbered series of versions under a configuration key.
+
+A version is never edited after it is written. Changing behaviour adds the next version; the model refuses an update to a version's definition. This is deliberate: an intake accepted under version 2 of a rule set, or a message sent from version 3 of a template, must still be explainable years later, and it cannot be if the definition it ran under has since been rewritten in place.
+
+The status of a single version is draft, active, superseded, or retired, and the transitions are enforced on the model rather than by the caller:
+
+| From       | May become          |
+| ---------- | ------------------- |
+| draft      | active, retired     |
+| active     | superseded, retired |
+| superseded | —                   |
+| retired    | —                   |
+
+At most one version of a configuration key is active. Activating a version supersedes the one it replaced. Retiring withdraws the configuration itself — every draft and active version of that key moves to retired together, so it stops being offered — while leaving what it governed intact. Superseded versions are left alone; they are already history.
+
+Nothing is deleted. A configuration cannot be removed, only retired, which is why the staff interface offers no delete action.
+
 ## Billing is a separate authority plane
 
 A Billing Account represents the payer for the official hosted Installation. It may fund several Organisations through separate Subscriptions but owns none of their operational data. Billing Account Membership grants billing authority only. Service Invoices and Service Payments are platform charges and never become an Organisation's donations.


### PR DESCRIPTION
Stacked on #105 — the transition table documents the Retired status that PR introduces. Review that one first; this diff is against its branch.

## The gap

The five configurable areas — Public Forms, Message Templates, Supporter Journeys, Intake Rules, Reporting — are a first-class tenant concept with their own immutability rule and their own state machine. Neither `CONTEXT.md` nor the explanation docs mentioned them at all. Easy to miss until a fourth status arrived and there was nowhere to write it down.

## CONTEXT.md

Three terms: **Organisation Configuration**, **Configuration Version**, **Configuration Status**, placed with the other lifecycle state machines at the end of the glossary, plus one exchange in the example dialogue.

The `_Avoid_` line on the first is doing real work. `docs/reference/configuration.md` is about environment variables — `APP_ENV`, `DB_HOST` — and the two senses of "configuration" were already colliding.

## docs/explanation/domain-and-tenancy.md

A new section carrying the invariant, the transition table, and two things the code cannot say for itself:

- **why** immutability is worth its cost — an intake accepted under version 2 of a rule set, or a message sent from version 3 of a template, has to stay explainable years later, and it cannot be if the definition it ran under was rewritten in place
- **why there is no delete action** anywhere in the interface, which is otherwise a surprising absence (and was, in fact, reported as a bug)

## Not a gap

`AGENTS.md` points at `docs/adr/`, which does not exist. That is intended: `docs/reference/decisions.md` says so explicitly, and `docs/agents/domain.md` says to proceed silently if it is absent. Left alone.

## Verification

Every claim checked against `OrganisationConfiguration::booted()` — the immutable-attribute guard, the transition `match`, and the `deleting` hook.

- `npm run docs:check` — passed for 10 published pages
- `npm run check` — clean

## AI-assisted contribution

Drafted with Claude Code (Opus 5) under my direction and review, as required by CONTRIBUTING.md.