### PR TITLE
Stop offering snapshot approval that cannot succeed

### DIFF
--- a/app/Actions/Reporting/PublishImpactSnapshot.php
+++ b/app/Actions/Reporting/PublishImpactSnapshot.php
@@ -6,6 +6,7 @@ use App\Actions\Auditing\RecordTenantAuditEvent;
 use App\Enums\OrganisationConfigurationArea;
 use App\Enums\OrganisationConfigurationStatus;
 use App\Enums\TenantAuditEventType;
+use App\Exceptions\ImpactSnapshotNotApprovable;
 use App\Models\Organisation;
 use App\Models\OrganisationConfiguration;
 use App\Models\PublishedImpactSnapshot;
@@ -27,7 +28,7 @@ final class PublishImpactSnapshot
         }
         $configuration = OrganisationConfiguration::query()->where('area', OrganisationConfigurationArea::Reporting)->where('configuration_key', 'impact')->where('status', OrganisationConfigurationStatus::Active)->latest('version')->first();
         if ($configuration === null) {
-            throw new LogicException('An active impact reporting configuration is required.');
+            throw new ImpactSnapshotNotApprovable('No impact reporting configuration is active yet. Activate one under Reporting publication before approving a snapshot.');
         }
         $configuredIds = $configuration->definition[$audience === 'public' ? 'public_metric_ids' : 'pack_metric_ids'] ?? null;
         $allowedIds = collect(is_array($configuredIds) ? array_values(array_filter($configuredIds, is_string(...))) : []);
