### PR TITLE
Let a reporting version publish to any set of destinations, including none

### DIFF
--- a/app/Actions/Configuration/ValidateConfigurationDefinition.php
+++ b/app/Actions/Configuration/ValidateConfigurationDefinition.php
@@ -31,10 +31,22 @@ final class ValidateConfigurationDefinition
             OrganisationConfigurationArea::MessageTemplate => ['channel' => ['required', Rule::in(['email', 'sms'])], 'subject' => ['nullable', 'string', 'max:160'], 'body' => ['required', 'string', 'max:4000'], 'journey_kind' => ['required', Rule::enum(SupporterJourneyKind::class)]],
             OrganisationConfigurationArea::SupporterJourney => ['default_kind' => ['required', Rule::enum(SupporterJourneyKind::class)], 'default_channel' => ['required', Rule::in(['email', 'sms'])], 'default_message_template_id' => ['nullable', 'uuid'], 'require_approval' => ['required', 'accepted'], 'dispatch_rechecks_consent' => ['required', 'accepted'], 'frequency_cap_days' => ['required', 'integer', 'min:'.config('engagement.frequency_cap_days'), 'max:365']],
             OrganisationConfigurationArea::IntakeRules => ['required_fields' => ['required', 'array', 'min:2'], 'required_fields.*' => ['required', Rule::in(['party_uuid', 'email', 'telephone', 'source', 'narrative', 'presenting_needs', 'program_id']), 'distinct'], 'default_urgency' => ['required', Rule::in(['routine', 'priority', 'urgent'])], 'allow_restricted_access_bypass' => ['required', 'declined']],
