### PR TITLE
Lead intake rules with its versions, and stop drawing safeguards as checkboxes

### DIFF
--- a/resources/js/pages/intake-rules/index.tsx
+++ b/resources/js/pages/intake-rules/index.tsx
@@ -174,19 +174,18 @@ export default function IntakeRulesIndex({
                                     </div>
                                 ))}
                             </div>
-                            <div className="bg-background rounded-lg border p-4">
-                                <div className="flex items-center gap-2">
-                                    <input
-                                        type="checkbox"
-                                        checked={false}
-                                        disabled
-                                        readOnly
-                                    />
-                                    <span className="font-medium">
-                                        Restricted-access bypass disabled
-                                    </span>
-                                </div>
-                                <p className="text-muted-foreground mt-2 text-sm">
+                            {/*
+                             * This was a disabled, permanently unchecked
+                             * checkbox. Nothing could ever tick it, and an
+                             * empty box reads as "safeguard off" when it means
+                             * the exact opposite.
+                             */}
+                            <div className="bg-background rounded-lg border p-4 text-sm">
+                                <p className="font-medium">
+                                    <span aria-hidden="true">✓ </span>
+                                    Restricted-access bypass unavailable
+                                </p>
+                                <p className="text-muted-foreground mt-2">
                                     Intake settings cannot weaken restricted
                                     case access or staff authorization.
                                 </p>

--- a/resources/js/pages/intake-rules/index.tsx
+++ b/resources/js/pages/intake-rules/index.tsx
@@ -1,10 +1,10 @@
 import { Form, Head, useForm, usePage } from '@inertiajs/react';
 import type { FormEvent } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import Heading from '@/components/heading';
 import InputError from '@/components/input-error';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { activate, index, store } from '@/routes/intake-rules';
 
