### PR TITLE
Give the metric matrix checkboxes a target you can hit

### DIFF
--- a/resources/js/pages/reporting-publication/index.tsx
+++ b/resources/js/pages/reporting-publication/index.tsx
@@ -78,6 +78,39 @@ function DestinationCell({
     );
 }
 
+function MetricToggleCell({
+    checked,
+    onChange,
+    label,
+}: {
+    checked: boolean;
+    onChange: (checked: boolean) => void;
+    label: string;
+}) {
+    return (
+        <td className="p-0 align-top">
+            {/*
+             * A bare `size-4` checkbox is a 16px target centred in a column
+             * five times its width, so almost every click in the cell lands on
+             * nothing. WCAG 2.2 AA 2.5.8 wants 24px; this gives the whole
+             * padded cell.
+             *
+             * The hit area is a pseudo-element on the checkbox rather than a
+             * wrapping label, so there is exactly one target and no question
+             * of a label forwarding a second click to the control inside it.
+             */}
+            <div className="hover:bg-muted/60 relative flex justify-center px-4 py-3">
+                <Checkbox
+                    className="after:absolute after:inset-0 after:cursor-pointer"
+                    checked={checked}
+                    onCheckedChange={(state) => onChange(state === true)}
+                    aria-label={label}
+                />
+            </div>
+        </td>
+    );
+}
+
 function VersionMetricMatrix({ version }: { version: ReportingVersion }) {
     const rows = new Map<
         string,
@@ -331,44 +364,32 @@ export default function ReportingPublicationIndex({
                                                             {metric.description}
                                                         </span>
                                                     </th>
-                                                    <td className="px-4 py-3 text-center align-top">
-                                                        <Checkbox
-                                                            className="mx-auto"
-                                                            checked={editor.data.public_metric_ids.includes(
+                                                    <MetricToggleCell
+                                                        checked={editor.data.public_metric_ids.includes(
+                                                            metric.id,
+                                                        )}
+                                                        onChange={(checked) =>
+                                                            toggle(
+                                                                'public_metric_ids',
                                                                 metric.id,
-                                                            )}
-                                                            onCheckedChange={(
                                                                 checked,
-                                                            ) =>
-                                                                toggle(
-                                                                    'public_metric_ids',
-                                                                    metric.id,
-                                                                    checked ===
-                                                                        true,
-                                                                )
-                                                            }
-                                                            aria-label={`Publish ${metric.label} on the ${PUBLIC_LABEL}`}
-                                                        />
-                                                    </td>
-                                                    <td className="px-4 py-3 text-center align-top">
-                                                        <Checkbox
-                                                            className="mx-auto"
-                                                            checked={editor.data.pack_metric_ids.includes(
+                                                            )
+                                                        }
+                                                        label={`Publish ${metric.label} on the ${PUBLIC_LABEL}`}
+                                                    />
+                                                    <MetricToggleCell
+                                                        checked={editor.data.pack_metric_ids.includes(
+                                                            metric.id,
+                                                        )}
+                                                        onChange={(checked) =>
+                                                            toggle(
+                                                                'pack_metric_ids',
                                                                 metric.id,
-                                                            )}
-                                                            onCheckedChange={(
                                                                 checked,
-                                                            ) =>
-                                                                toggle(
-                                                                    'pack_metric_ids',
-                                                                    metric.id,
-                                                                    checked ===
-                                                                        true,
-                                                                )
-                                                            }
-                                                            aria-label={`Include ${metric.label} in ${PACK_LABEL}`}
-                                                        />
-                                                    </td>
+                                                            )
+                                                        }
+                                                        label={`Include ${metric.label} in ${PACK_LABEL}`}
+                                                    />
                                                 </tr>
                                             ))}
                                         </tbody>

--- a/resources/js/tests/pages/reporting-publication-index.test.tsx
+++ b/resources/js/tests/pages/reporting-publication-index.test.tsx
@@ -132,6 +132,29 @@ describe('reporting publication editor', () => {
             '1 selected metric hidden by the current search',
         );
     });
+
+    /*
+     * The checkbox is a 16px square in a column five times its width, so almost
+     * every click in the cell used to land on nothing — reported from the
+     * running app as needing five or six attempts. WCAG 2.2 AA 2.5.8 asks for a
+     * 24px target.
+     *
+     * jsdom has no layout, so the hit area cannot be measured or clicked here.
+     * What is asserted is the contract that produces it: the checkbox carries a
+     * pseudo-element pinned to its cell, and the cell is a positioned ancestor
+     * for it to pin to. Either half missing puts the target back at 16px.
+     */
+    it('gives each matrix checkbox the whole cell as its target', () => {
+        render(<ReportingPublicationIndex metrics={metrics} versions={[]} />);
+
+        const checkboxes = screen.getAllByRole('checkbox');
+        expect(checkboxes.length).toBeGreaterThan(0);
+
+        for (const checkbox of checkboxes) {
+            expect(checkbox).toHaveClass('after:absolute', 'after:inset-0');
+            expect(checkbox.parentElement).toHaveClass('relative');
+        }
+    });
 });
 
 describe('reporting publication version history', () => {


### PR DESCRIPTION
Reported from the running app: the metric matrix checkboxes take five or six clicks to register.

## What is wrong

`Checkbox` is `size-4` — **a 16px square**, and it is the entire clickable area. It sits centred in a column five times its width, in a row three times its height. Everything else in the cell does nothing, so selecting a metric means aiming at roughly one percent of the cell you are pointing at.

It also fails **WCAG 2.2 AA 2.5.8 Target Size (Minimum)**, which asks for 24×24 CSS px — and `.impeccable.md` records WCAG 2.2 AA as enforced.

The toggle logic was never at fault. Nothing was being swallowed; the clicks were landing on the cell.

## The fix

The target is now the whole padded cell.

That is done with a pseudo-element on the checkbox — `after:absolute after:inset-0` against a positioned cell — rather than a wrapping `<label>`. With a label there are two elements that both want to activate the control and a real question of the label forwarding a second click to the Radix button inside it; with the pseudo-element there is exactly one target and the existing `aria-label` and `onCheckedChange` are untouched.

The cell gains a hover tint, so the larger target is visible rather than merely present.

## Also

The two nearly identical cells become one `MetricToggleCell`, which takes four levels of nesting out of the row.

## On the test

jsdom has no layout, so the hit area cannot be measured or clicked in a unit test. The guard asserts the contract that produces it — the checkbox carries the pinned pseudo-element and its cell is the positioned ancestor it pins to. Either half missing puts the target back at 16px, and the test says so. Verified failing against the old cells.

## Verification

- `npm test` — 399 passing
- `npm run check`, `npm run types:check` — clean

## AI-assisted contribution

Drafted with Claude Code (Opus 5) under my direction and review, as required by CONTRIBUTING.md.