### PR TITLE
Stop the reporting destination column headers wrapping

### DIFF
--- a/resources/js/pages/reporting-publication/index.tsx
+++ b/resources/js/pages/reporting-publication/index.tsx
@@ -153,13 +153,13 @@ function VersionMetricMatrix({ version }: { version: ReportingVersion }) {
                         </th>
                         <th
                             scope="col"
-                            className="w-28 px-4 py-2 text-center font-medium"
+                            className="w-40 px-4 py-2 text-center font-medium whitespace-nowrap"
                         >
                             Public page
                         </th>
                         <th
                             scope="col"
-                            className="w-28 px-4 py-2 text-center font-medium"
+                            className="w-40 px-4 py-2 text-center font-medium whitespace-nowrap"
                         >
                             Reporting pack
                         </th>
@@ -329,13 +329,13 @@ export default function ReportingPublicationIndex({
                                                 </th>
                                                 <th
                                                     scope="col"
-                                                    className="w-28 px-4 py-2 text-center font-medium"
+                                                    className="w-40 px-4 py-2 text-center font-medium whitespace-nowrap"
                                                 >
                                                     Public page
                                                 </th>
                                                 <th
                                                     scope="col"
-                                                    className="w-28 px-4 py-2 text-center font-medium"
+                                                    className="w-40 px-4 py-2 text-center font-medium whitespace-nowrap"
                                                 >
                                                     Reporting pack
                                                 </th>


### PR DESCRIPTION
The two destination columns in both reporting-publication tables were `w-28` (112px). With 32px of horizontal padding that leaves 80px of text width, so "Reporting pack" broke onto a second line — making the header row taller than the checkbox rows under it and leaving the two headers visually unequal.

Widened both to `w-40` and pinned them to a single line, in both tables: the read-only version detail and the editor.

## Verification

- `npm run check` — 147 files formatted, 123 linted, clean
- `npm test` — 412 passing

## AI assistance

Written with Claude Code (Claude Opus 5). Reviewed by me before submission.