@@ -21,32 +21,51 @@ type IntakeRule = {
 
 type Option = { value: string; label: string };
 
+type Draft = {
+    required_contact_fields: string[];
+    default_urgency: string;
+};
+
 const contactFields: Option[] = [
     { value: 'email', label: 'Email address' },
     { value: 'telephone', label: 'Telephone number' },
 ];
 
-export default function IntakeRulesIndex({
-    rules,
+const contactSummary = (requiredFields: string[]) =>
+    contactFields
+        .filter((field) => requiredFields.includes(field.value))
+        .map((field) => field.label)
+        .join(', ') || 'None';
+
+function DraftPanel({
+    initial,
     fixedRequiredFields,
     urgencies,
+    onDismiss,
 }: {
-    rules: IntakeRule[];
+    initial: Draft;
     fixedRequiredFields: Option[];
     urgencies: Option[];
+    onDismiss: () => void;
 }) {
     const organisation = usePage().props.currentOrganisation!;
     const form = useForm({
-        required_contact_fields: [] as string[],
-        default_urgency: 'routine',
+        ...initial,
         allow_restricted_access_bypass: false,
     });
+    const firstField = useRef<HTMLInputElement>(null);
+
+    /*
+     * The panel is not on the page until it is asked for, so opening it has to
+     * take the caret with it, exactly as on impact packs.
+     */
+    useEffect(() => firstField.current?.focus(), []);
 
     const submit = (event: FormEvent<HTMLFormElement>) => {
         event.preventDefault();
         form.post(store.url(organisation.slug), {
             preserveScroll: true,
-            onSuccess: () => form.reset(),
+            onSuccess: onDismiss,
         });
     };
 
@@ -61,201 +80,220 @@ export default function IntakeRulesIndex({
         );
     };
 
-    const useAsStartingPoint = (rule: IntakeRule) => {
-        form.setData({
-            required_contact_fields: contactFields
-                .map((field) => field.value)
-                .filter((field) => rule.requiredFields.includes(field)),
-            default_urgency: rule.defaultUrgency,
-            allow_restricted_access_bypass: false,
-        });
-        window.scrollTo({ top: 0, behavior: 'smooth' });
+    return (
+        <section
+            aria-labelledby="intake-rules-draft-heading"
+            className="bg-muted/30 max-w-xl space-y-5 rounded-xl border p-5"
+        >
+            <h2 id="intake-rules-draft-heading" className="font-medium">
+                New intake rules version
+            </h2>
+            <form className="space-y-5" onSubmit={submit}>
+                <fieldset className="space-y-2">
+                    <legend className="text-sm font-medium">
+                        Contact details staff must record
+                    </legend>
+                    {contactFields.map((field, fieldIndex) => (
+                        <label
+                            key={field.value}
+                            className="flex items-center gap-3 rounded-lg border p-3 text-sm"
+                        >
+                            <input
+                                type="checkbox"
+                                ref={fieldIndex === 0 ? firstField : undefined}
+                                className="size-4"
+                                checked={form.data.required_contact_fields.includes(
+                                    field.value,
+                                )}
+                                onChange={(event) =>
+                                    toggleContact(
+                                        field.value,
+                                        event.target.checked,
+                                    )
+                                }
+                            />
+                            {field.label}
+                        </label>
+                    ))}
+                    <InputError message={form.errors.required_contact_fields} />
+                </fieldset>
+
+                <div className="grid max-w-xs gap-2">
+                    <Label htmlFor="default-urgency">Default urgency</Label>
+                    <select
+                        id="default-urgency"
+                        className="h-9 rounded-md border bg-transparent px-3"
+                        value={form.data.default_urgency}
+                        onChange={(event) =>
+                            form.setData('default_urgency', event.target.value)
+                        }
+                    >
+                        {urgencies.map((urgency) => (
+                            <option key={urgency.value} value={urgency.value}>
+                                {urgency.label}
+                            </option>
+                        ))}
+                    </select>
+                    <InputError message={form.errors.default_urgency} />
+                </div>
+
+                <div className="flex gap-2">
+                    <Button disabled={form.processing}>
+                        {form.processing ? 'Creating draft…' : 'Create draft'}
+                    </Button>
+                    <Button type="button" variant="ghost" onClick={onDismiss}>
+                        Cancel
+                    </Button>
+                </div>
+            </form>
+
+            {/*
+             * The fixed material used to occupy half the form and was repeated
+             * in the page description and again on every version card. It never
+             * varies, so it is stated once, for the person who wonders why the
+             * two controls above are the only ones here.
+             */}
+            <details className="text-sm">
+                <summary className="cursor-pointer font-medium">
+                    What intake rules cannot change
+                </summary>
+                <p className="text-muted-foreground mt-2">
+                    {fixedRequiredFields.map((field) => field.label).join(', ')}{' '}
+                    are always required, whatever this version says. Intake
+                    rules also cannot weaken restricted case access or staff
+                    authorization.
+                </p>
+            </details>
+        </section>
+    );
+}
+
+export default function IntakeRulesIndex({
+    rules,
+    fixedRequiredFields,
+    urgencies,
+}: {
+    rules: IntakeRule[];
+    fixedRequiredFields: Option[];
+    urgencies: Option[];
+}) {
+    const organisation = usePage().props.currentOrganisation!;
+    const [draft, setDraft] = useState<Draft | null>(null);
+    const newVersionButton = useRef<HTMLButtonElement>(null);
+    const returnFocus = useRef(false);
+
+    /*
+     * The button is disabled while the panel is open, so it cannot take focus
+     * until the panel has gone and that render has landed.
+     */
+    useEffect(() => {
+        if (draft || !returnFocus.current) return;
+        returnFocus.current = false;
+        newVersionButton.current?.focus();
+    }, [draft]);
+
+    const dismiss = () => {
+        returnFocus.current = true;
+        setDraft(null);
     };
+
+    const startFrom = (rule: IntakeRule | null) =>
+        setDraft({
+            required_contact_fields: rule
+                ? contactFields
+                      .map((field) => field.value)
+                      .filter((field) => rule.requiredFields.includes(field))
+                : [],
+            default_urgency: rule?.defaultUrgency ?? 'routine',
+        });
 
     return (
         <div className="space-y-6 p-4">
             <Head title="Intake rules" />
-            <Heading
-                title="Intake rules"
-                description="Choose organisation-wide intake defaults while keeping identity, service context, and restricted-access protections fixed."
-            />
+            <div className="flex flex-wrap items-start justify-between gap-4">
+                <Heading
+                    title="Intake rules"
+                    description="Which contact details staff must record at intake, and the urgency a new case starts at."
+                />
+                <Button
+                    ref={newVersionButton}
+                    type="button"
+                    onClick={() => startFrom(rules[0] ?? null)}
+                    disabled={draft !== null}
+                >
+                    New version
+                </Button>
+            </div>
 
-            <Card>
-                <CardHeader>
-                    <CardTitle>Create an intake rules draft</CardTitle>
-                </CardHeader>
-                <CardContent>
-                    <form
-                        className="grid gap-6 lg:grid-cols-2"
-                        onSubmit={submit}
-                    >
-                        <div className="space-y-5">
-                            <fieldset className="space-y-3">
-                                <legend className="font-medium">
-                                    Required contact details
-                                </legend>
-                                <p className="text-muted-foreground text-sm">
-                                    Choose which contact details staff must
-                                    record before an intake can be accepted.
-                                </p>
-                                {contactFields.map((field) => (
-                                    <label
-                                        key={field.value}
-                                        className="flex items-center gap-2 rounded-lg border p-3"
-                                    >
-                                        <input
-                                            type="checkbox"
-                                            checked={form.data.required_contact_fields.includes(
-                                                field.value,
-                                            )}
-                                            onChange={(event) =>
-                                                toggleContact(
-                                                    field.value,
-                                                    event.target.checked,
-                                                )
-                                            }
-                                        />
-                                        {field.label}
-                                    </label>
-                                ))}
-                                <InputError
-                                    message={
-                                        form.errors.required_contact_fields
-                                    }
-                                />
-                            </fieldset>
+            {draft ? (
+                <DraftPanel
+                    key={JSON.stringify(draft)}
+                    initial={draft}
+                    fixedRequiredFields={fixedRequiredFields}
+                    urgencies={urgencies}
+                    onDismiss={dismiss}
+                />
+            ) : null}
 
-                            <div className="grid gap-2">
-                                <Label htmlFor="default-urgency">
-                                    Default urgency
-                                </Label>
-                                <select
-                                    id="default-urgency"
-                                    className="h-9 rounded-md border bg-transparent px-3"
-                                    value={form.data.default_urgency}
-                                    onChange={(event) =>
-                                        form.setData(
-                                            'default_urgency',
-                                            event.target.value,
-                                        )
-                                    }
-                                >
-                                    {urgencies.map((urgency) => (
-                                        <option
-                                            key={urgency.value}
-                                            value={urgency.value}
-                                        >
-                                            {urgency.label}
-                                        </option>
-                                    ))}
-                                </select>
-                                <InputError
-                                    message={form.errors.default_urgency}
-                                />
-                            </div>
-
-                            <Button disabled={form.processing}>
-                                {form.processing
-                                    ? 'Creating draft…'
-                                    : 'Create intake rules draft'}
-                            </Button>
-                        </div>
-
-                        <div className="bg-muted/40 space-y-4 rounded-xl border p-5">
-                            <strong>Fixed safeguards and context</strong>
-                            <div className="grid gap-2 sm:grid-cols-2">
-                                {fixedRequiredFields.map((field) => (
-                                    <div
-                                        key={field.value}
-                                        className="bg-background rounded-lg border p-3 text-sm"
-                                    >
-                                        <span aria-hidden="true">✓ </span>
-                                        {field.label} required
-                                    </div>
-                                ))}
-                            </div>
-                            {/*
-                             * This was a disabled, permanently unchecked
-                             * checkbox. Nothing could ever tick it, and an
-                             * empty box reads as "safeguard off" when it means
-                             * the exact opposite.
-                             */}
-                            <div className="bg-background rounded-lg border p-4 text-sm">
-                                <p className="font-medium">
-                                    <span aria-hidden="true">✓ </span>
-                                    Restricted-access bypass unavailable
-                                </p>
-                                <p className="text-muted-foreground mt-2">
-                                    Intake settings cannot weaken restricted
-                                    case access or staff authorization.
-                                </p>
-                            </div>
-                        </div>
-                    </form>
-                </CardContent>
-            </Card>
-
-            <section className="space-y-3">
-                <h2 className="text-xl font-semibold">Version history</h2>
+            <section aria-labelledby="intake-rules-versions-heading">
+                <h2
+                    id="intake-rules-versions-heading"
+                    className="mb-3 text-xl font-semibold"
+                >
+                    Versions
+                </h2>
                 {rules.length === 0 ? (
-                    <p className="text-muted-foreground text-sm">
-                        No intake rules versions yet. Platform defaults remain
-                        active until a draft is activated.
-                    </p>
-                ) : null}
-                {rules.map((rule) => (
-                    <Card key={rule.id}>
-                        <CardContent className="grid gap-4 pt-6 lg:grid-cols-[1fr_auto]">
-                            <div className="space-y-3">
-                                <div className="flex flex-wrap items-center gap-2">
-                                    <strong>
-                                        Intake rules · v{rule.version}
-                                    </strong>
-                                    <Badge>{rule.status}</Badge>
-                                    <Badge variant="outline">
-                                        {rule.defaultUrgency} urgency
-                                    </Badge>
+                    <div className="bg-muted/30 rounded-xl border border-dashed p-6">
+                        <p className="font-medium">No version yet</p>
+                        <p className="text-muted-foreground mt-1 max-w-prose text-sm">
+                            Platform defaults stay in force until a version is
+                            activated: no contact detail is required, and new
+                            cases start at routine urgency.
+                        </p>
+                    </div>
+                ) : (
+                    <ul className="space-y-3">
+                        {rules.map((rule) => (
+                            <li
+                                key={rule.id}
+                                className="flex flex-wrap items-center justify-between gap-3 rounded-xl border p-4"
+                            >
+                                <div className="space-y-1">
+                                    <div className="flex flex-wrap items-center gap-2">
+                                        <strong>v{rule.version}</strong>
+                                        <Badge>{rule.status}</Badge>
+                                        <Badge variant="outline">
+                                            {rule.defaultUrgency} urgency
+                                        </Badge>
+                                    </div>
+                                    <p className="text-muted-foreground text-sm">
+                                        Required contact details:{' '}
+                                        {contactSummary(rule.requiredFields)}
+                                    </p>
                                 </div>
-                                <p className="text-sm">
-                                    Required contact details:{' '}
-                                    {contactFields
-                                        .filter((field) =>
-                                            rule.requiredFields.includes(
-                                                field.value,
-                                            ),
-                                        )
-                                        .map((field) => field.label)
-                                        .join(', ') || 'None'}
-                                </p>
-                                <p className="text-muted-foreground text-sm">
-                                    Party identity, program, referral source,
-                                    narrative, and presenting needs remain
-                                    required. Restricted-access bypass remains
-                                    disabled.
-                                </p>
-                            </div>
-                            <div className="flex flex-wrap items-start gap-2">
-                                <Button
-                                    type="button"
-                                    variant="outline"
-                                    onClick={() => useAsStartingPoint(rule)}
-                                >
-                                    New version
-                                </Button>
-                                {rule.canActivate ? (
-                                    <Form
-                                        {...activate.form([
-                                            organisation.slug,
-                                            rule.id,
-                                        ])}
+                                <div className="flex flex-wrap items-center gap-2">
+                                    <Button
+                                        type="button"
+                                        variant="outline"
+                                        onClick={() => startFrom(rule)}
                                     >
-                                        <Button>Activate</Button>
-                                    </Form>
-                                ) : null}
-                            </div>
-                        </CardContent>
-                    </Card>
-                ))}
+                                        Copy to new version
+                                    </Button>
+                                    {rule.canActivate ? (
+                                        <Form
+                                            {...activate.form([
+                                                organisation.slug,
+                                                rule.id,
+                                            ])}
+                                        >
+                                            <Button>Activate</Button>
+                                        </Form>
+                                    ) : null}
+                                </div>
+                            </li>
+                        ))}
+                    </ul>
+                )}
             </section>
         </div>
     );

--- a/resources/js/pages/supporter-journey-policy/index.tsx
+++ b/resources/js/pages/supporter-journey-policy/index.tsx
@@ -371,12 +371,17 @@ function Safeguard({
     description: string;
 }) {
     return (
-        <div className="bg-background rounded-lg border p-4">
-            <div className="flex items-center gap-2">
-                <input type="checkbox" checked disabled readOnly />
-                <span className="font-medium">{title}</span>
-            </div>
-            <p className="text-muted-foreground mt-2 text-sm">{description}</p>
+        <div className="bg-background rounded-lg border p-4 text-sm">
+            {/*
+             * A safeguard is a statement of what the platform guarantees, not
+             * a setting. It used to be drawn as a disabled checkbox, which no
+             * one could operate.
+             */}
+            <p className="font-medium">
+                <span aria-hidden="true">✓ </span>
+                {title}
+            </p>
+            <p className="text-muted-foreground mt-2">{description}</p>
         </div>
     );
 }

--- a/resources/js/tests/pages/intake-rules-index.test.tsx
+++ b/resources/js/tests/pages/intake-rules-index.test.tsx
@@ -1,0 +1,71 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup, render, screen, within } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import IntakeRulesIndex from '@/pages/intake-rules/index';
+
+vi.mock('@inertiajs/react', () => ({
+    Form: ({ children, ...props }: ComponentProps<'form'>) => (
+        <form {...props}>{children}</form>
+    ),
+    Head: () => null,
+    useForm: <T,>(data: T) => ({
+        data,
+        errors: {},
+        post: vi.fn(),
+        processing: false,
+        reset: vi.fn(),
+        setData: vi.fn(),
+    }),
+    usePage: () => ({
+        props: { currentOrganisation: { slug: 'harbour-kind' } },
+    }),
+}));
+
+vi.mock('@/routes/intake-rules', () => ({
+    activate: { form: () => ({ action: '/activate' }) },
+    index: vi.fn(),
+    store: { url: () => '/store' },
+}));
+
+const renderPage = () =>
+    render(
+        <IntakeRulesIndex
+            rules={[]}
+            fixedRequiredFields={[
+                { value: 'consent', label: 'Consent record' },
+            ]}
+            urgencies={[{ value: 'routine', label: 'Routine' }]}
+        />,
+    );
+
+afterEach(cleanup);
+
+describe('intake rules index', () => {
+    it('states the restricted-access safeguard rather than drawing a control for it', () => {
+        renderPage();
+
+        const safeguard = screen
+            .getByText(/Restricted-access bypass/)
+            .closest('div')!;
+
+        /*
+         * This was a disabled, permanently unchecked checkbox: impossible to
+         * operate, and an empty box says the safeguard is off when it is on.
+         */
+        expect(
+            within(safeguard).queryByRole('checkbox'),
+        ).not.toBeInTheDocument();
+        expect(safeguard).toHaveTextContent(
+            /cannot weaken restricted case access/,
+        );
+    });
+
+    it('keeps the checkboxes that do change the draft', () => {
+        renderPage();
+
+        expect(
+            screen.getByRole('checkbox', { name: /Email address/ }),
+        ).toBeEnabled();
+    });
+});

--- a/resources/js/tests/pages/intake-rules-index.test.tsx
+++ b/resources/js/tests/pages/intake-rules-index.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom/vitest';
 import { cleanup, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { ComponentProps } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import IntakeRulesIndex from '@/pages/intake-rules/index';
@@ -28,44 +29,93 @@ vi.mock('@/routes/intake-rules', () => ({
     store: { url: () => '/store' },
 }));
 
-const renderPage = () =>
+const rule = {
+    id: 'rule-1',
+    version: 2,
+    status: 'active',
+    requiredFields: ['party_uuid', 'email'],
+    defaultUrgency: 'urgent',
+    restrictedAccessBypassAllowed: false,
+    activatedAt: '2026-08-01T00:00:00Z',
+    canActivate: false,
+};
+
+const renderPage = (rules = [rule]) =>
     render(
         <IntakeRulesIndex
-            rules={[]}
+            rules={rules}
             fixedRequiredFields={[
-                { value: 'consent', label: 'Consent record' },
+                { value: 'party_uuid', label: 'Party identity' },
+                { value: 'program_id', label: 'Program' },
             ]}
-            urgencies={[{ value: 'routine', label: 'Routine' }]}
+            urgencies={[
+                { value: 'routine', label: 'Routine' },
+                { value: 'urgent', label: 'Urgent' },
+            ]}
         />,
     );
 
 afterEach(cleanup);
 
 describe('intake rules index', () => {
-    it('states the restricted-access safeguard rather than drawing a control for it', () => {
+    it('shows the versions without a draft form open', () => {
         renderPage();
 
-        const safeguard = screen
-            .getByText(/Restricted-access bypass/)
-            .closest('div')!;
+        /*
+         * The page used to lead with the create form, so the versions it
+         * exists to show were below the fold.
+         */
+        expect(screen.queryByRole('form')).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('checkbox', { name: /Email address/ }),
+        ).not.toBeInTheDocument();
+        expect(screen.getByText('v2')).toBeInTheDocument();
+    });
+
+    it('opens the draft panel on request and focuses it', async () => {
+        renderPage();
+
+        await userEvent.click(
+            screen.getByRole('button', { name: 'New version' }),
+        );
+
+        const email = screen.getByRole('checkbox', { name: /Email address/ });
+        expect(email).toHaveFocus();
+        expect(email).toBeChecked();
+    });
+
+    it('states the fixed safeguards once, without a control for them', async () => {
+        renderPage();
+        await userEvent.click(
+            screen.getByRole('button', { name: 'New version' }),
+        );
+
+        const fixed = screen
+            .getByText('What intake rules cannot change')
+            .closest('details')!;
 
         /*
          * This was a disabled, permanently unchecked checkbox: impossible to
          * operate, and an empty box says the safeguard is off when it is on.
          */
-        expect(
-            within(safeguard).queryByRole('checkbox'),
-        ).not.toBeInTheDocument();
-        expect(safeguard).toHaveTextContent(
-            /cannot weaken restricted case access/,
+        expect(within(fixed).queryByRole('checkbox')).not.toBeInTheDocument();
+        expect(fixed).toHaveTextContent(/Party identity, Program/);
+        expect(fixed).toHaveTextContent(/cannot weaken restricted case access/);
+    });
+
+    it('does not repeat the fixed safeguards on every version', () => {
+        renderPage();
+
+        expect(screen.getByRole('listitem')).not.toHaveTextContent(
+            /remain required/,
         );
     });
 
-    it('keeps the checkboxes that do change the draft', () => {
-        renderPage();
+    it('teaches what applies while no version exists', () => {
+        renderPage([]);
 
         expect(
-            screen.getByRole('checkbox', { name: /Email address/ }),
-        ).toBeEnabled();
+            screen.getByText(/Platform defaults stay in force/),
+        ).toHaveTextContent(/routine urgency/);
     });
 });


### PR DESCRIPTION
Two changes to the same page, plus one sibling with the same defect.

## Safeguards were drawn as checkboxes nobody could tick

Intake rules presented "Restricted-access bypass disabled" as a `disabled readOnly` checkbox, permanently **unchecked**. Nothing could ever operate it, and an empty box reads as "this safeguard is off" while the sentence beside it says the opposite.

The supporter journey policy page had the same construction in its `Safeguard` component, permanently **checked** — reads correctly, still an unusable control. Both now render as a tick and a sentence.

## Intake rules led with a form to set three things

The page has three controls: two checkboxes and a select. It led with the form holding them, so the versions the page exists to show sat below the fold — and it stated the fixed safeguards three times over:

1. in the page description,
2. in a "Fixed safeguards and context" panel taking half the form's width,
3. again, word for word, on **every** version card.

The third is the worst: `Party identity, program, referral source, narrative, and presenting needs remain required. Restricted-access bypass remains disabled.` is identical on every card and can never differ, because it describes the platform rather than the version. It reads as data and carries none.

Now:

- **Versions come first.** `New version` opens a single-column draft panel, prefilled from the version it was started from, with focus moved into it — the shape used on impact packs (#111).
- The fixed material is stated **once**, inside that panel behind a `What intake rules cannot change` disclosure, where the person wondering why only two settings are offered will actually look.
- Version cards carry the four things that vary, and drop the repeated `Intake rules · ` prefix.
- The empty state says what applies until a version is activated, rather than only that nothing exists.

## Verification

- New `resources/js/tests/pages/intake-rules-index.test.tsx` (5 tests): ordering, prefill and focus move, safeguards stated once with no control inside, their absence from version cards, and the empty state. **All five confirmed failing against the previous page.**
- `npm run check` clean · `npm test` 417 passing
- `vendor/bin/pest` 411 passing, 2966 assertions · `phpstan` 0 errors

No controller, route, or prop changes.

## AI assistance

Written with Claude Code (Claude Opus 5). Reviewed by me before submission.