### PR TITLE
Type the party payload instead of declaring it any

### DIFF
--- a/resources/js/pages/parties/show.tsx
+++ b/resources/js/pages/parties/show.tsx
@@ -16,8 +16,75 @@ import { store as storeSafeContact } from '@/routes/parties/safe-contact-instruc
 
 type Program = { id: number; name: string };
 type Option = { value: string; label: string };
+
+type PartyAddress = {
+    id: string;
+    label: string;
+    address: string;
+    serviceArea: string | null;
+    countryCode: string;
+};
+
+type PartyRelationship = {
+    id: number;
+    type: string;
+    relatedParty: { uuid: string; displayName: string };
+    startedAt: string | null;
+    endedAt: string | null;
+};
+
+type PartyConsent = {
+    id: string;
+    purpose: string;
+    channel: string;
+    decision: string;
+    wordingVersion: string;
+    wording: string;
+    source: string;
+    occurredAt: string;
+    supersedesId: string | null;
+};
+
+type SafeContactInstruction = {
+    id: string;
+    instruction: string;
+    source: string;
+    effectiveAt: string;
+    endedAt: string | null;
+};
+
+type PartyTimelineEvent = {
+    id: string;
+    type: string;
+    summary: string;
+    occurredAt: string;
+};
+
+/*
+ * Mirrors the `party` payload in PartyController::show. Every collection is
+ * emptied rather than omitted when the viewer lacks the projection, so the
+ * arrays are always present and never optional.
+ */
+type Party = {
+    uuid: string;
+    kind: string;
+    displayName: string;
+    email: string | null;
+    telephone: string | null;
+    programIds: number[];
+    roles: string[];
+    interests: string[];
+    addresses: PartyAddress[];
+    relationships: PartyRelationship[];
+    consents: PartyConsent[];
+    safeContactInstructions: SafeContactInstruction[];
+    timeline: PartyTimelineEvent[];
+    supporterSafe: boolean;
+    administrativeMetadata: boolean;
+};
+
 type Props = {
-    party: any;
+    party: Party;
     canUpdate: boolean;
     canRecordConsent: boolean;
     canManageSafeContact: boolean;
@@ -109,7 +176,7 @@ export default function PartyShow({
                             <CardTitle>Addresses and relationships</CardTitle>
                         </CardHeader>
                         <CardContent className="space-y-3 text-sm">
-                            {party.addresses.map((address: any) => (
+                            {party.addresses.map((address) => (
                                 <div key={address.id}>
                                     <strong>{address.label}</strong>
                                     <p>{address.address}</p>
@@ -123,7 +190,7 @@ export default function PartyShow({
                                     </p>
                                 </div>
                             ))}
-                            {party.relationships.map((relationship: any) => (
+                            {party.relationships.map((relationship) => (
                                 <div key={relationship.id}>
                                     <strong>
                                         {relationship.relatedParty.displayName}
@@ -352,7 +419,7 @@ export default function PartyShow({
                             <CardTitle>Consent history</CardTitle>
                         </CardHeader>
                         <CardContent className="space-y-3">
-                            {party.consents.map((consent: any) => (
+                            {party.consents.map((consent) => (
                                 <div
                                     key={consent.id}
                                     className="rounded border p-3"
@@ -386,7 +453,7 @@ export default function PartyShow({
                         </CardHeader>
                         <CardContent>
                             <ul className="divide-y">
-                                {party.timeline.map((event: any) => (
+                                {party.timeline.map((event) => (
                                     <li
                                         key={event.id}
                                         className="py-3 first:pt-0 last:pb-0"
@@ -596,7 +663,7 @@ export default function PartyShow({
                         </CardHeader>
                         <CardContent className="space-y-4">
                             {party.safeContactInstructions.map(
-                                (instruction: any) => (
+                                (instruction) => (
                                     <div
                                         key={instruction.id}
                                         className="rounded border p-3 text-sm"


### PR DESCRIPTION
Stacked on #108 — both touch `parties/show.tsx`. Review that one first; this diff is against its branch.

## What

`party: any` switched off type checking for the largest page in the app. Every field access on it — six collections and thirteen scalars — was unchecked, and so were the five callbacks annotated `: any` to keep the compiler quiet about iterating them.

The shape now mirrors `PartyController::show`.

## Four types that would have been wrong

Written from the page alone, these would all have been guessed incorrectly. They came from the migration:

| Field | Looks like | Actually |
| --- | --- | --- |
| `addresses[].id`, `safeContactInstructions[].id` | number | **uuid string** |
| `consents[].id`, `consents[].supersedesId`, `timeline[].id` | number | **ulid string** |
| `addresses[].label`, `addresses[].countryCode` | nullable | **not null** |
| `consents[].source`, `safeContactInstructions[].source` | nullable | **not null** |

## One note on the type

Every collection is emptied rather than omitted when the viewer lacks the projection (`$serviceProjection ? … : []`), so none of the arrays are optional. That is worth a comment on the type, because the page reads as though they might be.

## Still untyped

Two pages remain: `cases/show.tsx` (16 uses, including two whole components typed `: any`) and `intakes/show.tsx` (10 uses, including its props). Not touched here — they are a separate and larger job, and I did not want to bury this diff. Once all three are typed, `vp lint` can turn on the explicit-`any` rule and keep them that way.

## Verification

- `npm run types:check` — clean
- `npm run check` — clean
- `npm test` — 294 passing

## AI-assisted contribution

Drafted with Claude Code (Opus 5) under my direction and review, as required by CONTRIBUTING.md.