### PR TITLE
Reduce an impact card to a label and a figure

### DIFF
--- a/resources/js/dashboard.test.tsx
+++ b/resources/js/dashboard.test.tsx
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom/vitest';
-import { render, screen } from '@testing-library/react';
+import { cleanup, render, screen, within } from '@testing-library/react';
 import type { ComponentProps, ReactNode } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import Dashboard from './pages/dashboard';
 
 vi.mock('@inertiajs/react', () => ({
@@ -78,7 +78,12 @@ const emptyOperations = {
     referrals: [],
 };
 
+const impactSection = () =>
+    screen.getByRole('region', { name: 'Reconciled impact' });
+
 describe('Service operations dashboard', () => {
+    afterEach(cleanup);
+
     it('exposes labelled, keyboard-focusable controls and work links', () => {
         render(
             <Dashboard
@@ -145,41 +150,73 @@ describe('Service operations dashboard', () => {
     });
 
     /*
-     * The four categories are a sequence — inputs cause activities cause
-     * outputs cause outcomes — and the registry currently holds one metric
-     * each. Rendering each category as a full-width block put one card per
-     * screenful and lost the ordering.
+     * A card is a label and a figure. It used to also carry a description, the
+     * registry code, the formula and a prior-period sentence, under a heading
+     * naming the category — five things where two were wanted.
      */
-    it('lays the logic-model categories out as columns with real plurals', () => {
+    it('shows a label and a figure on each card, nothing else', () => {
         render(
             <Dashboard serviceOperations={emptyOperations} impact={impact} />,
         );
 
-        const categoryGrid = screen.getByRole('heading', { name: 'Inputs' })
-            .parentElement?.parentElement;
-        expect(categoryGrid).toHaveClass('xl:grid-cols-4');
-        expect(categoryGrid?.children).toHaveLength(4);
+        const cards = within(impactSection()).getAllByRole('listitem');
+        expect(cards).toHaveLength(4);
 
-        const headings = [...(categoryGrid?.querySelectorAll('h3') ?? [])].map(
-            (heading) => heading.textContent,
-        );
-        expect(headings).toEqual([
-            'Inputs',
-            'Activities',
-            'Outputs',
-            'Outcomes',
-        ]);
+        const card = cards[0];
+        expect(card).toHaveTextContent('Requests received');
+        expect(card).toHaveTextContent('0');
+        expect(card).not.toHaveTextContent('service.requests_received');
+        expect(card).not.toHaveTextContent('count(requests)');
+        expect(card).not.toHaveTextContent('2026.4');
+        expect(card).not.toHaveTextContent('A fictional figure.');
 
         /*
-         * The columns stretch to the tallest card in the row, so a category
-         * with a shorter description must not leave a visibly short card.
+         * The category names the metric on its own card rather than heading a
+         * column, so the section keeps its one h2 and gains no h3s.
          */
-        for (const column of categoryGrid?.children ?? []) {
-            expect(column).toHaveClass('flex-col');
-            expect(column.querySelector('[data-slot="card"]')).toHaveClass(
-                'flex-1',
-            );
+        expect(card).toHaveTextContent('Input');
+        for (const category of ['Input', 'Activity', 'Output', 'Outcome']) {
+            expect(
+                within(impactSection()).queryByRole('heading', {
+                    name: category,
+                }),
+            ).toBeNull();
         }
+    });
+
+    it('orders the cards by the logic model', () => {
+        render(
+            <Dashboard serviceOperations={emptyOperations} impact={impact} />,
+        );
+
+        expect(
+            within(impactSection())
+                .getAllByRole('listitem')
+                .map((card) => card.textContent),
+        ).toEqual([
+            expect.stringContaining('Input'),
+            expect.stringContaining('Activity'),
+            expect.stringContaining('Output'),
+            expect.stringContaining('Outcome'),
+        ]);
+    });
+
+    /*
+     * The provenance the PRD requires on the dashboard is still here, once,
+     * behind a disclosure — not restated on every card.
+     */
+    it('keeps the definitions reachable without putting them on the cards', () => {
+        render(
+            <Dashboard serviceOperations={emptyOperations} impact={impact} />,
+        );
+
+        const definitions = within(impactSection())
+            .getByText('How these figures are calculated')
+            .closest('details');
+        expect(definitions).toHaveTextContent('service.requests_received');
+        expect(definitions).toHaveTextContent('count(things)');
+        expect(definitions).toHaveTextContent('2026.4');
+        expect(definitions).toHaveTextContent('A fictional figure.');
     });
 
     /*

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -272,19 +272,30 @@ export default function Dashboard({
 }
 
 /*
- * The logic-model sequence, in order. Plurals are spelled out because
- * appending "s" to the key rendered "activitys", and the next category added
- * would hit the same problem.
+ * The logic-model sequence, in order. Labels are spelled out rather than
+ * derived from the key: the heading used to append "s", which rendered
+ * "activitys", and the next category added would hit the same problem.
  */
 const categories = [
-    { key: 'input', label: 'Inputs' },
-    { key: 'activity', label: 'Activities' },
-    { key: 'output', label: 'Outputs' },
-    { key: 'outcome', label: 'Outcomes' },
+    { key: 'input', label: 'Input' },
+    { key: 'activity', label: 'Activity' },
+    { key: 'output', label: 'Output' },
+    { key: 'outcome', label: 'Outcome' },
 ] as const;
 
 function ImpactMetrics({ impact }: { impact: ImpactDashboard }) {
     const organisation = usePage().props.currentOrganisation!;
+
+    /*
+     * Ordered by the logic model — inputs cause activities cause outputs cause
+     * outcomes — so the row reads left to right in the order the theory of
+     * change runs, rather than in whatever order the registry returned.
+     */
+    const orderedMetrics = categories.flatMap(({ key, label }) =>
+        impact.metrics
+            .filter((metric) => metric.definition.category === key)
+            .map((metric) => ({ metric, categoryLabel: label })),
+    );
 
     if (impact.metrics.length === 0) return null;
 
@@ -391,73 +402,72 @@ function ImpactMetrics({ impact }: { impact: ImpactDashboard }) {
                 <Button className="self-end">Apply reporting filters</Button>
             </Form>
             {/*
-             * Each category is a column, so inputs, activities, outputs and
-             * outcomes read left to right in the order they cause one another.
-             * Categories used to be full-width blocks stacked down the page,
-             * which put one card per screenful and lost the sequence.
+             * A card carries a label and a figure. Its category is an overline
+             * rather than a heading above the column, because the reader is
+             * looking at one metric, not opening a section. Everything else the
+             * card used to carry — description, registry code, formula — is in
+             * the disclosure below, where a reader who wants provenance can
+             * find it without four cards restating it.
              */}
-            <div className="grid gap-5 sm:grid-cols-2 xl:grid-cols-4">
-                {categories.map(({ key, label }) => {
-                    const metrics = impact.metrics.filter(
-                        (metric) => metric.definition.category === key,
-                    );
-                    if (metrics.length === 0) return null;
-
-                    return (
-                        <div key={key} className="flex flex-col gap-2">
-                            <h3 className="text-sm font-semibold tracking-wide uppercase">
-                                {label}
-                            </h3>
-                            {/*
-                             * The column stretches to the tallest in the row,
-                             * so the cards inside have to grow with it or a
-                             * category with less to say ends up visibly short.
-                             */}
-                            <div className="flex flex-1 flex-col gap-3">
-                                {metrics.map((metric) => (
-                                    <Card
-                                        key={metric.definition.id}
-                                        className="flex-1"
-                                    >
-                                        <CardHeader className="pb-2">
-                                            <CardTitle className="text-sm">
-                                                {metric.definition.label}
-                                            </CardTitle>
-                                        </CardHeader>
-                                        <CardContent className="space-y-2">
-                                            <p className="font-display text-3xl font-semibold tabular-nums">
-                                                {metricValue(
-                                                    metric,
-                                                    impact.currency,
-                                                )}
-                                            </p>
-                                            <p className="text-muted-foreground text-xs">
-                                                {metric.definition.description}
-                                            </p>
-                                            <p className="text-muted-foreground text-xs">
-                                                Definition{' '}
-                                                {metric.definition.id}@
-                                                {metric.definition.version} ·{' '}
-                                                {metric.definition.formula}
-                                            </p>
-                                            {metric.comparison ? (
-                                                <p className="text-xs">
-                                                    Prior-period change:{' '}
-                                                    {metric.comparison.change >
-                                                    0
-                                                        ? '+'
-                                                        : ''}
-                                                    {metric.comparison.change}
-                                                </p>
-                                            ) : null}
-                                        </CardContent>
-                                    </Card>
-                                ))}
-                            </div>
+            <ol className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                {orderedMetrics.map(({ metric, categoryLabel }) => (
+                    <li key={metric.definition.id}>
+                        {/*
+                         * `display: contents` on the item would drop list
+                         * semantics in several browsers, so the item stays a
+                         * real grid cell and the card fills it.
+                         */}
+                        <Card className="h-full justify-between gap-3">
+                            <CardHeader className="gap-1">
+                                <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                                    {categoryLabel}
+                                </p>
+                                <CardTitle className="text-sm">
+                                    {metric.definition.label}
+                                </CardTitle>
+                            </CardHeader>
+                            <CardContent>
+                                <p className="font-display text-3xl font-semibold tabular-nums">
+                                    {metricValue(metric, impact.currency)}
+                                </p>
+                                {metric.comparison ? (
+                                    <p className="text-muted-foreground mt-1 text-xs tabular-nums">
+                                        {metric.comparison.change > 0
+                                            ? '+'
+                                            : ''}
+                                        {metric.comparison.change} on the prior
+                                        period
+                                    </p>
+                                ) : null}
+                            </CardContent>
+                        </Card>
+                    </li>
+                ))}
+            </ol>
+            <details className="text-sm">
+                <summary className="cursor-pointer font-medium">
+                    How these figures are calculated
+                </summary>
+                <dl className="mt-3 grid gap-3 sm:grid-cols-2">
+                    {orderedMetrics.map(({ metric, categoryLabel }) => (
+                        <div key={metric.definition.id}>
+                            <dt className="font-medium">
+                                {metric.definition.label}
+                                <span className="text-muted-foreground font-normal">
+                                    {' '}
+                                    · {categoryLabel}
+                                </span>
+                            </dt>
+                            <dd className="text-muted-foreground">
+                                {metric.definition.description} Counted as{' '}
+                                {metric.definition.formula}, from registry
+                                definition {metric.definition.id}@
+                                {metric.definition.version}.
+                            </dd>
                         </div>
-                    );
-                })}
-            </div>
+                    ))}
+                </dl>
+            </details>
             <MetricChart metrics={impact.metrics} currency={impact.currency} />
             <p className="text-muted-foreground text-xs">
                 Slices with 1–{impact.minimumCohort - 1} people are suppressed.


### PR DESCRIPTION
Stacked on #117. Review that first; this diff is against its branch.

## What a card was carrying

Six things, where two were wanted:

- a heading above it — `INPUTS`
- the label — `Requests received`
- the figure — `0`
- a description — `Submitted requests created in the reporting period.`
- a definition — `Definition service.requests_received@2026.4 · count(requests)`
- a prior-period sentence

## What it carries now

The label and the figure.

The category becomes a quiet overline **inside** the card rather than a heading above the column — the reader is looking at one metric, not opening a section. That also removes the plural problem at the root: a card holds one *input*, not *inputs*.

The prior-period delta stays, shortened to `+12 on the prior period` under the figure. It is part of reading the figure rather than an annotation on it. Say the word and it goes too.

## Where the rest went

Into one disclosure under the row — *How these figures are calculated* — listing each metric's description, formula and registry code once.

The PRD requires the dashboard to display definition provenance (§M3: *"display data freshness and metric-definition version on each dashboard/export"*), and it still does. Once, where a reader who wants it can find it, instead of four cards each restating a registry version that **already appears in the section header** — `Registry 2026.4 · refreshed 02/09/2026…`.

The CSV export is untouched and still carries `definition_id`, `definition_version` and `formula` as their own columns per row, which is where an auditor reconciling figures actually goes.

## Also

The cards are an ordered list, so the logic-model sequence lives in the markup rather than being implied by four separate column headings.

## Verification

All three new tests were verified failing against the previous card.

- `npm test` — 402 passing
- `npm run check`, `npm run types:check` — clean

## AI-assisted contribution

Drafted with Claude Code (Opus 5) under my direction and review, as required by CONTRIBUTING.md.