### PR TITLE
Lay the impact categories out as a row and stop the caption leaking

### DIFF
--- a/resources/js/dashboard.test.tsx
+++ b/resources/js/dashboard.test.tsx
@@ -21,6 +21,63 @@ vi.mock('@/components/pending-invitations-modal', () => ({
     default: ({ children }: { children?: ReactNode }) => children ?? null,
 }));
 
+const metric = (category: string, id: string, label: string) => ({
+    definition: {
+        id,
+        version: '2026.4',
+        category,
+        label,
+        description: 'A fictional figure.',
+        formula: 'count(things)',
+        unit: 'count',
+    },
+    value: 0,
+    availability: 'available' as const,
+    sampleSize: null,
+    comparison: null,
+});
+
+const impact = {
+    registryVersion: '2026.4',
+    fictional: true,
+    freshAt: '2026-09-02T03:57:23Z',
+    timezone: 'Africa/Johannesburg',
+    currency: 'ZAR',
+    period: { start: '2026-09-01', endExclusive: '2026-09-03' },
+    filters: {},
+    minimumCohort: 5,
+    metrics: [
+        metric('input', 'service.requests_received', 'Requests received'),
+        metric('activity', 'service.case_interactions', 'Case interactions'),
+        metric('output', 'service.cases_closed', 'Cases closed'),
+        metric('outcome', 'service.outcomes_improved', 'Outcomes improved'),
+    ],
+    options: {
+        programs: [],
+        areas: [],
+        locations: [],
+        cohorts: [],
+        campaigns: [],
+    },
+};
+
+const emptyOperations = {
+    programs: [],
+    selectedProgramId: null,
+    counts: {
+        caseload: 0,
+        waitlist: 0,
+        overdue: 0,
+        risks: 0,
+        referrals: 0,
+    },
+    caseload: [],
+    waitlist: [],
+    overdue: [],
+    risks: [],
+    referrals: [],
+};
+
 describe('Service operations dashboard', () => {
     it('exposes labelled, keyboard-focusable controls and work links', () => {
         render(
@@ -85,5 +142,61 @@ describe('Service operations dashboard', () => {
             element.focus();
             expect(element).toHaveFocus();
         }
+    });
+
+    /*
+     * The four categories are a sequence — inputs cause activities cause
+     * outputs cause outcomes — and the registry currently holds one metric
+     * each. Rendering each category as a full-width block put one card per
+     * screenful and lost the ordering.
+     */
+    it('lays the logic-model categories out as columns with real plurals', () => {
+        render(
+            <Dashboard serviceOperations={emptyOperations} impact={impact} />,
+        );
+
+        const categoryGrid = screen.getByRole('heading', { name: 'Inputs' })
+            .parentElement?.parentElement;
+        expect(categoryGrid).toHaveClass('xl:grid-cols-4');
+        expect(categoryGrid?.children).toHaveLength(4);
+
+        const headings = [...(categoryGrid?.querySelectorAll('h3') ?? [])].map(
+            (heading) => heading.textContent,
+        );
+        expect(headings).toEqual([
+            'Inputs',
+            'Activities',
+            'Outputs',
+            'Outcomes',
+        ]);
+
+        /*
+         * The columns stretch to the tallest card in the row, so a category
+         * with a shorter description must not leave a visibly short card.
+         */
+        for (const column of categoryGrid?.children ?? []) {
+            expect(column).toHaveClass('flex-col');
+            expect(column.querySelector('[data-slot="card"]')).toHaveClass(
+                'flex-1',
+            );
+        }
+    });
+
+    /*
+     * `sr-only` clips an absolutely positioned box, but a table's caption is
+     * laid out outside that box and escapes the clip. Putting the class on the
+     * table left the caption showing through beneath the chart.
+     */
+    it('hides the chart data table without leaking its caption', () => {
+        const { container } = render(
+            <Dashboard serviceOperations={emptyOperations} impact={impact} />,
+        );
+
+        const caption = container.querySelector('caption');
+        expect(caption).toHaveTextContent(
+            'Nonvisual equivalent of the impact chart',
+        );
+        expect(caption?.closest('table')).not.toHaveClass('sr-only');
+        expect(caption?.closest('.sr-only')).not.toBeNull();
     });
 });

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -271,7 +271,17 @@ export default function Dashboard({
     );
 }
 
-const categories = ['input', 'activity', 'output', 'outcome'] as const;
+/*
+ * The logic-model sequence, in order. Plurals are spelled out because
+ * appending "s" to the key rendered "activitys", and the next category added
+ * would hit the same problem.
+ */
+const categories = [
+    { key: 'input', label: 'Inputs' },
+    { key: 'activity', label: 'Activities' },
+    { key: 'output', label: 'Outputs' },
+    { key: 'outcome', label: 'Outcomes' },
+] as const;
 
 function ImpactMetrics({ impact }: { impact: ImpactDashboard }) {
     const organisation = usePage().props.currentOrganisation!;
@@ -380,56 +390,74 @@ function ImpactMetrics({ impact }: { impact: ImpactDashboard }) {
                 />
                 <Button className="self-end">Apply reporting filters</Button>
             </Form>
-            {categories.map((category) => {
-                const metrics = impact.metrics.filter(
-                    (metric) => metric.definition.category === category,
-                );
-                if (metrics.length === 0) return null;
+            {/*
+             * Each category is a column, so inputs, activities, outputs and
+             * outcomes read left to right in the order they cause one another.
+             * Categories used to be full-width blocks stacked down the page,
+             * which put one card per screenful and lost the sequence.
+             */}
+            <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-4">
+                {categories.map(({ key, label }) => {
+                    const metrics = impact.metrics.filter(
+                        (metric) => metric.definition.category === key,
+                    );
+                    if (metrics.length === 0) return null;
 
-                return (
-                    <div key={category} className="space-y-2">
-                        <h3 className="text-sm font-semibold tracking-wide uppercase">
-                            {category}s
-                        </h3>
-                        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                            {metrics.map((metric) => (
-                                <Card key={metric.definition.id}>
-                                    <CardHeader className="pb-2">
-                                        <CardTitle className="text-sm">
-                                            {metric.definition.label}
-                                        </CardTitle>
-                                    </CardHeader>
-                                    <CardContent className="space-y-2">
-                                        <p className="font-display text-3xl font-semibold tabular-nums">
-                                            {metricValue(
-                                                metric,
-                                                impact.currency,
-                                            )}
-                                        </p>
-                                        <p className="text-muted-foreground text-xs">
-                                            {metric.definition.description}
-                                        </p>
-                                        <p className="text-muted-foreground text-xs">
-                                            Definition {metric.definition.id}@
-                                            {metric.definition.version} ·{' '}
-                                            {metric.definition.formula}
-                                        </p>
-                                        {metric.comparison ? (
-                                            <p className="text-xs">
-                                                Prior-period change:{' '}
-                                                {metric.comparison.change > 0
-                                                    ? '+'
-                                                    : ''}
-                                                {metric.comparison.change}
+                    return (
+                        <div key={key} className="flex flex-col gap-2">
+                            <h3 className="text-sm font-semibold tracking-wide uppercase">
+                                {label}
+                            </h3>
+                            {/*
+                             * The column stretches to the tallest in the row,
+                             * so the cards inside have to grow with it or a
+                             * category with less to say ends up visibly short.
+                             */}
+                            <div className="flex flex-1 flex-col gap-3">
+                                {metrics.map((metric) => (
+                                    <Card
+                                        key={metric.definition.id}
+                                        className="flex-1"
+                                    >
+                                        <CardHeader className="pb-2">
+                                            <CardTitle className="text-sm">
+                                                {metric.definition.label}
+                                            </CardTitle>
+                                        </CardHeader>
+                                        <CardContent className="space-y-2">
+                                            <p className="font-display text-3xl font-semibold tabular-nums">
+                                                {metricValue(
+                                                    metric,
+                                                    impact.currency,
+                                                )}
                                             </p>
-                                        ) : null}
-                                    </CardContent>
-                                </Card>
-                            ))}
+                                            <p className="text-muted-foreground text-xs">
+                                                {metric.definition.description}
+                                            </p>
+                                            <p className="text-muted-foreground text-xs">
+                                                Definition{' '}
+                                                {metric.definition.id}@
+                                                {metric.definition.version} ·{' '}
+                                                {metric.definition.formula}
+                                            </p>
+                                            {metric.comparison ? (
+                                                <p className="text-xs">
+                                                    Prior-period change:{' '}
+                                                    {metric.comparison.change >
+                                                    0
+                                                        ? '+'
+                                                        : ''}
+                                                    {metric.comparison.change}
+                                                </p>
+                                            ) : null}
+                                        </CardContent>
+                                    </Card>
+                                ))}
+                            </div>
                         </div>
-                    </div>
-                );
-            })}
+                    );
+                })}
+            </div>
             <MetricChart metrics={impact.metrics} currency={impact.currency} />
             <p className="text-muted-foreground text-xs">
                 Slices with 1–{impact.minimumCohort - 1} people are suppressed.
@@ -498,25 +526,33 @@ function MetricChart({
                     </div>
                 ))}
             </div>
-            <table className="sr-only">
-                <caption>Nonvisual equivalent of the impact chart</caption>
-                <thead>
-                    <tr>
-                        <th scope="col">Metric</th>
-                        <th scope="col">Value</th>
-                        <th scope="col">Status</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {metrics.map((metric) => (
-                        <tr key={metric.definition.id}>
-                            <th scope="row">{metric.definition.label}</th>
-                            <td>{metricValue(metric, currency)}</td>
-                            <td>{metric.availability}</td>
+            {/*
+             * `sr-only` clips an absolutely positioned box, but a table's
+             * caption is laid out outside that box and escapes the clip, so
+             * the caption was showing through beneath the bars. Hiding the
+             * wrapper instead takes the caption with it.
+             */}
+            <div className="sr-only">
+                <table>
+                    <caption>Nonvisual equivalent of the impact chart</caption>
+                    <thead>
+                        <tr>
+                            <th scope="col">Metric</th>
+                            <th scope="col">Value</th>
+                            <th scope="col">Status</th>
                         </tr>
-                    ))}
-                </tbody>
-            </table>
+                    </thead>
+                    <tbody>
+                        {metrics.map((metric) => (
+                            <tr key={metric.definition.id}>
+                                <th scope="row">{metric.definition.label}</th>
+                                <td>{metricValue(metric, currency)}</td>
+                                <td>{metric.availability}</td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
         </figure>
     );
 }


### PR DESCRIPTION
Three things on the reconciled impact section, all visible on one screen.

## "Activitys"

The category heading was `{category}s` — appending an `s` to the registry key. That works for three of the four words. The categories now carry explicit plural labels, so the next category added does not hit the same problem.

## One card per screenful

Each category was a full-width block containing its own `md:grid-cols-2 xl:grid-cols-4` grid — but the registry holds **one metric per category**, so every grid had a single child and the four cards stacked down the page with three empty columns beside each.

Categories are now the columns. Inputs → activities → outputs → outcomes read left to right, in the order they cause one another, which is what the logic model is for. It still stacks on narrow screens and pairs at `sm`.

Cards stretch to the tallest in the row. Outcomes has no prior-period comparison and a shorter description, so it was visibly short next to the other three.

## The caption showing through

The chart's nonvisual data table carried `sr-only` on the `<table>` itself. That clips an absolutely positioned box — but a `<caption>` is laid out outside its table's principal box and escapes the clip, so **"Nonvisual equivalent of the impact chart" was rendering visibly** beneath the bars, half-cut by the card edge.

The class moves to a wrapping `div`, which takes the caption with it. This was the only `sr-only` table in the codebase.

## Verification

Both new tests were verified failing against the old markup — the first on `Name "activitys"`.

- `npm test` — 400 passing
- `npm run check`, `npm run types:check` — clean

## AI-assisted contribution

Drafted with Claude Code (Opus 5) under my direction and review, as required by CONTRIBUTING.md.