### PR TITLE
Group the chart bars by scale and say what suppression means

### DIFF
--- a/resources/js/dashboard.test.tsx
+++ b/resources/js/dashboard.test.tsx
@@ -21,7 +21,7 @@ vi.mock('@/components/pending-invitations-modal', () => ({
     default: ({ children }: { children?: ReactNode }) => children ?? null,
 }));
 
-const metric = (category: string, id: string, label: string) => ({
+const countMetric = (category: string, id: string, label: string) => ({
     definition: {
         id,
         version: '2026.4',
@@ -47,10 +47,18 @@ const impact = {
     filters: {},
     minimumCohort: 5,
     metrics: [
-        metric('input', 'service.requests_received', 'Requests received'),
-        metric('activity', 'service.case_interactions', 'Case interactions'),
-        metric('output', 'service.cases_closed', 'Cases closed'),
-        metric('outcome', 'service.outcomes_improved', 'Outcomes improved'),
+        countMetric('input', 'service.requests_received', 'Requests received'),
+        countMetric(
+            'activity',
+            'service.case_interactions',
+            'Case interactions',
+        ),
+        countMetric('output', 'service.cases_closed', 'Cases closed'),
+        countMetric(
+            'outcome',
+            'service.outcomes_improved',
+            'Outcomes improved',
+        ),
     ],
     options: {
         programs: [],
@@ -217,6 +225,75 @@ describe('Service operations dashboard', () => {
         expect(definitions).toHaveTextContent('count(things)');
         expect(definitions).toHaveTextContent('2026.4');
         expect(definitions).toHaveTextContent('A fictional figure.');
+    });
+
+    /*
+     * Net raised is the only currency metric, so it used to draw a full-width
+     * bar whatever its value — R50 and R5,000,000 rendered identically.
+     */
+    it('draws no bar for a value with nothing on its scale to compare against', () => {
+        render(
+            <Dashboard
+                serviceOperations={emptyOperations}
+                impact={{
+                    ...impact,
+                    metrics: [
+                        { ...countMetric('input', 'a', 'Alpha'), value: 40 },
+                        { ...countMetric('output', 'b', 'Beta'), value: 10 },
+                        {
+                            ...countMetric('output', 'c', 'Net raised'),
+                            value: 5000,
+                            definition: {
+                                ...countMetric('output', 'c', 'Net raised')
+                                    .definition,
+                                unit: 'currency',
+                            },
+                        },
+                    ],
+                }}
+            />,
+        );
+
+        const chart = screen
+            .getByRole('heading', { name: 'Presentation chart' })
+            .closest('figure');
+        const bars = [...(chart?.querySelectorAll('.bg-primary') ?? [])];
+
+        /* Two counts share a scale; the lone currency value does not. */
+        expect(bars).toHaveLength(2);
+        expect(bars[0]).toHaveStyle({ width: '100%' });
+        expect(bars[1]).toHaveStyle({ width: '25%' });
+        expect(chart).toHaveTextContent('Counts · scaled to 40');
+        expect(chart).toHaveTextContent('ZAR');
+        expect(chart).not.toHaveTextContent('ZAR · scaled to');
+    });
+
+    it('draws no bar for a zero rather than a misleading sliver', () => {
+        render(
+            <Dashboard serviceOperations={emptyOperations} impact={impact} />,
+        );
+
+        const chart = screen
+            .getByRole('heading', { name: 'Presentation chart' })
+            .closest('figure');
+        expect(chart?.querySelectorAll('.bg-primary')).toHaveLength(0);
+    });
+
+    /*
+     * Suppression only applies once a service area, location or cohort filter
+     * is set. The old wording named neither the trigger nor the reason.
+     */
+    it('says what triggers suppression and why', () => {
+        render(
+            <Dashboard serviceOperations={emptyOperations} impact={impact} />,
+        );
+
+        const section = impactSection();
+        expect(section).toHaveTextContent(
+            'Filtering by service area, location, or cohort',
+        );
+        expect(section).toHaveTextContent('can identify the people in it');
+        expect(section).not.toHaveTextContent('drill-down');
     });
 
     /*

--- a/resources/js/pages/dashboard.tsx
+++ b/resources/js/pages/dashboard.tsx
@@ -469,9 +469,18 @@ function ImpactMetrics({ impact }: { impact: ImpactDashboard }) {
                 </dl>
             </details>
             <MetricChart metrics={impact.metrics} currency={impact.currency} />
+            {/*
+             * Suppression only applies once a service area, location or cohort
+             * filter is set — see BuildImpactDashboard's `sensitiveSlice`. The
+             * old wording named neither the trigger nor the reason, so a reader
+             * could not tell whether it applied to what they were looking at.
+             */}
             <p className="text-muted-foreground text-xs">
-                Slices with 1–{impact.minimumCohort - 1} people are suppressed.
-                Aggregates do not provide person or case drill-down.
+                Filtering by service area, location, or cohort can narrow a
+                figure to fewer than {impact.minimumCohort} people. Those
+                figures are withheld rather than shown, because a count that
+                small can identify the people in it. No figure here opens onto
+                the people or cases behind it.
             </p>
         </section>
     );
@@ -488,16 +497,23 @@ function MetricChart({
         (metric) =>
             metric.availability === 'available' && metric.value !== null,
     );
-    const maximumByUnit = available.reduce<Record<string, number>>(
-        (maximums, metric) => ({
-            ...maximums,
-            [metric.definition.unit]: Math.max(
-                maximums[metric.definition.unit] ?? 1,
-                Math.abs(metric.value ?? 0),
-            ),
-        }),
-        {},
-    );
+
+    /*
+     * Grouped by unit, in the order the units first appear. A bar is only
+     * meaningful against other bars on the same scale, and the groups now say
+     * that structurally instead of the description warning about it in prose.
+     */
+    const unitGroups = available.reduce<
+        Array<{ unit: string; metrics: Metric[] }>
+    >((groups, metric) => {
+        const group = groups.find(
+            (candidate) => candidate.unit === metric.definition.unit,
+        );
+        if (group) group.metrics.push(metric);
+        else groups.push({ unit: metric.definition.unit, metrics: [metric] });
+
+        return groups;
+    }, []);
 
     return (
         <figure
@@ -513,28 +529,70 @@ function MetricChart({
                     id="impact-chart-description"
                     className="text-muted-foreground text-sm"
                 >
-                    Relative bars for available aggregate values, scaled
-                    separately by unit. Units are retained in each label;
-                    suppressed and unavailable values have no bar.
+                    A bar shows a value against the largest on its own scale.
+                    Values that are suppressed, unavailable, or alone on their
+                    scale have none.
                 </p>
             </figcaption>
-            <div className="space-y-3" aria-hidden="true">
-                {available.map((metric) => (
-                    <div key={metric.definition.id} className="grid gap-1">
-                        <div className="flex justify-between gap-3 text-sm">
-                            <span>{metric.definition.label}</span>
-                            <strong>{metricValue(metric, currency)}</strong>
+            <div className="space-y-5" aria-hidden="true">
+                {unitGroups.map(({ unit, metrics: unitMetrics }) => {
+                    const maximum = Math.max(
+                        ...unitMetrics.map((metric) =>
+                            Math.abs(metric.value ?? 0),
+                        ),
+                    );
+                    /*
+                     * One metric on a scale would draw a full-width bar
+                     * whatever its value, which reads as "the most" and means
+                     * nothing. Net raised is the only currency metric, so it
+                     * did exactly that.
+                     */
+                    const comparable = unitMetrics.length > 1 && maximum > 0;
+                    const largest = unitMetrics.find(
+                        (metric) => Math.abs(metric.value ?? 0) === maximum,
+                    );
+
+                    return (
+                        <div key={unit} className="space-y-3">
+                            <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+                                {unitLabel(unit, currency)}
+                                {comparable && largest
+                                    ? ` · scaled to ${metricValue(largest, currency)}`
+                                    : null}
+                            </p>
+                            {unitMetrics.map((metric) => (
+                                <div
+                                    key={metric.definition.id}
+                                    className="grid gap-1"
+                                >
+                                    <div className="flex justify-between gap-3 text-sm">
+                                        <span>{metric.definition.label}</span>
+                                        <strong>
+                                            {metricValue(metric, currency)}
+                                        </strong>
+                                    </div>
+                                    {comparable ? (
+                                        <div className="bg-muted h-4 rounded-sm">
+                                            {/*
+                                             * A zero gets no sliver. The old
+                                             * `min-w-1` floor made a true zero
+                                             * and a true near-zero identical.
+                                             */}
+                                            {Math.abs(metric.value ?? 0) > 0 ? (
+                                                <div
+                                                    className="bg-primary h-4 min-w-1 rounded-sm"
+                                                    style={{
+                                                        width: `${(Math.abs(metric.value ?? 0) / maximum) * 100}%`,
+                                                    }}
+                                                />
+                                            ) : null}
+                                        </div>
+                                    ) : null}
+                                </div>
+                            ))}
                         </div>
-                        <div className="bg-muted h-4 rounded-sm">
-                            <div
-                                className="bg-primary h-4 min-w-1 rounded-sm"
-                                style={{
-                                    width: `${(Math.abs(metric.value ?? 0) / maximumByUnit[metric.definition.unit]) * 100}%`,
-                                }}
-                            />
-                        </div>
-                    </div>
-                ))}
+                    );
+                })}
             </div>
             {/*
              * `sr-only` clips an absolutely positioned box, but a table's
@@ -566,6 +624,15 @@ function MetricChart({
         </figure>
     );
 }
+
+const unitLabels: Record<string, string> = {
+    count: 'Counts',
+    percent: 'Percentages',
+};
+
+/* Currency names the Organisation's own currency rather than the word. */
+const unitLabel = (unit: string, currency: string) =>
+    unit === 'currency' ? currency : (unitLabels[unit] ?? unit);
 
 function metricValue(metric: Metric, currency: string) {
     if (metric.availability === 'suppressed') return 'Suppressed';


### PR DESCRIPTION
Stacked on #118 → #117. Review those first; this diff is against #118's branch.

## The chart was capable of lying

Bar width was `|value| ÷ largest |value| sharing that unit`. **`fundraising.net_raised` is the only currency metric in the registry**, so it always drew a full-width bar — R50 and R5,000,000 rendered identically, each reading as "the most". Percent hit the same thing whenever one of its two metrics was unavailable.

Bars are now grouped by unit, under a label naming the scale they are drawn against — `COUNTS · scaled to 1,208` — and **a scale holding one value draws no bar at all**, because a bar with nothing to compare against carries no information.

## Which let the description shrink

The chart's structure now carries the "scaled separately by unit" caveat that the description had to assert in prose. So the first sentence — *"Relative bars for available aggregate values"* — could go. It was explaining what a bar chart is.

What is left is only what a reader cannot see:

> A bar shows a value against the largest on its own scale. Values that are suppressed, unavailable, or alone on their scale have none.

## Zeroes

A zero no longer draws the `min-w-1` sliver. With every value at zero the chart was four identical slivers, and a true zero was indistinguishable from a true near-zero.

## The suppression footnote

> Slices with 1–4 people are suppressed. Aggregates do not provide person or case drill-down.

This is a safeguarding control, and it named neither what a slice is nor why it matters — so a reader could not tell whether it applied to what they were looking at. It never does until a **service area, location, or cohort** filter is set (`BuildImpactDashboard::$sensitiveSlice`); filtering by program or campaign alone does not trigger it.

> Filtering by service area, location, or cohort can narrow a figure to fewer than 5 people. Those figures are withheld rather than shown, because a count that small can identify the people in it. No figure here opens onto the people or cases behind it.

## Verification

All three new tests were verified failing against the old chart.

- `npm test` — passing
- `npm run check`, `npm run types:check` — clean

## AI-assisted contribution

Drafted with Claude Code (Opus 5) under my direction and review, as required by CONTRIBUTING.md.