@@ -39,7 +40,7 @@ final class PublishImpactSnapshot
         }
         $metrics = collect($reconciledMetrics)->filter(fn (mixed $metric): bool => is_array($metric) && is_array($metric['definition'] ?? null) && $allowedIds->contains($metric['definition']['id'] ?? null))->values();
         if ($metrics->isEmpty()) {
-            throw new LogicException('The active reporting configuration does not approve any available metrics for this audience.');
+            throw new ImpactSnapshotNotApprovable('The active reporting configuration approves no metric that is available for this audience and period.');
         }
         $cohorts = collect($reconciledCohorts)->filter(fn (mixed $cohort): bool => is_array($cohort))->map(function (array $cohort) use ($allowedIds): array {
             $cohortMetrics = is_array($cohort['metrics'] ?? null) ? $cohort['metrics'] : [];

--- a/app/Exceptions/ImpactSnapshotNotApprovable.php
+++ b/app/Exceptions/ImpactSnapshotNotApprovable.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+/*
+ * An Organisation that has not activated an impact reporting configuration, or
+ * whose configuration approves no metric available for an audience, cannot
+ * approve a snapshot. That is an ordinary state for a new tenant, not a
+ * programming error, so it is reportable to the person who asked rather than a
+ * LogicException that reaches them as a 500.
+ */
+final class ImpactSnapshotNotApprovable extends RuntimeException {}

--- a/app/Http/Controllers/Organisations/PublishedImpactSnapshotController.php
+++ b/app/Http/Controllers/Organisations/PublishedImpactSnapshotController.php
@@ -38,6 +38,13 @@ class PublishedImpactSnapshotController extends Controller
 
         return Inertia::render('impact-snapshots/index', [
             'canApprove' => $hasActiveConfiguration,
+            /*
+             * Approving a snapshot needs ExecutiveViewer; activating the
+             * configuration it depends on needs OrganisationAdministrator. The
+             * person blocked here is usually not the person who can unblock it,
+             * so only offer the link to someone the gate will actually admit.
+             */
+            'canConfigureReporting' => Gate::allows('viewAny', [OrganisationConfiguration::class, $currentOrganisation]),
             'snapshots' => PublishedImpactSnapshot::query()->latest()->get()->map(fn (PublishedImpactSnapshot $snapshot): array => ['id' => $snapshot->id, 'audience' => $snapshot->audience, 'registryVersion' => $snapshot->registry_version, 'metricCount' => count($snapshot->metrics), 'approvedAt' => $snapshot->approved_at->toAtomString(), 'publishedAt' => $snapshot->published_at?->toAtomString()]),
         ]);
     }

--- a/app/Http/Controllers/Organisations/PublishedImpactSnapshotController.php
+++ b/app/Http/Controllers/Organisations/PublishedImpactSnapshotController.php
@@ -4,9 +4,13 @@ namespace App\Http\Controllers\Organisations;
 
 use App\Actions\Reporting\BuildImpactReportPack;
 use App\Actions\Reporting\PublishImpactSnapshot;
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Exceptions\ImpactSnapshotNotApprovable;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Organisations\StoreImpactSnapshotRequest;
 use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
 use App\Models\PublishedImpactSnapshot;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
@@ -20,14 +24,39 @@ class PublishedImpactSnapshotController extends Controller
     {
         Gate::authorize('viewAny', [PublishedImpactSnapshot::class, $currentOrganisation]);
 
-        return Inertia::render('impact-snapshots/index', ['snapshots' => PublishedImpactSnapshot::query()->latest()->get()->map(fn (PublishedImpactSnapshot $snapshot): array => ['id' => $snapshot->id, 'audience' => $snapshot->audience, 'registryVersion' => $snapshot->registry_version, 'metricCount' => count($snapshot->metrics), 'approvedAt' => $snapshot->approved_at->toAtomString(), 'publishedAt' => $snapshot->published_at?->toAtomString()])]);
+        /*
+         * Approving a snapshot needs an active impact reporting configuration.
+         * Without this the page offered the action, took the form, and failed
+         * in the action with a 500 that told the person nothing they could act
+         * on.
+         */
+        $hasActiveConfiguration = OrganisationConfiguration::query()
+            ->where('area', OrganisationConfigurationArea::Reporting)
+            ->where('configuration_key', 'impact')
+            ->where('status', OrganisationConfigurationStatus::Active)
+            ->exists();
+
+        return Inertia::render('impact-snapshots/index', [
+            'canApprove' => $hasActiveConfiguration,
+            'snapshots' => PublishedImpactSnapshot::query()->latest()->get()->map(fn (PublishedImpactSnapshot $snapshot): array => ['id' => $snapshot->id, 'audience' => $snapshot->audience, 'registryVersion' => $snapshot->registry_version, 'metricCount' => count($snapshot->metrics), 'approvedAt' => $snapshot->approved_at->toAtomString(), 'publishedAt' => $snapshot->published_at?->toAtomString()]),
+        ]);
     }
 
     public function store(StoreImpactSnapshotRequest $request, Organisation $currentOrganisation, PublishImpactSnapshot $publish): RedirectResponse
     {
         Gate::authorize('create', [PublishedImpactSnapshot::class, $currentOrganisation]);
         $validated = $request->validated();
-        $publish->handle($currentOrganisation, $request->user(), (string) $validated['audience'], collect($validated)->except('audience')->all());
+
+        /*
+         * The page hides the action when no configuration is active, but the
+         * configuration can be retired between loading the page and submitting
+         * it. Report that on the form rather than as a 500.
+         */
+        try {
+            $publish->handle($currentOrganisation, $request->user(), (string) $validated['audience'], collect($validated)->except('audience')->all());
+        } catch (ImpactSnapshotNotApprovable $exception) {
+            return back()->withErrors(['audience' => $exception->getMessage()]);
+        }
 
         return back();
     }

--- a/resources/js/components/create-panel.tsx
+++ b/resources/js/components/create-panel.tsx
@@ -1,0 +1,141 @@
+import {
+    useCallback,
+    useEffect,
+    useId,
+    useRef,
+    useState,
+    type ReactNode,
+} from 'react';
+import { Button } from '@/components/ui/button';
+
+/*
+ * The pattern behind every staff index page: the records come first, and the
+ * form that creates one appears in place above them only when it is asked for.
+ * A form that sits on the page permanently makes reading the list — which is
+ * what the page is for — mean scrolling past it every time.
+ *
+ * It is a panel rather than a modal. The list stays readable behind it and
+ * dismissing it does not lose the page.
+ */
+export function useCreatePanel() {
+    const [open, setOpen] = useState(false);
+    const trigger = useRef<HTMLButtonElement>(null);
+    const returnFocus = useRef(false);
+
+    /*
+     * The trigger is disabled while the panel is open, so it cannot take focus
+     * until the panel has gone and this render has landed. Restoring focus
+     * inside the dismiss handler silently does nothing.
+     */
+    useEffect(() => {
+        if (open || !returnFocus.current) return;
+        returnFocus.current = false;
+        trigger.current?.focus();
+    }, [open]);
+
+    const dismiss = useCallback(() => {
+        returnFocus.current = true;
+        setOpen(false);
+    }, []);
+
+    return {
+        open,
+        trigger,
+        dismiss,
+        show: useCallback(() => setOpen(true), []),
+    };
+}
+
+export function CreatePanelTrigger({
+    panel,
+    children,
+}: {
+    panel: ReturnType<typeof useCreatePanel>;
+    children: ReactNode;
+}) {
+    return (
+        <Button
+            ref={panel.trigger}
+            type="button"
+            onClick={panel.show}
+            disabled={panel.open}
+        >
+            {children}
+        </Button>
+    );
+}
+
+export function CreatePanel({
+    heading,
+    description,
+    onDismiss,
+    children,
+}: {
+    heading: string;
+    description?: string;
+    onDismiss: () => void;
+    children: ReactNode;
+}) {
+    const headingId = useId();
+    const panel = useRef<HTMLElement>(null);
+
+    /*
+     * The panel is not on the page until it is asked for, so opening it has to
+     * take the caret with it. Without this the keyboard user is left at the
+     * trigger and has to tab back into a region that appeared behind them.
+     */
+    useEffect(() => {
+        panel.current
+            ?.querySelector<HTMLElement>(
+                'input:not([type="hidden"]), select, textarea',
+            )
+            ?.focus();
+    }, []);
+
+    /* Escape dismisses, the way it would if this were a dialog. */
+    useEffect(() => {
+        const close = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') onDismiss();
+        };
+        document.addEventListener('keydown', close);
+
+        return () => document.removeEventListener('keydown', close);
+    }, [onDismiss]);
+
+    return (
+        <section
+            ref={panel}
+            aria-labelledby={headingId}
+            className="bg-muted/30 space-y-4 rounded-xl border p-5"
+        >
+            <div className="space-y-1">
+                <h2 id={headingId} className="font-medium">
+                    {heading}
+                </h2>
+                {description ? (
+                    <p className="text-muted-foreground text-sm">
+                        {description}
+                    </p>
+                ) : null}
+            </div>
+            {children}
+        </section>
+    );
+}
+
+export function CreatePanelActions({
+    onDismiss,
+    children,
+}: {
+    onDismiss: () => void;
+    children: ReactNode;
+}) {
+    return (
+        <div className="flex flex-wrap gap-2">
+            {children}
+            <Button type="button" variant="ghost" onClick={onDismiss}>
+                Cancel
+            </Button>
+        </div>
+    );
+}