-            OrganisationConfigurationArea::Reporting => ['public_metric_ids' => ['required', 'array'], 'public_metric_ids.*' => ['required', Rule::in($this->metrics->ids()), 'distinct'], 'pack_metric_ids' => ['required', 'array', 'min:1'], 'pack_metric_ids.*' => ['required', Rule::in($this->metrics->ids()), 'distinct']],
+            OrganisationConfigurationArea::Reporting => ['public_metric_ids' => ['present', 'array'], 'public_metric_ids.*' => ['required', Rule::in($this->metrics->ids()), 'distinct'], 'pack_metric_ids' => ['present', 'array'], 'pack_metric_ids.*' => ['required', Rule::in($this->metrics->ids()), 'distinct']],
         };
         $validator = Validator::make($definition, $rules);
         $validator->after(function ($validator) use ($area, $definition): void {
+            /*
+             * A destination may be empty: publishing a funder pack without a
+             * public page, or the reverse, is an ordinary choice. Publishing
+             * nowhere is the one combination that cannot mean anything.
+             */
+            if ($area === OrganisationConfigurationArea::Reporting) {
+                $public = is_array($definition['public_metric_ids'] ?? null) ? $definition['public_metric_ids'] : [];
+                $pack = is_array($definition['pack_metric_ids'] ?? null) ? $definition['pack_metric_ids'] : [];
+                if ($public === [] && $pack === []) {
+                    $validator->errors()->add('public_metric_ids', 'Select at least one metric for the public page or the reporting pack.');
+                }
+            }
             $requiredFields = is_array($definition['required_fields'] ?? null) ? $definition['required_fields'] : [];
             if ($area === OrganisationConfigurationArea::PublicForm) {
                 $required = collect($requiredFields);

--- a/app/Actions/Configuration/ValidateConfigurationDefinition.php
+++ b/app/Actions/Configuration/ValidateConfigurationDefinition.php
@@ -35,18 +35,6 @@ final class ValidateConfigurationDefinition
         };
         $validator = Validator::make($definition, $rules);
         $validator->after(function ($validator) use ($area, $definition): void {
-            /*
-             * A destination may be empty: publishing a funder pack without a
-             * public page, or the reverse, is an ordinary choice. Publishing
-             * nowhere is the one combination that cannot mean anything.
-             */
-            if ($area === OrganisationConfigurationArea::Reporting) {
-                $public = is_array($definition['public_metric_ids'] ?? null) ? $definition['public_metric_ids'] : [];
-                $pack = is_array($definition['pack_metric_ids'] ?? null) ? $definition['pack_metric_ids'] : [];
-                if ($public === [] && $pack === []) {
-                    $validator->errors()->add('public_metric_ids', 'Select at least one metric for the public page or the reporting pack.');
-                }
-            }
             $requiredFields = is_array($definition['required_fields'] ?? null) ? $definition['required_fields'] : [];
             if ($area === OrganisationConfigurationArea::PublicForm) {
                 $required = collect($requiredFields);

--- a/app/Http/Requests/Organisations/StoreReportingPublicationRequest.php
+++ b/app/Http/Requests/Organisations/StoreReportingPublicationRequest.php
@@ -6,7 +6,6 @@ use App\Reporting\MetricRegistry;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
-use Illuminate\Validation\Validator;
 
 class StoreReportingPublicationRequest extends FormRequest
 {
@@ -27,32 +26,17 @@ class StoreReportingPublicationRequest extends FormRequest
     {
         /*
          * Each destination requires only that it is sent, not that it holds
-         * something. Requiring `min:1` on both meant an Organisation could not
-         * publish a funder pack without also publishing a public page, or the
-         * reverse — a restriction nothing in the product asks for.
+         * something. Requiring `min:1` meant an Organisation could not publish
+         * a funder pack without also publishing a public page — and could not
+         * withdraw the last metric it had published either. An empty
+         * publication means nothing may leave the dashboard, which is a state
+         * an Organisation has to be able to reach.
          */
         return [
             'public_metric_ids' => ['present', 'array'],
             'public_metric_ids.*' => ['required', 'string', Rule::in(app(MetricRegistry::class)->ids()), 'distinct'],
             'pack_metric_ids' => ['present', 'array'],
             'pack_metric_ids.*' => ['required', 'string', Rule::in(app(MetricRegistry::class)->ids()), 'distinct'],
-        ];
-    }
-
-    /**
-     * A version that publishes nothing anywhere is the one combination that
-     * cannot mean anything, so that is the only one refused.
-     *
-     * @return array<int, callable>
-     */
-    public function after(): array
-    {
-        return [
-            function (Validator $validator): void {
-                if ($this->array('public_metric_ids') === [] && $this->array('pack_metric_ids') === []) {
-                    $validator->errors()->add('public_metric_ids', 'Select at least one metric for the public page or the reporting pack.');
-                }
-            },
         ];
     }
 }

--- a/app/Http/Requests/Organisations/StoreReportingPublicationRequest.php
+++ b/app/Http/Requests/Organisations/StoreReportingPublicationRequest.php
@@ -6,6 +6,7 @@ use App\Reporting\MetricRegistry;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\Validator;
 
 class StoreReportingPublicationRequest extends FormRequest
 {
@@ -24,11 +25,34 @@ class StoreReportingPublicationRequest extends FormRequest
      */
     public function rules(): array
     {
+        /*
+         * Each destination requires only that it is sent, not that it holds
+         * something. Requiring `min:1` on both meant an Organisation could not
+         * publish a funder pack without also publishing a public page, or the
+         * reverse — a restriction nothing in the product asks for.
+         */
         return [
-            'public_metric_ids' => ['required', 'array', 'min:1'],
+            'public_metric_ids' => ['present', 'array'],
             'public_metric_ids.*' => ['required', 'string', Rule::in(app(MetricRegistry::class)->ids()), 'distinct'],
-            'pack_metric_ids' => ['required', 'array', 'min:1'],
+            'pack_metric_ids' => ['present', 'array'],
             'pack_metric_ids.*' => ['required', 'string', Rule::in(app(MetricRegistry::class)->ids()), 'distinct'],
+        ];
+    }
+
+    /**
+     * A version that publishes nothing anywhere is the one combination that
+     * cannot mean anything, so that is the only one refused.
+     *
+     * @return array<int, callable>
+     */
+    public function after(): array
+    {
+        return [
+            function (Validator $validator): void {
+                if ($this->array('public_metric_ids') === [] && $this->array('pack_metric_ids') === []) {
+                    $validator->errors()->add('public_metric_ids', 'Select at least one metric for the public page or the reporting pack.');
+                }
+            },
         ];
     }
 }

--- a/resources/js/pages/public-forms/index.tsx
+++ b/resources/js/pages/public-forms/index.tsx
@@ -93,10 +93,6 @@ function VersionDetail({
     organisationSlug: string;
     onNewVersion: () => void;
 }) {
-    const optionalCount = version.fields.filter(
-        (field) => !field.required,
-    ).length;
-
     return (
         <div className="space-y-2">
             <div className="flex flex-wrap items-center justify-between gap-3">
@@ -131,40 +127,28 @@ function VersionDetail({
                 </div>
             </div>
             {/*
-             * The fields were a two-column grid, so a list whose whole point is
-             * the order the fields appear in read 1,2 then 3,4 across — and
-             * stretched two short columns over the full card width. They now
-             * run in one wrapped sequence at reading width, in form order.
+             * A form is read top to bottom, so its fields are listed the same
+             * way. They were a two-column grid, which made a list whose whole
+             * point is the order read 1,2 then 3,4 across the card.
              *
              * "required" was printed against every field, which says nothing
-             * when it is the common case. Only the exception is marked, and the
-             * count is stated once.
+             * when it is the common case. Only the exception is marked.
              */}
-            <ol className="text-muted-foreground flex max-w-prose flex-wrap items-center text-sm">
+            <ol className="max-w-sm space-y-1 text-sm">
                 {version.fields.map((field, fieldIndex) => (
-                    <li key={field.key} className="flex items-center">
-                        {fieldIndex > 0 ? (
-                            <span
-                                aria-hidden="true"
-                                className="mx-2 opacity-50"
-                            >
-                                ·
-                            </span>
-                        ) : null}
-                        <span className="text-foreground">{field.label}</span>
+                    <li key={field.key} className="flex gap-2">
+                        <span className="text-muted-foreground tabular-nums">
+                            {fieldIndex + 1}.
+                        </span>
+                        <span>{field.label}</span>
                         {field.required ? null : (
-                            <span className="ml-1">(optional)</span>
+                            <span className="text-muted-foreground">
+                                optional
+                            </span>
                         )}
                     </li>
                 ))}
             </ol>
-            <p className="text-muted-foreground text-xs">
-                {version.fields.length}{' '}
-                {version.fields.length === 1 ? 'field' : 'fields'}
-                {optionalCount > 0
-                    ? `, ${optionalCount} optional`
-                    : ', all required'}
-            </p>
         </div>
     );
 }

--- a/resources/js/pages/public-forms/index.tsx
+++ b/resources/js/pages/public-forms/index.tsx
@@ -93,9 +93,13 @@ function VersionDetail({
     organisationSlug: string;
     onNewVersion: () => void;
 }) {
+    const optionalCount = version.fields.filter(
+        (field) => !field.required,
+    ).length;
+
     return (
-        <div className="grid gap-3 lg:grid-cols-[1fr_auto]">
-            <div className="space-y-2">
+        <div className="space-y-2">
+            <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="flex flex-wrap items-center gap-2">
                     <strong>v{version.version}</strong>
                     <Badge>{version.status}</Badge>
@@ -109,25 +113,58 @@ function VersionDetail({
                         </time>
                     ) : null}
                 </div>
-                <ol className="grid gap-1 text-sm sm:grid-cols-2">
-                    {version.fields.map((field, fieldIndex) => (
-                        <li key={field.key}>
-                            {fieldIndex + 1}. {field.label}
-                            {field.required ? ' · required' : ' · optional'}
-                        </li>
-                    ))}
-                </ol>
+                <div className="flex flex-wrap gap-2">
+                    <Button
+                        type="button"
+                        variant="outline"
+                        onClick={onNewVersion}
+                    >
+                        New version
+                    </Button>
+                    {version.canActivate ? (
+                        <Form
+                            {...activate.form([organisationSlug, version.id])}
+                        >
+                            <Button>Activate</Button>
+                        </Form>
+                    ) : null}
+                </div>
             </div>
-            <div className="flex flex-wrap items-start gap-2">
-                <Button type="button" variant="outline" onClick={onNewVersion}>
-                    New version
-                </Button>
-                {version.canActivate ? (
-                    <Form {...activate.form([organisationSlug, version.id])}>
-                        <Button>Activate</Button>
-                    </Form>
-                ) : null}
-            </div>
+            {/*
+             * The fields were a two-column grid, so a list whose whole point is
+             * the order the fields appear in read 1,2 then 3,4 across — and
+             * stretched two short columns over the full card width. They now
+             * run in one wrapped sequence at reading width, in form order.
+             *
+             * "required" was printed against every field, which says nothing
+             * when it is the common case. Only the exception is marked, and the
+             * count is stated once.
+             */}
+            <ol className="text-muted-foreground flex max-w-prose flex-wrap items-center text-sm">
+                {version.fields.map((field, fieldIndex) => (
+                    <li key={field.key} className="flex items-center">
+                        {fieldIndex > 0 ? (
+                            <span
+                                aria-hidden="true"
+                                className="mx-2 opacity-50"
+                            >
+                                ·
+                            </span>
+                        ) : null}
+                        <span className="text-foreground">{field.label}</span>
+                        {field.required ? null : (
+                            <span className="ml-1">(optional)</span>
+                        )}
+                    </li>
+                ))}
+            </ol>
+            <p className="text-muted-foreground text-xs">
+                {version.fields.length}{' '}
+                {version.fields.length === 1 ? 'field' : 'fields'}
+                {optionalCount > 0
+                    ? `, ${optionalCount} optional`
+                    : ', all required'}
+            </p>
         </div>
     );
 }
@@ -402,7 +439,12 @@ export default function PublicFormsIndex({
 
                     return (
                         <Card key={form.purpose}>
-                            <CardHeader className="flex-row items-baseline justify-between gap-3 space-y-0">
+                            {/*
+                             * The status sits beside the name it describes.
+                             * Pushed to the far edge of a full-width card it
+                             * read as unrelated to anything.
+                             */}
+                            <CardHeader className="flex-row flex-wrap items-baseline space-y-0 gap-x-3 gap-y-1">
                                 <CardTitle>{form.purposeLabel}</CardTitle>
                                 <p className="text-muted-foreground text-sm">
                                     {form.activeVersion === null

--- a/resources/js/pages/reporting-publication/index.tsx
+++ b/resources/js/pages/reporting-publication/index.tsx
@@ -430,6 +430,20 @@ export default function ReportingPublicationIndex({
                                     : 'Create reporting draft'}
                             </Button>
                         </div>
+                        {/*
+                         * Selecting nothing is allowed and is the way to stop
+                         * publishing, so it has to be stated rather than
+                         * refused. Withdrawing the last metric used to fail
+                         * validation, which left no way back out of publishing.
+                         */}
+                        {editor.data.public_metric_ids.length === 0 &&
+                        editor.data.pack_metric_ids.length === 0 ? (
+                            <p className="text-muted-foreground text-sm">
+                                This version publishes nothing. Activating it
+                                withdraws every metric from the public page and
+                                from reporting packs.
+                            </p>
+                        ) : null}
                     </form>
                 </CardContent>
             </Card>

--- a/resources/js/pages/reporting-publication/index.tsx
+++ b/resources/js/pages/reporting-publication/index.tsx
@@ -443,42 +443,51 @@ export default function ReportingPublicationIndex({
                 ) : null}
                 {versions.map((version) => (
                     <Card key={version.id}>
-                        <CardContent className="grid gap-4 pt-6 lg:grid-cols-[1fr_auto]">
-                            <div className="space-y-3">
+                        <CardContent className="space-y-3 pt-6">
+                            {/*
+                             * The actions sat in a column of their own, so they
+                             * floated at the far right of a narrow table. They
+                             * now share a line with the version they act on.
+                             *
+                             * Every row was titled "Reporting publication · v1",
+                             * restating the page title once per version. There
+                             * is only one reporting publication, so the version
+                             * is the only part that varies.
+                             */}
+                            <div className="flex flex-wrap items-center justify-between gap-3">
                                 <div className="flex items-center gap-2">
-                                    <strong>
-                                        Reporting publication · v
-                                        {version.version}
-                                    </strong>
+                                    <strong>v{version.version}</strong>
                                     <Badge>{version.status}</Badge>
                                 </div>
-                                <VersionMetricMatrix version={version} />
-                                {version.hasUnavailableMetrics ? (
-                                    <p className="text-muted-foreground text-sm">
-                                        Create a new version to replace retired
-                                        metrics before activation.
-                                    </p>
-                                ) : null}
-                            </div>
-                            <div className="flex flex-wrap items-start gap-2">
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    onClick={() => useAsStartingPoint(version)}
-                                >
-                                    New version
-                                </Button>
-                                {version.canActivate ? (
-                                    <Form
-                                        {...activate.form([
-                                            organisation.slug,
-                                            version.id,
-                                        ])}
+                                <div className="flex flex-wrap gap-2">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={() =>
+                                            useAsStartingPoint(version)
+                                        }
                                     >
-                                        <Button>Activate</Button>
-                                    </Form>
-                                ) : null}
+                                        New version
+                                    </Button>
+                                    {version.canActivate ? (
+                                        <Form
+                                            {...activate.form([
+                                                organisation.slug,
+                                                version.id,
+                                            ])}
+                                        >
+                                            <Button>Activate</Button>
+                                        </Form>
+                                    ) : null}
+                                </div>
                             </div>
+                            <VersionMetricMatrix version={version} />
+                            {version.hasUnavailableMetrics ? (
+                                <p className="text-muted-foreground text-sm">
+                                    Create a new version to replace retired
+                                    metrics before activation.
+                                </p>
+                            ) : null}
                         </CardContent>
                     </Card>
                 ))}

--- a/resources/js/tests/pages/public-forms-index.test.tsx
+++ b/resources/js/tests/pages/public-forms-index.test.tsx
@@ -1,0 +1,109 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import PublicFormsIndex from '@/pages/public-forms/index';
+
+vi.mock('@inertiajs/react', () => ({
+    Form: ({ children, ...props }: ComponentProps<'form'>) => (
+        <form {...props}>{children}</form>
+    ),
+    Head: () => null,
+    useForm: <T,>(data: T) => ({
+        data,
+        errors: {},
+        clearErrors: vi.fn(),
+        post: vi.fn(),
+        processing: false,
+        setData: vi.fn(),
+    }),
+    usePage: () => ({
+        props: { currentOrganisation: { slug: 'harbour-kind' } },
+    }),
+}));
+
+vi.mock('@/routes/public-forms', () => ({
+    activate: { form: () => ({ action: '/activate' }) },
+    index: vi.fn(),
+    store: { url: () => '/store' },
+}));
+
+const field = (key: string, label: string, required: boolean) => ({
+    key,
+    label,
+    type: 'text',
+    required,
+    fixedRequired: required,
+});
+
+const fields = [
+    field('name', 'Name', true),
+    field('email', 'Email address', true),
+    field('category', 'Category', true),
+    field('estimated_value', 'Estimated value', false),
+    field('currency', 'Currency', false),
+];
+
+const purposes = [
+    {
+        value: 'in_kind_offer',
+        label: 'In-kind offer',
+        description: 'Offer goods or services.',
+        fields,
+    },
+];
+
+const forms = [
+    {
+        purpose: 'in_kind_offer',
+        purposeLabel: 'In-kind offer',
+        activeVersion: null,
+        versions: [
+            {
+                id: 'version-1',
+                version: 1,
+                status: 'draft',
+                fields,
+                activatedAt: null,
+                canActivate: true,
+            },
+        ],
+    },
+];
+
+describe('public forms index', () => {
+    afterEach(cleanup);
+
+    /*
+     * The fields were a two-column grid, so a list whose whole point is the
+     * order the fields appear in read 1,2 then 3,4 across the card.
+     */
+    it('lists the fields once, in form order, in a single sequence', () => {
+        render(<PublicFormsIndex purposes={purposes} forms={forms} />);
+
+        const list = screen.getByRole('list');
+        expect(list).not.toHaveClass('sm:grid-cols-2');
+        expect(
+            within(list)
+                .getAllByRole('listitem')
+                .map((item) => item.textContent?.replace(/^·\s*/, '')),
+        ).toEqual([
+            'Name',
+            'Email address',
+            'Category',
+            'Estimated value(optional)',
+            'Currency(optional)',
+        ]);
+    });
+
+    /*
+     * "required" against every field says nothing when it is the common case,
+     * and it was printed five times on a five-field form.
+     */
+    it('marks only the exception and states the count once', () => {
+        render(<PublicFormsIndex purposes={purposes} forms={forms} />);
+
+        expect(screen.queryByText(/· required/)).not.toBeInTheDocument();
+        expect(screen.getByText('5 fields, 2 optional')).toBeVisible();
+    });
+});

--- a/resources/js/tests/pages/public-forms-index.test.tsx
+++ b/resources/js/tests/pages/public-forms-index.test.tsx
@@ -86,13 +86,13 @@ describe('public forms index', () => {
         expect(
             within(list)
                 .getAllByRole('listitem')
-                .map((item) => item.textContent?.replace(/^·\s*/, '')),
+                .map((item) => item.textContent),
         ).toEqual([
-            'Name',
-            'Email address',
-            'Category',
-            'Estimated value(optional)',
-            'Currency(optional)',
+            '1.Name',
+            '2.Email address',
+            '3.Category',
+            '4.Estimated valueoptional',
+            '5.Currencyoptional',
         ]);
     });
 
@@ -100,10 +100,10 @@ describe('public forms index', () => {
      * "required" against every field says nothing when it is the common case,
      * and it was printed five times on a five-field form.
      */
-    it('marks only the exception and states the count once', () => {
+    it('marks only the exception', () => {
         render(<PublicFormsIndex purposes={purposes} forms={forms} />);
 
         expect(screen.queryByText(/· required/)).not.toBeInTheDocument();
-        expect(screen.getByText('5 fields, 2 optional')).toBeVisible();
+        expect(screen.getAllByText('optional')).toHaveLength(2);
     });
 });

--- a/tests/Feature/ReportingPublicationEditorTest.php
+++ b/tests/Feature/ReportingPublicationEditorTest.php
@@ -96,6 +96,39 @@ it('shows retired metrics in immutable legacy versions without making them selec
     ]);
 });
 
+/*
+ * Both destinations were `required|array|min:1`, so an Organisation could not
+ * publish a funder pack without also publishing a public page, or the reverse.
+ * Nothing in the product asks for that.
+ */
+it('accepts a version that publishes to one destination only', function () {
+    extract(reportingPublicationEditorFixture());
+
+    $this->actingAs($administrator)
+        ->post(route('reporting-publication.store', $organisation), [
+            'public_metric_ids' => ['engagement.event_attendance'],
+            'pack_metric_ids' => [],
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    $this->actingAs($administrator)
+        ->post(route('reporting-publication.store', $organisation), [
+            'public_metric_ids' => [],
+            'pack_metric_ids' => ['engagement.event_attendance'],
+        ])
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    /* Publishing nowhere is the one combination that cannot mean anything. */
+    $this->actingAs($administrator)
+        ->post(route('reporting-publication.store', $organisation), [
+            'public_metric_ids' => [],
+            'pack_metric_ids' => [],
+        ])
+        ->assertSessionHasErrors('public_metric_ids');
+});
+
 it('rejects unavailable metrics and removes reporting from the generic JSON workflow', function () {
     extract(reportingPublicationEditorFixture());
 
@@ -104,7 +137,8 @@ it('rejects unavailable metrics and removes reporting from the generic JSON work
             'public_metric_ids' => ['legacy.people_reached'],
             'pack_metric_ids' => [],
         ])
-        ->assertSessionHasErrors(['public_metric_ids.0', 'pack_metric_ids']);
+        ->assertSessionHasErrors('public_metric_ids.0')
+        ->assertSessionDoesntHaveErrors('pack_metric_ids');
     $this->actingAs($administrator)
         ->post("/{$organisation->slug}/organisation-configurations", [
             'area' => 'reporting',

--- a/tests/Feature/ReportingPublicationEditorTest.php
+++ b/tests/Feature/ReportingPublicationEditorTest.php
@@ -101,7 +101,7 @@ it('shows retired metrics in immutable legacy versions without making them selec
  * publish a funder pack without also publishing a public page, or the reverse.
  * Nothing in the product asks for that.
  */
-it('accepts a version that publishes to one destination only', function () {
+it('accepts a version that publishes to one destination, or to none', function () {
     extract(reportingPublicationEditorFixture());
 
     $this->actingAs($administrator)
@@ -120,13 +120,34 @@ it('accepts a version that publishes to one destination only', function () {
         ->assertRedirect()
         ->assertSessionHasNoErrors();
 
-    /* Publishing nowhere is the one combination that cannot mean anything. */
+    /*
+     * Publishing nothing is how an Organisation stops publishing. Refusing it
+     * meant the last metric could never be withdrawn once it was approved.
+     */
     $this->actingAs($administrator)
         ->post(route('reporting-publication.store', $organisation), [
             'public_metric_ids' => [],
             'pack_metric_ids' => [],
         ])
-        ->assertSessionHasErrors('public_metric_ids');
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
+
+    /*
+     * Activation runs ValidateConfigurationDefinition, which enforced the same
+     * minimum separately. Fixing only the form request would have moved the
+     * refusal from submit to activate.
+     */
+    $empty = app(OrganisationContext::class)->run($organisation, fn (): OrganisationConfiguration => OrganisationConfiguration::query()
+        ->where('area', OrganisationConfigurationArea::Reporting)
+        ->where('configuration_key', 'impact')
+        ->latest('version')
+        ->firstOrFail());
+    expect($empty->definition)->toBe(['public_metric_ids' => [], 'pack_metric_ids' => []]);
+
+    $this->actingAs($administrator)
+        ->post(route('reporting-publication.activate', [$organisation, $empty]))
+        ->assertRedirect()
+        ->assertSessionHasNoErrors();
 });
 
 it('rejects unavailable metrics and removes reporting from the generic JSON workflow', function () {


### PR DESCRIPTION
Reported from the running app, in three rounds.

## 1. You could not choose one destination

Selecting a metric for the public page but not the reporting pack — or the reverse — was refused. Both destinations required at least one metric, so **an Organisation could not publish a funder pack without also publishing a public page.** Nothing in the PRD asks for that.

It was enforced in **two** places:

- `StoreReportingPublicationRequest` — `['required', 'array', 'min:1']` on both
- `ValidateConfigurationDefinition` — `min:1` on `pack_metric_ids`, and this is the one **activation** runs

Fixing only the form request would have moved the refusal from submit to activate, which is worse.

## 2. …and you could not un-publish either

My first fix replaced "at least one in each" with "at least one somewhere" — the same trap in a weaker form. With one approved metric you could not withdraw it. **There was no way back out of publishing.**

Publishing nothing is a state an Organisation has to be able to reach. It is how you stop publishing — during an incident, or when a funder relationship ends — and it is the only mechanism available, because a reporting publication cannot be deleted and has no retire action.

Nothing downstream breaks on it: `PublishImpactSnapshot` already reports an empty allowed set as `ImpactSnapshotNotApprovable` (#121) rather than failing, so an empty publication simply means no snapshot can be approved.

Both destinations now require only that they are **sent**, not that they are **filled**. There is no minimum. The editor *states* what an empty version does rather than refusing it, because activating one withdraws every published metric and that should not be a surprise.

The test activates the empty version too, not just stores it — activation is the second enforcement point.

## 3. The two version lists

**Public forms.** The field list was a two-column grid, so a list whose entire point is **the order the fields appear in** read 1,2 then 3,4 across the card, with two short columns stretched over the full width. A form is read top to bottom, so its fields are now listed the same way — one numbered column at reading width. `· required` was printed against every field, which says nothing when it is the common case; only the exception is marked. The card status now sits beside the name it describes rather than at the far edge.

**Reporting publication.** Every row was titled `Reporting publication · v1`, restating the page title once per version when only the version varies. The actions sat in a column of their own, so two buttons floated at the far right of a narrow table. The version and its actions now share a line.

## Verification

The field-list tests were verified failing against the old layout; the destination tests fail against the old rules at both enforcement points.

- `vendor/bin/pest` — 411 passing
- `vendor/bin/phpstan` — 0 errors
- `npm test` — 412 passing
- `npm run check`, `npm run types:check` — clean

## AI-assisted contribution

Drafted with Claude Code (Opus 5) under my direction and review, as required by CONTRIBUTING.md.