--- a/resources/js/pages/impact-snapshots/index.tsx
+++ b/resources/js/pages/impact-snapshots/index.tsx
@@ -93,9 +93,11 @@ function ApprovalPanel({ onDismiss }: { onDismiss: () => void }) {
 export default function ImpactSnapshotsIndex({
     snapshots,
     canApprove,
+    canConfigureReporting,
 }: {
     snapshots: Snapshot[];
     canApprove: boolean;
+    canConfigureReporting: boolean;
 }) {
     const organisation = usePage().props.currentOrganisation!;
     const [approving, setApproving] = useState(false);
@@ -150,14 +152,26 @@ export default function ImpactSnapshotsIndex({
                     </p>
                     <p className="text-muted-foreground mt-1 text-sm">
                         A snapshot can only carry metrics an active reporting
-                        configuration has approved for release. Activate one,
-                        then come back to approve a snapshot.
+                        configuration has approved for release.
+                        {canConfigureReporting
+                            ? ' Activate one, then come back to approve a snapshot.'
+                            : ' An organisation administrator activates one under Reporting publication.'}
                     </p>
-                    <Button asChild variant="outline" className="mt-3">
-                        <Link href={reportingPublication(organisation.slug)}>
-                            Open Reporting publication
-                        </Link>
-                    </Button>
+                    {/*
+                     * Reporting publication needs OrganisationAdministrator,
+                     * which the Executive Viewer approving snapshots does not
+                     * have. Offering the link regardless would replace a failing
+                     * button with a link to a 403.
+                     */}
+                    {canConfigureReporting ? (
+                        <Button asChild variant="outline" className="mt-3">
+                            <Link
+                                href={reportingPublication(organisation.slug)}
+                            >
+                                Open Reporting publication
+                            </Link>
+                        </Button>
+                    ) : null}
                 </div>
             )}
 

--- a/resources/js/pages/impact-snapshots/index.tsx
+++ b/resources/js/pages/impact-snapshots/index.tsx
@@ -1,4 +1,4 @@
-import { Form, Head, usePage } from '@inertiajs/react';
+import { Form, Head, Link, usePage } from '@inertiajs/react';
 import { useEffect, useRef, useState } from 'react';
 import Heading from '@/components/heading';
 import { Badge } from '@/components/ui/badge';
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { download, index, store } from '@/routes/impact-snapshots';
+import { index as reportingPublication } from '@/routes/reporting-publication';
 
 type Snapshot = {
     id: string;
@@ -91,8 +92,10 @@ function ApprovalPanel({ onDismiss }: { onDismiss: () => void }) {
 
 export default function ImpactSnapshotsIndex({
     snapshots,
+    canApprove,
 }: {
     snapshots: Snapshot[];
+    canApprove: boolean;
 }) {
     const organisation = usePage().props.currentOrganisation!;
     const [approving, setApproving] = useState(false);
@@ -123,15 +126,40 @@ export default function ImpactSnapshotsIndex({
                     title="Impact packs"
                     description="Immutable board, funder, and public snapshots approved from the reconciled metric registry."
                 />
-                <Button
-                    ref={approveButton}
-                    type="button"
-                    onClick={() => setApproving(true)}
-                    disabled={approving}
-                >
-                    Approve snapshot
-                </Button>
+                {canApprove ? (
+                    <Button
+                        ref={approveButton}
+                        type="button"
+                        onClick={() => setApproving(true)}
+                        disabled={approving}
+                    >
+                        Approve snapshot
+                    </Button>
+                ) : null}
             </div>
+
+            {/*
+             * Approving needs an active impact reporting configuration to say
+             * which metrics may leave the dashboard. The page used to offer the
+             * action anyway and fail on submit with a 500.
+             */}
+            {canApprove ? null : (
+                <div className="bg-muted/30 rounded-xl border p-5">
+                    <p className="font-medium">
+                        No reporting configuration is active
+                    </p>
+                    <p className="text-muted-foreground mt-1 text-sm">
+                        A snapshot can only carry metrics an active reporting
+                        configuration has approved for release. Activate one,
+                        then come back to approve a snapshot.
+                    </p>
+                    <Button asChild variant="outline" className="mt-3">
+                        <Link href={reportingPublication(organisation.slug)}>
+                            Open Reporting publication
+                        </Link>
+                    </Button>
+                </div>
+            )}
 
             {approving ? <ApprovalPanel onDismiss={dismiss} /> : null}
 

--- a/resources/js/tests/pages/impact-snapshots-index.test.tsx
+++ b/resources/js/tests/pages/impact-snapshots-index.test.tsx
@@ -9,9 +9,16 @@ vi.mock('@inertiajs/react', () => ({
         <form {...props}>{children}</form>
     ),
     Head: () => null,
+    Link: ({ children, ...props }: ComponentProps<'a'>) => (
+        <a {...props}>{children}</a>
+    ),
     usePage: () => ({
         props: { currentOrganisation: { slug: 'harbour-kind' } },
     }),
+}));
+
+vi.mock('@/routes/reporting-publication', () => ({
+    index: () => '/harbour-kind/reporting-publication',
 }));
 
 vi.mock('@/routes/impact-snapshots', () => ({
@@ -38,7 +45,7 @@ describe('Impact packs index', () => {
      * a form nobody had asked for.
      */
     it('shows the records first and the approval form only when asked for', () => {
-        render(<ImpactSnapshotsIndex snapshots={[snapshot]} />);
+        render(<ImpactSnapshotsIndex snapshots={[snapshot]} canApprove />);
 
         expect(
             screen.getByRole('heading', { name: 'Approved snapshots' }),
@@ -55,7 +62,7 @@ describe('Impact packs index', () => {
     });
 
     it('moves focus into the panel and back out again on cancel', () => {
-        render(<ImpactSnapshotsIndex snapshots={[snapshot]} />);
+        render(<ImpactSnapshotsIndex snapshots={[snapshot]} canApprove />);
 
         const open = screen.getByRole('button', { name: 'Approve snapshot' });
         fireEvent.click(open);
@@ -66,8 +73,27 @@ describe('Impact packs index', () => {
         expect(open).toHaveFocus();
     });
 
+    /*
+     * A snapshot can only carry metrics an active reporting configuration has
+     * approved for release. The page used to offer the action anyway and fail
+     * on submit with a 500 naming a LogicException.
+     */
+    it('explains the missing configuration instead of offering an action that fails', () => {
+        render(<ImpactSnapshotsIndex snapshots={[]} canApprove={false} />);
+
+        expect(
+            screen.queryByRole('button', { name: 'Approve snapshot' }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.getByText('No reporting configuration is active'),
+        ).toBeVisible();
+        expect(
+            screen.getByRole('link', { name: 'Open Reporting publication' }),
+        ).toHaveAttribute('href', '/harbour-kind/reporting-publication');
+    });
+
     it('teaches the interface when nothing has been approved', () => {
-        render(<ImpactSnapshotsIndex snapshots={[]} />);
+        render(<ImpactSnapshotsIndex snapshots={[]} canApprove />);
 
         expect(screen.getByText('No snapshots approved yet')).toBeVisible();
         expect(

--- a/resources/js/tests/pages/impact-snapshots-index.test.tsx
+++ b/resources/js/tests/pages/impact-snapshots-index.test.tsx
@@ -45,7 +45,13 @@ describe('Impact packs index', () => {
      * a form nobody had asked for.
      */
     it('shows the records first and the approval form only when asked for', () => {
-        render(<ImpactSnapshotsIndex snapshots={[snapshot]} canApprove />);
+        render(
+            <ImpactSnapshotsIndex
+                snapshots={[snapshot]}
+                canApprove
+                canConfigureReporting
+            />,
+        );
 
         expect(
             screen.getByRole('heading', { name: 'Approved snapshots' }),
@@ -62,7 +68,13 @@ describe('Impact packs index', () => {
     });
 
     it('moves focus into the panel and back out again on cancel', () => {
-        render(<ImpactSnapshotsIndex snapshots={[snapshot]} canApprove />);
+        render(
+            <ImpactSnapshotsIndex
+                snapshots={[snapshot]}
+                canApprove
+                canConfigureReporting
+            />,
+        );
 
         const open = screen.getByRole('button', { name: 'Approve snapshot' });
         fireEvent.click(open);
@@ -79,7 +91,13 @@ describe('Impact packs index', () => {
      * on submit with a 500 naming a LogicException.
      */
     it('explains the missing configuration instead of offering an action that fails', () => {
-        render(<ImpactSnapshotsIndex snapshots={[]} canApprove={false} />);
+        render(
+            <ImpactSnapshotsIndex
+                snapshots={[]}
+                canApprove={false}
+                canConfigureReporting
+            />,
+        );
 
         expect(
             screen.queryByRole('button', { name: 'Approve snapshot' }),
@@ -92,8 +110,41 @@ describe('Impact packs index', () => {
         ).toHaveAttribute('href', '/harbour-kind/reporting-publication');
     });
 
+    /*
+     * Approving a snapshot needs ExecutiveViewer; Reporting publication needs
+     * OrganisationAdministrator. Offering the link to everyone replaced a
+     * button that 500s with a link that 403s.
+     */
+    it('names who can activate a configuration rather than linking a reader to a 403', () => {
+        render(
+            <ImpactSnapshotsIndex
+                snapshots={[]}
+                canApprove={false}
+                canConfigureReporting={false}
+            />,
+        );
+
+        expect(
+            screen.getByText('No reporting configuration is active'),
+        ).toBeVisible();
+        expect(
+            screen.queryByRole('link', {
+                name: 'Open Reporting publication',
+            }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.getByText(/An organisation administrator activates one/),
+        ).toBeVisible();
+    });
+
     it('teaches the interface when nothing has been approved', () => {
-        render(<ImpactSnapshotsIndex snapshots={[]} canApprove />);
+        render(
+            <ImpactSnapshotsIndex
+                snapshots={[]}
+                canApprove
+                canConfigureReporting
+            />,
+        );
 
         expect(screen.getByText('No snapshots approved yet')).toBeVisible();
         expect(

--- a/tests/Feature/ImpactSnapshotApprovalTest.php
+++ b/tests/Feature/ImpactSnapshotApprovalTest.php
@@ -47,6 +47,31 @@ it('tells the page that a snapshot cannot be approved without an active configur
         ->assertInertia(fn (Assert $page) => $page->where('canApprove', true));
 });
 
+/*
+ * Approving a snapshot needs ExecutiveViewer; activating the configuration it
+ * depends on needs OrganisationAdministrator. The person blocked is usually not
+ * the person who can unblock, so the page must not send them to a 403.
+ */
+it('offers the configuration link only to a reader the reporting page will admit', function () {
+    extract(impactSnapshotFixture());
+
+    $this->actingAs($executive)
+        ->get(route('impact-snapshots.index', $organisation))
+        ->assertInertia(fn (Assert $page) => $page->where('canConfigureReporting', false));
+    $this->actingAs($executive)
+        ->get(route('reporting-publication.index', $organisation))
+        ->assertForbidden();
+
+    /* One membership per user, so the second role is another assignment on it. */
+    $administrator = User::factory()->create();
+    $membership = $organisation->memberships()->create(['user_id' => $administrator->id, 'role' => OrganisationRole::OrganisationAdministrator]);
+    app(OrganisationContext::class)->run($organisation, fn () => $membership->roleAssignments()->create(['role' => OrganisationRole::ExecutiveViewer]));
+
+    $this->actingAs($administrator)
+        ->get(route('impact-snapshots.index', $organisation))
+        ->assertInertia(fn (Assert $page) => $page->where('canConfigureReporting', true));
+});
+
 it('reports a missing configuration on the form rather than as a server error', function () {
     extract(impactSnapshotFixture());
 

--- a/tests/Feature/ImpactSnapshotApprovalTest.php
+++ b/tests/Feature/ImpactSnapshotApprovalTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Enums\OrganisationConfigurationArea;
+use App\Enums\OrganisationConfigurationStatus;
+use App\Enums\OrganisationRole;
+use App\Models\Organisation;
+use App\Models\OrganisationConfiguration;
+use App\Models\User;
+use App\OrganisationContext;
+use Inertia\Testing\AssertableInertia as Assert;
+
+/** @return array{organisation: Organisation, executive: User} */
+function impactSnapshotFixture(): array
+{
+    $organisation = Organisation::factory()->active()->create();
+    $executive = User::factory()->create();
+    $organisation->memberships()->create(['user_id' => $executive->id, 'role' => OrganisationRole::ExecutiveViewer]);
+
+    return compact('organisation', 'executive');
+}
+
+/*
+ * Approving a snapshot needs an active impact reporting configuration to say
+ * which metrics may leave the dashboard. Without one the page used to offer the
+ * action, take the form, and fail in the action with a LogicException that
+ * reached the person as a 500.
+ */
+it('tells the page that a snapshot cannot be approved without an active configuration', function () {
+    extract(impactSnapshotFixture());
+
+    $this->actingAs($executive)
+        ->get(route('impact-snapshots.index', $organisation))
+        ->assertOk()
+        ->assertInertia(fn (Assert $page) => $page
+            ->component('impact-snapshots/index')
+            ->where('canApprove', false));
+
+    app(OrganisationContext::class)->run($organisation, fn (): OrganisationConfiguration => OrganisationConfiguration::factory()->create([
+        'area' => OrganisationConfigurationArea::Reporting,
+        'configuration_key' => 'impact',
+        'status' => OrganisationConfigurationStatus::Active,
+        'definition' => ['pack_metric_ids' => ['service.requests_received'], 'public_metric_ids' => []],
+    ]));
+
+    $this->actingAs($executive)
+        ->get(route('impact-snapshots.index', $organisation))
+        ->assertInertia(fn (Assert $page) => $page->where('canApprove', true));
+});
+
+it('reports a missing configuration on the form rather than as a server error', function () {
+    extract(impactSnapshotFixture());
+
+    $this->actingAs($executive)
+        ->post(route('impact-snapshots.store', $organisation), [
+            'audience' => 'board',
+            'period_start' => '2026-08-01',
+            'period_end' => '2026-09-01',
+        ])
+        ->assertRedirect()
+        ->assertSessionHasErrors('audience');
+});


### PR DESCRIPTION
Reported from the running app: pressing **Approve snapshot** on `/harbourkind/impact-snapshots` returns a 500, and the first fix for it then returned a 403.

```
local.ERROR: An active impact reporting configuration is required.
LogicException at app/Actions/Reporting/PublishImpactSnapshot.php:30
```

## What is actually wrong

A snapshot can only carry metrics that an **active impact reporting configuration** has approved for release. A new Organisation has none. The page offered the action anyway, took the form, and failed inside the action — reaching the person as a 500 naming a class they have no way to act on.

## Changes

**1. Two of the action's four `LogicException`s were misclassified.** No active configuration, and a configuration that approves no metric available for the audience, are ordinary tenant states — not programming errors. They now throw `ImpactSnapshotNotApprovable`. The other two, an invalid audience and malformed reconciled data, stay `LogicException`, because they are.

**2. The page no longer offers what cannot succeed.** `index` reports `canApprove`. When false, the page explains what is missing rather than rendering a button that 500s.

**3. `store` still catches.** The configuration can be retired between loading the page and submitting, so the race reports on the form instead of as a server error.

**4. The way out is offered only to someone who can take it.** This is the second commit, and it fixes a defect the first one introduced.

Approving a snapshot needs `ExecutiveViewer`. Activating the configuration it depends on needs `OrganisationAdministrator`. **The person blocked is therefore usually not the person who can unblock** — so an *Open Reporting publication* button shown to every reader traded a button that 500s for a link that 403s.

`index` now reports whether the reader passes the same gate `ReportingPublicationController` applies. Where they do, the link stands. Where they do not, the panel names who activates a configuration instead of offering a door that will not open.

## Verification

Every new test was verified failing against the behaviour it replaces — the first two on the 500 and the `LogicException`, the last two on the 403 link.

- `vendor/bin/pest` — 410 passing
- `vendor/bin/phpstan` — 0 errors
- `npm test` — 402 passing
- `npm run check`, `npm run types:check` — clean

## AI-assisted contribution

Drafted with Claude Code (Opus 5) under my direction and review, as required by CONTRIBUTING.md.